### PR TITLE
Bulk Exports

### DIFF
--- a/src/pages/datamodel/DataModel.tsx
+++ b/src/pages/datamodel/DataModel.tsx
@@ -29,12 +29,6 @@ export const Vocabulary = () => {
             <TabsTrigger value="folderMetadata">
               <Folder size={16} className="mr-2" /> Folder Metadata
             </TabsTrigger>
-
-            {/*
-            <TabsTrigger value="tags">
-              <Tags size={16} className="mr-2" /> Tags
-            </TabsTrigger>
-            */}
           </TabsList>
 
           <TabsContent value="entityTypes">

--- a/src/pages/export/Export.tsx
+++ b/src/pages/export/Export.tsx
@@ -1,29 +1,38 @@
 import { AppNavigationSidebar } from '@/components/AppNavigationSidebar';
-import { useStore } from '@/store';
-import { Button } from '@/ui/Button';
-import { exportAnnotations } from './annotations/exportAnnotations';
+import { Separator } from '@/ui/Separator';
+import { ExportAnnotations } from './ExportAnnotations';
 
 export const Export = () => {
-
-  const store = useStore();
-
-  const exportStuff = () => {
-    exportAnnotations(store);
-  }
 
   return (
     <div className="page-root">
       <AppNavigationSidebar />
 
       <main className="page export">
-        <h1 className="text-xl font-semibold tracking-tight mb-4">Nothing to see here. (Yet.)</h1>
-        <p className="text-sm text-muted-foreground max-w-lg leading-6">
-          This page is just a placeholder. In the future, we might (for example) offer 
-          download options for exporting your data in different formats.
-        </p>
+        <div>
+          <h1 className="text-xl font-semibold tracking-tight mb-2">Export</h1>
 
-        <div className="mt-4">
-          <Button onClick={exportStuff}>Export</Button>
+          <p className="mt-1 text-sm leading-6">
+            Export your data in different export formats.
+          </p>
+
+          <Separator className="mt-7 w-full mb-2" />
+        </div>
+
+        <div className="flex flex-row">
+          <aside className="py-4">
+            <nav className="w-52">
+              <ol>
+                <li className="bg-muted px-3 py-1.5 rounded w-full my-2">Annotations</li>
+                <li className="px-3 py-1.5 text-muted-foreground/50">Metadata</li>
+                <li className="px-3 py-1.5 text-muted-foreground/50">Images</li>
+              </ol>
+            </nav>
+          </aside>
+
+          <section className="pl-12 py-2 flex-grow">
+            <ExportAnnotations />
+          </section>
         </div>
       </main>
     </div>

--- a/src/pages/export/Export.tsx
+++ b/src/pages/export/Export.tsx
@@ -21,7 +21,7 @@ export const Export = () => {
 
         <div className="flex flex-row">
           <aside className="py-4">
-            <nav className="w-52">
+            <nav className="w-44">
               <ol>
                 <li className="bg-muted px-3 py-1.5 rounded w-full my-2">Annotations</li>
                 <li className="px-3 py-1.5 text-muted-foreground/50">Metadata</li>

--- a/src/pages/export/Export.tsx
+++ b/src/pages/export/Export.tsx
@@ -1,6 +1,15 @@
 import { AppNavigationSidebar } from '@/components/AppNavigationSidebar';
+import { useStore } from '@/store';
+import { Button } from '@/ui/Button';
+import { exportAnnotations } from './annotations/exportAnnotations';
 
 export const Export = () => {
+
+  const store = useStore();
+
+  const exportStuff = () => {
+    exportAnnotations(store);
+  }
 
   return (
     <div className="page-root">
@@ -12,6 +21,10 @@ export const Export = () => {
           This page is just a placeholder. In the future, we might (for example) offer 
           download options for exporting your data in different formats.
         </p>
+
+        <div className="mt-4">
+          <Button onClick={exportStuff}>Export</Button>
+        </div>
       </main>
     </div>
   )

--- a/src/pages/export/ExportAnnotations/ExportAnnotations.tsx
+++ b/src/pages/export/ExportAnnotations/ExportAnnotations.tsx
@@ -46,14 +46,14 @@ export const ExportAnnotations = () => {
   return (
     <ul className="py-2">
       <li>
-        <section className="w-full py-2 flex flex-row gap-16 justify-between">
+        <section className="w-full py-2 flex flex-row gap-20 justify-between">
           <div>
             <h3 className="font-medium mb-1">
               All Annotations
             </h3>
 
             <p className="text-sm">
-              All annotations, on all images in this work folder, as a flat list
+              All annotations, on all images in your current work folder, as a flat list
               in <a className="underline underline-offset-4 hover:text-primary" href="https://www.w3.org/TR/annotation-model/" target="_blank">W3C Web Annotation format</a>.
             </p>
           </div>

--- a/src/pages/export/ExportAnnotations/ExportAnnotations.tsx
+++ b/src/pages/export/ExportAnnotations/ExportAnnotations.tsx
@@ -1,6 +1,8 @@
-import { Folder, Image, RootFolder } from '@/model';
-import { Store } from '@/store';
 import { W3CAnnotation } from '@annotorious/react';
+import { Download } from 'lucide-react';
+import { Store, useStore } from '@/store';
+import { Button } from '@/ui/Button';
+import { Folder, Image, RootFolder } from '@/model';
 
 export const exportAnnotations = (store: Store) => {
 
@@ -23,8 +25,6 @@ export const exportAnnotations = (store: Store) => {
   }, Promise.resolve([]))
 
   annotations.then(annotations => {
-    console.log('downloading', annotations);
-
     const str = JSON.stringify(annotations);
     const data = new TextEncoder().encode(str);
     const blob = new Blob([data], {
@@ -36,5 +36,38 @@ export const exportAnnotations = (store: Store) => {
     anchor.download = 'annotations.json';
     anchor.click();
   });
+
+}
+
+export const ExportAnnotations = () => {
+
+  const store = useStore();
+
+  return (
+    <ul className="py-2">
+      <li>
+        <section className="w-full py-2 flex flex-row gap-16 justify-between">
+          <div>
+            <h3 className="font-medium mb-1">
+              All Annotations
+            </h3>
+
+            <p className="text-sm">
+              All annotations, on all images in this work folder, as a flat list
+              in <a className="underline underline-offset-4 hover:text-primary" href="https://www.w3.org/TR/annotation-model/" target="_blank">W3C Web Annotation format</a>.
+            </p>
+          </div>
+
+          <div>
+            <Button 
+              className="whitespace-nowrap flex gap-2"
+              onClick={() => exportAnnotations(store)}>
+              <Download className="h-4 w-4" /> JSON-LD
+            </Button>
+          </div>
+        </section>
+      </li>
+    </ul>
+  )
 
 }

--- a/src/pages/export/ExportAnnotations/index.ts
+++ b/src/pages/export/ExportAnnotations/index.ts
@@ -1,0 +1,1 @@
+export * from './ExportAnnotations';

--- a/src/pages/export/annotations/exportAnnotations.ts
+++ b/src/pages/export/annotations/exportAnnotations.ts
@@ -1,0 +1,40 @@
+import { Folder, Image, RootFolder } from '@/model';
+import { Store } from '@/store';
+import { W3CAnnotation } from '@annotorious/react';
+
+export const exportAnnotations = (store: Store) => {
+
+  const getImagesRecursive = (folder: RootFolder | Folder, allImages: Image[] = []): Image[] => {
+    const { images, folders } = store.getFolderContents(folder.handle);
+
+    const updatedImages = [...allImages, ...images];
+
+    return folders.reduce((all, subfolder) => getImagesRecursive(subfolder, all), updatedImages);
+  }
+
+  const images = getImagesRecursive(store.getRootFolder());
+
+  const annotations = images.reduce<Promise<W3CAnnotation[]>>((promise, image) => {
+    return promise.then((all) => {
+      return store.getAnnotations(image.id).then(annotations => {
+        return [...all, ...annotations]
+      })
+    })
+  }, Promise.resolve([]))
+
+  annotations.then(annotations => {
+    console.log('downloading', annotations);
+
+    const str = JSON.stringify(annotations);
+    const data = new TextEncoder().encode(str);
+    const blob = new Blob([data], {
+      type: 'application/json;charset=utf-8'
+    });
+
+    const anchor = document.createElement('a');
+    anchor.href = URL.createObjectURL(blob);
+    anchor.download = 'annotations.json';
+    anchor.click();
+  });
+
+}


### PR DESCRIPTION
## In this PR

This PR adds one first export option. (All annotations as a flat list, in W3C format.) So far, this is just a starting point/demo. More options will be added as we go. Also, not that this PR is currently still affected by [Annotorious issue 361](https://github.com/annotorious/annotorious/issues/361).