### PR TITLE
Window layout no longer loses state

### DIFF
--- a/src/pages/annotate/WorkspaceSection/WorkspaceSection.tsx
+++ b/src/pages/annotate/WorkspaceSection/WorkspaceSection.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Mosaic } from 'react-mosaic-component';
+import { Mosaic, MosaicNode } from 'react-mosaic-component';
 import { Image, LoadedImage } from '@/model';
 import { AnnotatableImage } from './AnnotatableImage';
 import { Tool, ToolMode } from '../Tool';
@@ -24,8 +24,16 @@ interface WorkspaceSectionProps {
 
 }
 
+const initial = {
+  "direction": "row",
+  "first": "a",
+  "second": "b",
+  "splitPercentage": 40
+} as MosaicNode<string>;
+
 const createInitialValue= (list: string[], direction = 'row') => {
   const [first, ...rest] = list;
+
   return {
     direction,
     first,
@@ -35,9 +43,25 @@ const createInitialValue= (list: string[], direction = 'row') => {
 
 export const WorkspaceSection = (props: WorkspaceSectionProps) => {
 
-  const [windowMap, setWindowMap] = useState<{ windowId: string, image: LoadedImage }[]>([]);
+  const [value, setValue] = useState<MosaicNode<string>>();
+  
+  // const [windowMap, setWindowMap] = useState<{ windowId: string, image: LoadedImage }[]>([]);
+
 
   useEffect(() => {
+    if (props.images.length > 1) {
+      console.log('rendering initial view');
+
+      const view = createInitialValue(props.images.map(i => i.id));
+
+      console.log(view);
+
+      setValue(view);
+    } else {
+      console.log('not enough images');
+    }
+
+    /*
     setWindowMap(entries => {
       const diff = props.images.length - entries.length;
 
@@ -55,15 +79,19 @@ export const WorkspaceSection = (props: WorkspaceSectionProps) => {
           .map(({ windowId}, idx) => ({ windowId, image: props.images[idx] }));
       }
     });
-  }, [props.images]);
+    */
+  }, [props.images?.map(i => i.id).join()]);
 
+  /*
   const onChangeImage = (windowId: string, image: Image) => {
     const nextImages = windowMap
       .map(entry => entry.windowId === windowId ? image : entry.image);
 
     props.onChangeImages(nextImages);
   }
+  */
 
+  /*
   const onClose = (windowId: string) => {
     const nextImages = windowMap
       .filter(entry => entry.windowId !== windowId)
@@ -71,29 +99,17 @@ export const WorkspaceSection = (props: WorkspaceSectionProps) => {
 
     props.onChangeImages(nextImages);
   }
+  */
   
   return (
     <section className="workspace flex-grow bg-muted">
-      {windowMap.length === 1 ? (
-        <AnnotatableImage 
-          image={windowMap[0].image} 
-          mode={props.mode}
-          tool={props.tool} />
-      ) : windowMap.length > 1 ? (
-        <Mosaic
-          renderTile={(windowId, path) => (
-            <WorkspaceWindow 
-              windowId={windowId} 
-              windowPath={path} 
-              image={windowMap.find(t => t.windowId === windowId)?.image}
-              mode={props.mode}
-              tool={props.tool}
-              onAddImage={props.onAddImage}
-              onChangeImage={(_, next) => onChangeImage(windowId, next)} 
-              onClose={() => onClose(windowId)} />
-          )} 
-          initialValue={createInitialValue(windowMap.map(({ windowId }) => windowId))} />
-      ) : undefined}
+      {value && (
+        <Mosaic<string>
+          renderTile={id => (<div>{id}</div>)}
+          value={value}
+          onChange={setValue}
+        />
+      )}
     </section>
   )
 

--- a/src/pages/annotate/WorkspaceSection/WorkspaceSection.tsx
+++ b/src/pages/annotate/WorkspaceSection/WorkspaceSection.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { Mosaic, MosaicNode } from 'react-mosaic-component';
+import { Mosaic, MosaicNode, createBalancedTreeFromLeaves } from 'react-mosaic-component';
 import { v4 as uuidv4 } from 'uuid';
 import { Image, LoadedImage } from '@/model';
 import { AnnotatableImage } from './AnnotatableImage';
@@ -22,15 +22,6 @@ interface WorkspaceSectionProps {
 
   onRemoveImage(image: Image): void;
 
-}
-
-const createInitialValue= (list: string[], direction = 'row') => {
-  const [first, ...rest] = list;
-  return {
-    direction,
-    first,
-    second: rest.length === 1 ? rest[0] : createInitialValue(rest, direction === 'row' ? 'column' : 'row')
-  };
 }
 
 export const WorkspaceSection = (props: WorkspaceSectionProps) => {
@@ -60,7 +51,7 @@ export const WorkspaceSection = (props: WorkspaceSectionProps) => {
 
       windowMap.current = next;
 
-      setValue(createInitialValue(next.map(t => t.windowId)));
+      setValue(createBalancedTreeFromLeaves(next.map(t => t.windowId)));
     }
   }, [props.images]);
 

--- a/src/pages/annotate/WorkspaceSection/WorkspaceSection.tsx
+++ b/src/pages/annotate/WorkspaceSection/WorkspaceSection.tsx
@@ -4,7 +4,6 @@ import { Image, LoadedImage } from '@/model';
 import { AnnotatableImage } from './AnnotatableImage';
 import { Tool, ToolMode } from '../Tool';
 import { WorkspaceWindow } from './WorkspaceWindow';
-import { v4 as uuidv4 } from 'uuid';
 
 import 'react-mosaic-component/react-mosaic-component.css';
 
@@ -24,16 +23,8 @@ interface WorkspaceSectionProps {
 
 }
 
-const initial = {
-  "direction": "row",
-  "first": "a",
-  "second": "b",
-  "splitPercentage": 40
-} as MosaicNode<string>;
-
 const createInitialValue= (list: string[], direction = 'row') => {
   const [first, ...rest] = list;
-
   return {
     direction,
     first,
@@ -45,67 +36,44 @@ export const WorkspaceSection = (props: WorkspaceSectionProps) => {
 
   const [value, setValue] = useState<MosaicNode<string>>();
   
-  // const [windowMap, setWindowMap] = useState<{ windowId: string, image: LoadedImage }[]>([]);
-
-
   useEffect(() => {
     if (props.images.length > 1) {
-      console.log('rendering initial view');
-
-      const view = createInitialValue(props.images.map(i => i.id));
-
-      console.log(view);
-
-      setValue(view);
-    } else {
-      console.log('not enough images');
+      setValue(createInitialValue(props.images.map(i => i.id)));
     }
+  }, [props.images]);
 
-    /*
-    setWindowMap(entries => {
-      const diff = props.images.length - entries.length;
-
-      if (diff === 0) {
-        return entries.map(({ windowId }, idx) => ({ windowId, image: props.images[idx] }));
-      } else if (diff > 0) {
-        // More images
-        return [
-          ...entries.map(({ windowId }, idx) => ({ windowId, image: props.images[idx] })),
-          ...props.images.slice(-diff).map(image => ({ windowId: uuidv4(), image: image }))
-        ];
-      } else {
-        // Fewer images
-        return entries.slice(0, props.images.length)
-          .map(({ windowId}, idx) => ({ windowId, image: props.images[idx] }));
-      }
-    });
-    */
-  }, [props.images?.map(i => i.id).join()]);
-
-  /*
-  const onChangeImage = (windowId: string, image: Image) => {
-    const nextImages = windowMap
-      .map(entry => entry.windowId === windowId ? image : entry.image);
+  const onChangeImage = (currentImageId: string, nextImage: Image) => {
+    const nextImages = props.images
+      .map(i => i.id === currentImageId ? nextImage : i);
 
     props.onChangeImages(nextImages);
   }
-  */
 
-  /*
-  const onClose = (windowId: string) => {
-    const nextImages = windowMap
-      .filter(entry => entry.windowId !== windowId)
-      .map(entry => entry.image);
-
+  const onClose = (imageId: string) => {
+    const nextImages = props.images.filter(i => i.id !== imageId)
     props.onChangeImages(nextImages);
   }
-  */
   
   return (
     <section className="workspace flex-grow bg-muted">
-      {value && (
+      {props.images.length === 1 ? (
+        <AnnotatableImage 
+          image={props.images[0]} 
+          mode={props.mode}
+          tool={props.tool} />
+      ) : props.images.length > 1 && (
         <Mosaic<string>
-          renderTile={id => (<div>{id}</div>)}
+          renderTile={(imageId, path) => props.images.find(image => image.id === imageId) && (
+            <WorkspaceWindow 
+              windowId={imageId} 
+              windowPath={path} 
+              image={props.images.find(image => image.id === imageId)}
+              mode={props.mode}
+              tool={props.tool}
+              onAddImage={props.onAddImage}
+              onChangeImage={(_, next) => onChangeImage(imageId, next)} 
+              onClose={() => onClose(imageId)} />
+          )}
           value={value}
           onChange={setValue}
         />


### PR DESCRIPTION
## In this PR

This PR fixes a bug in the multi-window view. Because [React Mosaic](https://github.com/nomcopter/react-mosaic) was used in uncontrolled mode, re-renders of the parent component would cause it to reset state, as reported in issue #43. This PR changes React Mosaic to controlled mode.