### PR TITLE
Folder Metadata for the Top-Level Folder

### DIFF
--- a/src/pages/images/Images.tsx
+++ b/src/pages/images/Images.tsx
@@ -1,11 +1,12 @@
 import { Fragment, useEffect, useMemo, useState } from 'react';
 import { AppNavigationSidebar } from '@/components/AppNavigationSidebar';
-import { ChevronRight } from 'lucide-react';
+import { ChevronRight, Info, NotebookPen } from 'lucide-react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { useStore } from '@/store';
 import { ItemGrid } from './ItemGrid';
 import { MetadataDrawer } from './MetadataDrawer';
 import { GridItem } from './ItemGrid/Item';
+import { Button } from '@/ui/Button';
 
 export const Images = () => {
 
@@ -66,8 +67,14 @@ export const Images = () => {
               {currentFolder.name}
             </h2>
 
-            <p className="text-sm text-muted-foreground">
-              {images.length} images
+            <p className="text-sm text-muted-foreground flex gap-2">
+              <span>{images.length} images</span>
+              <span>·</span> 
+              <Button 
+                variant="link"
+                className="text-muted-foreground flex items-center gap-1 p-0 h-auto font-normal">
+                <NotebookPen className="h-4 w-4" /> Metadata
+              </Button>
             </p>
           </div>
 

--- a/src/pages/images/Images.tsx
+++ b/src/pages/images/Images.tsx
@@ -71,7 +71,7 @@ export const Images = () => {
               {currentFolder.name}
             </h2>
 
-            <p className="text-sm text-muted-foreground flex gap-2">
+            <p className="text-sm text-muted-foreground flex gap-2 pt-0.5">
               <span>{images.length} images</span>
               <span>·</span> 
               <Button 

--- a/src/pages/images/Images.tsx
+++ b/src/pages/images/Images.tsx
@@ -1,12 +1,13 @@
 import { Fragment, useEffect, useMemo, useState } from 'react';
 import { AppNavigationSidebar } from '@/components/AppNavigationSidebar';
-import { ChevronRight, Info, NotebookPen } from 'lucide-react';
+import { ChevronRight, NotebookPen } from 'lucide-react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Folder, RootFolder } from '@/model';
 import { useStore } from '@/store';
+import { Button } from '@/ui/Button';
 import { ItemGrid } from './ItemGrid';
 import { MetadataDrawer } from './MetadataDrawer';
-import { GridItem } from './ItemGrid/Item';
-import { Button } from '@/ui/Button';
+import { GridItem } from './Types';
 
 export const Images = () => {
 
@@ -18,7 +19,7 @@ export const Images = () => {
 
   const navigate = useNavigate();
 
-  const currentFolder = useMemo(() => folder ? store.getFolder(folder) : store.getRootFolder(), [folder]);
+  const currentFolder: Folder | RootFolder = useMemo(() => folder ? store.getFolder(folder) : store.getRootFolder(), [folder]);
  
   if (!currentFolder)
     navigate('/404');
@@ -29,6 +30,9 @@ export const Images = () => {
     // Reset selection when folder changes
     setSelected(undefined);
   }, [folder]);
+
+  const onShowFolderMetadata = () =>
+    setSelected({ type: 'folder', ...currentFolder });
 
   return store && (
     <div className="page-root">
@@ -72,7 +76,8 @@ export const Images = () => {
               <span>·</span> 
               <Button 
                 variant="link"
-                className="text-muted-foreground flex items-center gap-1 p-0 h-auto font-normal">
+                className="text-muted-foreground flex items-center gap-1 p-0 h-auto font-normal"
+                onClick={onShowFolderMetadata}>
                 <NotebookPen className="h-4 w-4" /> Metadata
               </Button>
             </p>

--- a/src/pages/images/ItemGrid/FolderItem/FolderItemActions.tsx
+++ b/src/pages/images/ItemGrid/FolderItem/FolderItemActions.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
 import { Folder } from '@/model';
-import { FolderIcon, Info, MoreVertical } from 'lucide-react';
+import { FolderOpen, MoreVertical, NotebookPen } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -31,12 +31,12 @@ export const FolderItemActions = (props: FolderItemActionProps) => {
 
       <DropdownMenuContent align="start">
         <DropdownMenuItem onSelect={props.onSelect}>
-          <Info className="h-4 w-4 text-muted-foreground mr-2" /> Information
+          <NotebookPen className="h-4 w-4 text-muted-foreground mr-2" /> Metadata
         </DropdownMenuItem>
 
         <DropdownMenuItem asChild>
           <Link to={`/images/${props.folder.id}`}>
-            <FolderIcon className="h-4 w-4 text-muted-foreground mr-2" /> Open folder
+            <FolderOpen className="h-4 w-4 text-muted-foreground mr-2" /> Open folder
           </Link>
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/src/pages/images/ItemGrid/ImageItem/ImageItemActions.tsx
+++ b/src/pages/images/ItemGrid/ImageItem/ImageItemActions.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
 import { Image } from '@/model';
-import { Info, MoreVertical, PanelTop } from 'lucide-react';
+import { ImageIcon, MoreVertical, NotebookPen } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -31,12 +31,12 @@ export const ImageItemActions = (props: ImageItemActionProps) => {
 
       <DropdownMenuContent align="start">
         <DropdownMenuItem onSelect={props.onSelect}>
-          <Info className="h-4 w-4 text-muted-foreground mr-2" /> Information
+          <NotebookPen className="h-4 w-4 text-muted-foreground mr-2" /> Metadata
         </DropdownMenuItem>
 
         <DropdownMenuItem asChild>
           <Link to={`/annotate/${props.image.id}`}>
-            <PanelTop className="h-4 w-4 text-muted-foreground mr-2" /> Open image
+            <ImageIcon className="h-4 w-4 text-muted-foreground mr-2" /> Open image
           </Link>
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/src/pages/images/ItemGrid/ItemGrid.tsx
+++ b/src/pages/images/ItemGrid/ItemGrid.tsx
@@ -3,7 +3,7 @@ import { useImages } from '@/store';
 import { Folder, Image, LoadedImage } from '@/model';
 import { FolderItem } from './FolderItem';
 import { ImageItem } from './ImageItem';
-import { GridItem } from './Item';
+import { GridItem } from '../Types';
 
 import './ItemGrid.css';
 
@@ -53,7 +53,7 @@ export const ItemGrid = (props: ItemGridProps) => {
           <li key={image.id}>
             <ImageItem 
               image={image} 
-              selected={props.selected?.id === image.id}
+              selected={props.selected && 'id' in props.selected && props.selected?.id === image.id}
               onOpen={() => onOpenImage(image)} 
               onSelect={() => onSelectImage(image)}/>
           </li>

--- a/src/pages/images/ItemGrid/index.ts
+++ b/src/pages/images/ItemGrid/index.ts
@@ -1,2 +1,1 @@
-export * from './Item';
 export * from './ItemGrid';

--- a/src/pages/images/MetadataDrawer/FolderMetadataPanel.tsx
+++ b/src/pages/images/MetadataDrawer/FolderMetadataPanel.tsx
@@ -1,10 +1,10 @@
 import { FormEvent, useEffect, useState } from 'react';
+import { W3CAnnotationBody } from '@annotorious/react';
 import { useFolderMetadata } from '@/store';
-import { FolderGridItem } from '../ItemGrid';
 import { PropertyValidation } from '@/components/PropertyFields';
 import { Button } from '@/ui/Button';
-import { W3CAnnotationBody } from '@annotorious/react';
 import { FolderMetadataForm, hasChanges } from '@/components/MetadataForm';
+import { FolderGridItem } from '../Types';
 
 interface FolderMetadataPanelProps {
 
@@ -14,7 +14,7 @@ interface FolderMetadataPanelProps {
 
 export const FolderMetadataPanel = (props: FolderMetadataPanelProps) => {
 
-  const { metadata, updateMetadata } = useFolderMetadata(props.folder?.id);
+  const { metadata, updateMetadata } = useFolderMetadata(props.folder);
 
   const [formState, setFormState] = useState<W3CAnnotationBody | undefined>();
 

--- a/src/pages/images/MetadataDrawer/MetadataDrawer.tsx
+++ b/src/pages/images/MetadataDrawer/MetadataDrawer.tsx
@@ -1,4 +1,4 @@
-import { FolderGridItem, GridItem, ImageGridItem } from '../ItemGrid';
+import { FolderGridItem, GridItem, ImageGridItem } from '../Types';
 import { FolderMetadataPanel } from './FolderMetadataPanel';
 import { ImageMetadataPanel } from './ImageMetadataPanel';
 import { Drawer } from '@/components/Drawer';

--- a/src/pages/images/Types.ts
+++ b/src/pages/images/Types.ts
@@ -1,6 +1,6 @@
-import { Folder, Image } from '@/model';
+import { Folder, Image, RootFolder } from '@/model';
 
-export type FolderGridItem = Folder & {
+export type FolderGridItem = (Folder | RootFolder) & {
 
   type: 'folder';
 

--- a/src/pages/knowledgegraph/SelectionDetailsDrawer/FolderDetails/FolderDetails.tsx
+++ b/src/pages/knowledgegraph/SelectionDetailsDrawer/FolderDetails/FolderDetails.tsx
@@ -14,7 +14,7 @@ interface FolderDetailsProps {
 
 export const FolderDetails = (props: FolderDetailsProps) => {
 
-  const { metadata, updateMetadata } = useFolderMetadata(props.folder.id);
+  const { metadata, updateMetadata } = useFolderMetadata(props.folder);
 
   const [formState, setFormState] = useState<W3CAnnotationBody | undefined>();
 

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -19,11 +19,11 @@ export interface Store {
 
   getDataModel(): DataModelStore;
 
-  getFolder(folderId: string | FileSystemDirectoryHandle): Folder | RootFolder;
+  getFolder(idOrHandle: string | FileSystemDirectoryHandle): Folder | RootFolder;
 
   getFolderContents(dir: FileSystemDirectoryHandle): FolderItems;
 
-  getFolderMetadata(folderId: string): Promise<W3CAnnotation>;
+  getFolderMetadata(idOrHandle: string | FileSystemDirectoryHandle): Promise<W3CAnnotation>;
 
   getImage(imageId: string): Image;
 
@@ -35,7 +35,7 @@ export interface Store {
 
   upsertAnnotation(imageId: string, annotation: W3CAnnotation): Promise<void>;
 
-  upsertFolderMetadata(folderId: string, annotation: W3CAnnotation): Promise<void>;
+  upsertFolderMetadata(idOrHandle: string | FileSystemDirectoryHandle, annotation: W3CAnnotation): Promise<void>;
   
   upsertImageMetadata(imageId: string, metadata: W3CAnnotationBody): Promise<void>;
 
@@ -178,8 +178,8 @@ export const loadStore = (
     return { images: imageItems, folders: folderItems };
   }
 
-  const getFolderMetadata = (folderId: string): Promise<W3CAnnotation> => {
-    const folder = getFolder(folderId);
+  const getFolderMetadata = (idOrHandle: string | FileSystemDirectoryHandle): Promise<W3CAnnotation> => {
+    const folder = getFolder(idOrHandle);
     if (folder) {
       return folder.handle.getFileHandle('_immarkus.folder.meta.json', { create: true })
         .then(handle => handle.getFile())
@@ -261,13 +261,13 @@ export const loadStore = (
     }
   });
 
-  const upsertFolderMetadata = (folderId: string, annotation: W3CAnnotation): Promise<void> => {
-    const folder = getFolder(folderId);
+  const upsertFolderMetadata = (idOrHandle: string | FileSystemDirectoryHandle, annotation: W3CAnnotation): Promise<void> => {
+    const folder = getFolder(idOrHandle);
     if (folder) {
       return folder.handle.getFileHandle('_immarkus.folder.meta.json', { create: true })
         .then(handle => writeJSONFile(handle, annotation))
     } else {
-      return Promise.reject(`Missing folder: ${folderId}`);
+      return Promise.reject(`Missing folder: ${idOrHandle}`);
     }
   }
 

--- a/src/store/hooks/useFolderMetadata.ts
+++ b/src/store/hooks/useFolderMetadata.ts
@@ -1,21 +1,22 @@
 import { useEffect, useMemo, useState } from 'react';
 import { W3CAnnotation, W3CAnnotationBody } from '@annotorious/react';
 import { v4 as uuidv4 } from 'uuid';
+import { Folder, RootFolder } from '@/model';
 import { useStore } from './useStore';
 
-export const useFolderMetadata = (folderId: string) => {
+export const useFolderMetadata = (folder: Folder | RootFolder) => {
   const store = useStore();
 
   const [annotation, setAnnotation] = useState<W3CAnnotation | undefined>();
 
   useEffect(() => {
-    store.getFolderMetadata(folderId)
+    store.getFolderMetadata(folder.handle)
       .then(annotation => setAnnotation(annotation || {
         '@context': 'http://www.w3.org/ns/anno.jsonld',
         type: 'Annotation',
         id: uuidv4()
       } as W3CAnnotation));
-  }, [folderId]);
+  }, [folder]);
 
   const updateMetadata = (metadata: W3CAnnotationBody) => {
     const next = { 
@@ -26,7 +27,7 @@ export const useFolderMetadata = (folderId: string) => {
       }
     } as W3CAnnotation;
 
-    store.upsertFolderMetadata(folderId, next);
+    store.upsertFolderMetadata(folder.handle, next);
 
     setAnnotation(next);
   }


### PR DESCRIPTION
## In this PR

This PR adds a "Metadata" button directly below the folder name in the image gallery. As a consequence, it is now also possible to enter metadata for the project folder itself, not just the sub-folders.