### PR TITLE
Graph Search: Search by File- and Foldername

### DIFF
--- a/src/components/AnnotationValuePreview/AnnotationValuePreview.tsx
+++ b/src/components/AnnotationValuePreview/AnnotationValuePreview.tsx
@@ -15,7 +15,6 @@ interface AnnotationValuePreviewProps {
 const serializeRelation = (definition: RelationPropertyDefinition, value: any) => {
   const firstValue = Array.isArray(value) ? value[0] : value;
   return [
-    // `${definition.name}:${definition.targetType ? `${definition.targetType} ` : ''}${firstValue.instance}`
     `${definition.name}:${firstValue.instance}`
   ];
 }

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -23,27 +23,27 @@ export interface ComboboxOption {
 
 }
  
-interface ComboboxProps {
+interface ComboboxProps <T extends ComboboxOption>{
 
   className?: string;
 
   placeholder?: string;
 
-  value?: string;
+  value?: T;
   
-  options: ComboboxOption[];
+  options: T[];
 
-  onChange(value: string): void;
+  onChange(value: T): void;
 
 }
 
-export const Combobox = (props: ComboboxProps) => {
+export const Combobox = <T extends ComboboxOption = ComboboxOption>(props: ComboboxProps<T>) => {
 
-  const { value, options, placeholder } = props;
+  const { value, placeholder } = props;
 
   const [open, setOpen] = useState(false);
 
-  const onSelect = (value: string) => {
+  const onSelect = (value: T) => {
     setOpen(false);
     props.onChange(value);
   }
@@ -58,7 +58,7 @@ export const Combobox = (props: ComboboxProps) => {
           className={cn(props.className, 'text-xs font-normal justify-between overflow-hidden')}>
           <span className="overflow-hidden text-ellipsis whitespace-nowrap">
             {value
-              ? options.find(o => o.value === value)?.label
+              ? value.label
               : placeholder}
           </span>
           <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
@@ -67,7 +67,7 @@ export const Combobox = (props: ComboboxProps) => {
 
       <PopoverContent 
         align="start"
-        className="min-w-[80px] w-auto p-0 overflow-hidden">
+        className="min-w-[80px] max-w-[60vw] w-auto p-0 overflow-hidden">
         <Command>
           <CommandInput 
             className="h-auto py-2 text-xs"
@@ -83,9 +83,9 @@ export const Combobox = (props: ComboboxProps) => {
               <CommandItem 
                 key={option.value}
                 className="block text-xs overflow-hidden whitespace-nowrap text-ellipsis"
-                value={option.value}
+                value={JSON.stringify(option)}
                 // Warning: cmdk trims the values, possibly breaking them!
-                onSelect={() => onSelect(option.value)}>
+                onSelect={() => onSelect(option)}>
                 {option.label}
               </CommandItem>
             ))}

--- a/src/pages/knowledgegraph/GraphSearch/GraphSearch.tsx
+++ b/src/pages/knowledgegraph/GraphSearch/GraphSearch.tsx
@@ -82,7 +82,7 @@ export const GraphSearch = (props: GraphSearchProps) => {
         n.type === objectType && intersection.has(n.id);
 
       props.onChangeQuery(query);
-  }
+    }
   }, [conditions]);
 
   const isComplete = (sentence: Partial<Sentence>) => {
@@ -98,8 +98,10 @@ export const GraphSearch = (props: GraphSearchProps) => {
   }
   
   const onChange = (current: Partial<Sentence>, next: Partial<Sentence>, matches?: string[]) => {
-    setConditions(c => c.map(condition => 
-      condition.sentence === current ? ({ sentence : next, matches }) : condition));
+    const updated = conditions.map(condition => 
+        condition.sentence === current ? ({ sentence : next, matches }) : condition);
+
+    setConditions(updated);
   }
 
   const onDelete = (sentence: Partial<Sentence>) => {

--- a/src/pages/knowledgegraph/GraphSearch/GraphSearchConditionBuilder.tsx
+++ b/src/pages/knowledgegraph/GraphSearch/GraphSearchConditionBuilder.tsx
@@ -142,7 +142,7 @@ export const GraphSearchConditionBuilder = (props: GraphSearchConditionBuilderPr
         </Select>
 
         {sentence.ConditionType === 'WHERE' && (
-          <Combobox 
+          <Combobox
             className={selectStyle}
             value={(sentence as SimpleConditionSentence).Attribute}
             options={attributeOptions} 
@@ -200,7 +200,7 @@ export const GraphSearchConditionBuilder = (props: GraphSearchConditionBuilderPr
           <GraphSearchSubConditionBuilder
             key={idx}
             annotations={props.annotations}
-            subjectId={sentence.Value}
+            subjectId={sentence.Value.value}
             subcondition={subcondition} 
             onChange={next => onUpdateSubcondition(subcondition, next)} 
             onDelete={() => onDeleteSubcondition(subcondition)} />

--- a/src/pages/knowledgegraph/GraphSearch/GraphSearchSubConditionBuilder.tsx
+++ b/src/pages/knowledgegraph/GraphSearch/GraphSearchSubConditionBuilder.tsx
@@ -4,7 +4,7 @@ import { W3CAnnotation } from '@annotorious/react';
 import { Combobox } from '@/components/Combobox';
 import { Image } from '@/model';
 import { useSubConditions } from './useSubConditions';
-import { SubCondition } from './Types';
+import { DropdownOption, SubCondition } from './Types';
 
 interface GraphSearchSubConditionBuilderProps {
 
@@ -32,10 +32,10 @@ export const GraphSearchSubConditionBuilder = (props: GraphSearchSubConditionBui
   const selectStyle = 
     'rounded-none min-w-32 max-w-40 px-2 py-1 h-auto min-h-[30px] bg-white shadow-none whitespace-nowrap overflow-hidden text-ellipsis';
 
-  const onChangeAttribute = (attribute: string) =>
+  const onChangeAttribute = (attribute: DropdownOption) =>
     props.onChange({...props.subcondition, Attribute: attribute });
 
-  const onChangeValue = (value: string) =>
+  const onChangeValue = (value: DropdownOption) =>
     props.onChange(({...props.subcondition, Value: value }));
   
   return (
@@ -52,7 +52,7 @@ export const GraphSearchSubConditionBuilder = (props: GraphSearchSubConditionBui
 
       <Combobox 
         className={selectStyle}
-        value={props.subcondition.Value || ''}
+        value={props.subcondition.Value}
         options={values.map(value => ({ label: value, value }))} 
         onChange={onChangeValue} />
 

--- a/src/pages/knowledgegraph/GraphSearch/Types.ts
+++ b/src/pages/knowledgegraph/GraphSearch/Types.ts
@@ -1,3 +1,5 @@
+import { ComboboxOption } from '@/components/Combobox';
+
 /**
  * Example queries:
  * 
@@ -22,17 +24,17 @@ export type ConditionType = 'WHERE' | 'WITH_ENTITY' | 'WITH_NOTE';
 
 export interface SimpleConditionSentence extends BaseSentence {
 
-  Attribute: string;
+  Attribute: DropdownOption;
 
   Comparator: Comparator;
 
-  Value: string;
+  Value: DropdownOption;
 
 }
 
 export interface NestedConditionSentence extends BaseSentence {
 
-  Value: string;
+  Value: DropdownOption;
 
   SubConditions: SubCondition[];
 
@@ -44,15 +46,17 @@ export type Comparator = 'IS' | 'IS_NOT_EMPTY';
 
 export interface SubCondition {
 
-  Attribute: string;
+  Attribute: DropdownOption;
 
   Comparator: Comparator;
 
-  Value: string;
+  Value: DropdownOption;
 
 }
 
-export interface DropdownOption {
+export interface DropdownOption extends ComboboxOption {
+
+  builtIn?: boolean;
 
   label: string;
 

--- a/src/pages/knowledgegraph/GraphSearch/Types.ts
+++ b/src/pages/knowledgegraph/GraphSearch/Types.ts
@@ -62,6 +62,8 @@ export interface DropdownOption {
 
 export interface SchemaProperty { 
 
+  builtIn?: boolean;
+
   type: ObjectType;
 
   propertyName: string;

--- a/src/pages/knowledgegraph/GraphSearch/searchUtils.ts
+++ b/src/pages/knowledgegraph/GraphSearch/searchUtils.ts
@@ -81,6 +81,19 @@ const listMetadataProperties = (schemas: { type: ObjectType, schema: MetadataSch
   }, []);
 }
 
+const sortProperties = (properties: SchemaProperty[]) =>
+  [...properties].sort((a, b) => {
+    if (a.type !== b.type) {
+      return a.type.localeCompare(b.type);
+    } else {
+      if (a.builtIn !== b.builtIn) {
+        return a.builtIn ? -1 : 1;
+      } else {
+        return a.propertyName.localeCompare(b.propertyName);
+      }
+    }      
+  });
+
 /** List metadata properties from all folder/image schemas **/
 export const listAllMetadataProperties = (store: Store): SchemaProperty[] => {
   const model = store.getDataModel();
@@ -90,14 +103,21 @@ export const listAllMetadataProperties = (store: Store): SchemaProperty[] => {
     ...model.imageSchemas.map(schema => ({ type: 'IMAGE' as ObjectType, schema }))
   ];
 
-  return listMetadataProperties(schemas);
+  return sortProperties([
+    { type: 'FOLDER', propertyName: 'foldername', builtIn: true },
+    { type: 'IMAGE', propertyName: 'filename', builtIn: true },
+    ...listMetadataProperties(schemas)
+  ]);
 }
 
 /** List metadata properties from all folder schemas **/
 export const listFolderMetadataProperties = (store: Store): SchemaProperty[] => {
   const model = store.getDataModel();
   const schemas = model.folderSchemas.map(schema => ({ type: 'FOLDER' as ObjectType, schema }));
-  return listMetadataProperties(schemas);
+  return sortProperties([
+    { type: 'FOLDER', propertyName: 'foldername', builtIn: true },
+    ...listMetadataProperties(schemas)
+  ]);
 }
 
 const enumerateNotes = (

--- a/src/pages/knowledgegraph/GraphSearch/searchUtils.ts
+++ b/src/pages/knowledgegraph/GraphSearch/searchUtils.ts
@@ -180,7 +180,7 @@ export const listMetadataValues = (
         const serialized = serializePropertyValue(definition, value);
 
         const exists = all.find(o => o === serialized);
-        return exists ? all : [...all, serialized];
+        return exists ? all : [...all, ...serialized];
       } else {
         return all;
       }
@@ -193,7 +193,6 @@ export const listMetadataValues = (
         const bodies = annotations
           .filter(Boolean)
           .map(a => Array.isArray(a.body) ? a.body[0] : a.body)
-
         return getMetadataObjectOptions(bodies);
       })
   } else {
@@ -253,7 +252,12 @@ const hasMatchingValue = (propertyValue: SchemaPropertyValue, value?: string) =>
 }
 
 /** Find images where property name and value match on the given FOLDER or IMAGE property **/
-export const findImagesByMetadata = (store: Store, propertyType: 'FOLDER' | 'IMAGE', propertyName: string, value?: string): Promise<Image[]> => {
+export const findImagesByMetadata = (
+  store: Store, propertyType: 'FOLDER' | 'IMAGE', 
+  propertyName: string, 
+  value?: string,
+  builtIn?: boolean
+): Promise<Image[]> => {
   const { images } = store;
 
   // Warning: heavy operation! Resolve aggregated metadata for all images.
@@ -273,7 +277,12 @@ export const findImagesByMetadata = (store: Store, propertyType: 'FOLDER' | 'IMA
 
 }
 
-export const findFoldersByMetadata = (store: Store, propertyName: string, value?: string): Promise<Folder[]> => {
+export const findFoldersByMetadata = (
+  store: Store, 
+  propertyName: string, 
+  value?: string,
+  builtin?: boolean
+): Promise<Folder[]> => {
   const { folders } = store;
 
   const model = store.getDataModel();
@@ -342,10 +351,12 @@ export const findImagesByEntityConditions = (
         if (!('properties' in body)) return false;
 
         return conditions.every(c => { 
-          const definition = type.properties.find(p => p.name === c.Attribute);
+          if (!c.Attribute || !c.Value) return; 
+
+          const definition = type.properties.find(p => p.name === c.Attribute.value);
           if (definition) {
-            const serialized = serializePropertyValue(definition, body.properties[c.Attribute]);
-            return serialized.includes(c.Value);
+            const serialized = serializePropertyValue(definition, body.properties[c.Attribute.value]);
+            return serialized.includes(c.Value.value);
           }
         });
       });

--- a/src/pages/knowledgegraph/GraphSearch/searchUtils.ts
+++ b/src/pages/knowledgegraph/GraphSearch/searchUtils.ts
@@ -83,15 +83,15 @@ const listMetadataProperties = (schemas: { type: ObjectType, schema: MetadataSch
 
 const sortProperties = (properties: SchemaProperty[]) =>
   [...properties].sort((a, b) => {
-    if (a.type !== b.type) {
-      return a.type.localeCompare(b.type);
+    if (a.builtIn !== b.builtIn) {
+      return a.builtIn ? -1 : 1;
     } else {
-      if (a.builtIn !== b.builtIn) {
-        return a.builtIn ? -1 : 1;
+      if (a.type !== b.type) {
+        return a.type.localeCompare(b.type);
       } else {
         return a.propertyName.localeCompare(b.propertyName);
-      }
-    }      
+      }    
+    }  
   });
 
 /** List metadata properties from all folder/image schemas **/
@@ -104,8 +104,8 @@ export const listAllMetadataProperties = (store: Store): SchemaProperty[] => {
   ];
 
   return sortProperties([
-    { type: 'FOLDER', propertyName: 'foldername', builtIn: true },
-    { type: 'IMAGE', propertyName: 'filename', builtIn: true },
+    { type: 'FOLDER', propertyName: 'folder name', builtIn: true },
+    { type: 'IMAGE', propertyName: 'image filename', builtIn: true },
     ...listMetadataProperties(schemas)
   ]);
 }

--- a/src/pages/knowledgegraph/GraphSearch/useGraphSearch.ts
+++ b/src/pages/knowledgegraph/GraphSearch/useGraphSearch.ts
@@ -72,14 +72,14 @@ export const useGraphSearch = (
 
         setAttributeOptions(properties.map(p => {
           const value = `${p.type === 'FOLDER' ? 'folder' : 'image'}:${p.propertyName}`;
-          return { label: value, value }
+          return { label: value, value, builtIn: p.builtIn }
         }));
       } else if (!s.Comparator) {
         setComparatorOptions(ComparatorOptions);
       } else if (!s.Value && s.Comparator === 'IS') {
         // Resolve attribute
         const [type, propertyName] = resolveAttribute(s.Attribute.value);
-        listMetadataValues(store, type, propertyName).then(propertyValues => {
+        listMetadataValues(store, type, propertyName, s.Attribute.builtIn).then(propertyValues => {
           const options = propertyValues.map(label => ({ label, value: label }));
           setValueOptions(options);
         });

--- a/src/pages/knowledgegraph/GraphSearch/useGraphSearch.ts
+++ b/src/pages/knowledgegraph/GraphSearch/useGraphSearch.ts
@@ -71,7 +71,10 @@ export const useGraphSearch = (
           ? listFolderMetadataProperties(store) : listAllMetadataProperties(store);
 
         setAttributeOptions(properties.map(p => {
-          const value = `${p.type === 'FOLDER' ? 'folder' : 'image'}:${p.propertyName}`;
+          const value = p.builtIn 
+            ? p.propertyName
+            : `${p.type === 'FOLDER' ? 'folder' : 'image'}:${p.propertyName}`;
+            
           return { label: value, value, builtIn: p.builtIn }
         }));
       } else if (!s.Comparator) {

--- a/src/pages/knowledgegraph/GraphSearch/useGraphSearch.ts
+++ b/src/pages/knowledgegraph/GraphSearch/useGraphSearch.ts
@@ -78,20 +78,20 @@ export const useGraphSearch = (
         setComparatorOptions(ComparatorOptions);
       } else if (!s.Value && s.Comparator === 'IS') {
         // Resolve attribute
-        const [type, propertyName] = resolveAttribute(s.Attribute);
+        const [type, propertyName] = resolveAttribute(s.Attribute.value);
         listMetadataValues(store, type, propertyName).then(propertyValues => {
           const options = propertyValues.map(label => ({ label, value: label }));
           setValueOptions(options);
         });
       } else {
-        const [type, propertyName] = resolveAttribute(s.Attribute);
-        const value = s.Comparator === 'IS_NOT_EMPTY' ? undefined : s.Value;
+        const [type, propertyName] = resolveAttribute(s.Attribute.value);
+        const value = s.Comparator === 'IS_NOT_EMPTY' ? undefined : s.Value.value;
 
         if (objectType === 'IMAGE') {
-          findImagesByMetadata(store, type, propertyName, value).then(results =>
+          findImagesByMetadata(store, type, propertyName, value, s.Attribute.builtIn).then(results =>
             setMatches(results.map(image => image.id)));  
         } else {
-          findFoldersByMetadata(store, propertyName, value).then(results =>
+          findFoldersByMetadata(store, propertyName, value, s.Attribute.builtIn).then(results =>
             setMatches(results.map(folder => folder.id)));
         }
       }
@@ -103,10 +103,10 @@ export const useGraphSearch = (
         const options = entityTypes.map(t => ({ value: t.id, label: t.label || t.id }));
         setValueOptions(options);
       } else if ((s.SubConditions || []).length === 0) {
-        const imageNodes = findImagesByEntityClass(store, graph, s.Value);
+        const imageNodes = findImagesByEntityClass(store, graph, s.Value.value);
         setMatches(imageNodes.map(n => n.id));
       } else {
-        const images = findImagesByEntityConditions(store, annotations, s.Value, s.SubConditions);
+        const images = findImagesByEntityConditions(store, annotations, s.Value.value, s.SubConditions);
         setMatches(images.map(i => i.id));
       }
     } else if (sentence.ConditionType === 'WITH_NOTE') {
@@ -114,7 +114,7 @@ export const useGraphSearch = (
         const notes = listAllNotes(annotations);
         setValueOptions(notes.map(n => ({ label: n, value: n })));
       } else {
-        const imageIds = findImagesByNote(annotations, sentence.Value);
+        const imageIds = findImagesByNote(annotations, sentence.Value.value);
         setMatches(imageIds);
       }
     }

--- a/src/pages/knowledgegraph/GraphSearch/useGraphSearch.ts
+++ b/src/pages/knowledgegraph/GraphSearch/useGraphSearch.ts
@@ -53,10 +53,17 @@ export const useGraphSearch = (
   const updateSentence = (part: Partial<Sentence>) =>
     setSentence(prev => ({ ...prev, ...part }));
 
-  const resolveAttribute = (attribute: string): ['FOLDER' | 'IMAGE', string] => {
-    return attribute.startsWith('folder:') 
-      ? ['FOLDER', attribute.substring('folder:'.length)]
-      : ['IMAGE',  attribute.substring('image:'.length)];
+  // This is a horrible hack... but well, the customer is always right
+  const resolveAttribute = (attribute: DropdownOption): ['FOLDER' | 'IMAGE', string] => {
+    if (attribute.builtIn) {
+      return attribute.value.startsWith('folder')
+        ? ['FOLDER', attribute.value]
+        : ['IMAGE',  attribute.value];
+    } else {
+      return attribute.value.startsWith('folder:') 
+        ? ['FOLDER', attribute.value.substring('folder:'.length)]
+        : ['IMAGE',  attribute.value.substring('image:'.length)];
+    }
   }
 
   useEffect(() => {
@@ -81,13 +88,13 @@ export const useGraphSearch = (
         setComparatorOptions(ComparatorOptions);
       } else if (!s.Value && s.Comparator === 'IS') {
         // Resolve attribute
-        const [type, propertyName] = resolveAttribute(s.Attribute.value);
+        const [type, propertyName] = resolveAttribute(s.Attribute);
         listMetadataValues(store, type, propertyName, s.Attribute.builtIn).then(propertyValues => {
           const options = propertyValues.map(label => ({ label, value: label }));
           setValueOptions(options);
         });
       } else {
-        const [type, propertyName] = resolveAttribute(s.Attribute.value);
+        const [type, propertyName] = resolveAttribute(s.Attribute);
         const value = s.Comparator === 'IS_NOT_EMPTY' ? undefined : s.Value.value;
 
         if (objectType === 'IMAGE') {

--- a/src/pages/knowledgegraph/GraphSearch/useSubConditions.ts
+++ b/src/pages/knowledgegraph/GraphSearch/useSubConditions.ts
@@ -2,11 +2,12 @@ import { useMemo } from 'react';
 import { useDataModel } from '@/store';
 import { W3CAnnotation, W3CAnnotationBody } from '@annotorious/react';
 import { serializePropertyValue } from '@/utils/serialize';
+import { DropdownOption } from './Types';
 
 export const useSubConditions = (
   annotations: W3CAnnotation[],
   subjectId: string, 
-  attribute?: string,
+  attribute?: DropdownOption,
 ) => {
   const model = useDataModel();
 
@@ -28,15 +29,15 @@ export const useSubConditions = (
     const values = entityBodies.reduce<string[]>((all, body) => {
       if (!('properties' in body && body.properties)) return all;
 
-      if (!body.properties[attribute]) return all;
+      if (!body.properties[attribute.value]) return all;
       
       const type = model.getEntityType(body.source, true);
       if (!type) return all;
 
-      const property = (type.properties || []).find(p => p.name === attribute);
+      const property = (type.properties || []).find(p => p.name === attribute.value);
       if (!property) return all;
 
-      const serialized = serializePropertyValue(property, body.properties[attribute]);
+      const serialized = serializePropertyValue(property, body.properties[attribute.value]);
       return [...all, ...serialized]; 
     }, []);
 


### PR DESCRIPTION
## In this PR

Issue #113: this PR adds image filename and folder name to the searchable paramters in the graph search.