### PR TITLE
Knowledge Graph: Legend

### DIFF
--- a/src/pages/knowledgegraph/GraphControls/GraphControls.tsx
+++ b/src/pages/knowledgegraph/GraphControls/GraphControls.tsx
@@ -41,7 +41,7 @@ export const GraphControls = (props: GraphControlsProps) => {
         className={props.isSearchOpen 
           ? 'rounded-full bg-black'
           : 'rounded-full bg-white/70 backdrop-blur-sm'}
-        tooltip="Toggle graph search"
+        tooltip="Graph search"
         onClick={props.onToggleSearch}>
         <Search className="h-5 w-5" />
       </TooltippedButton>
@@ -62,7 +62,7 @@ export const GraphControls = (props: GraphControlsProps) => {
         className={props.isSettingsOpen 
           ? 'gap-2 pl-3.5 pr-4 rounded-full border'
           : 'gap-2 pl-3.5 pr-4 rounded-full bg-white/70 backdrop-blur-sm'}
-        tooltip="View and filter settings"
+        tooltip="Graph settings"
         onClick={props.onToggleSettings}>
         <Settings className="h-5 w-5" /> Settings
       </TooltippedButton>

--- a/src/pages/knowledgegraph/KnowledgeGraphState.tsx
+++ b/src/pages/knowledgegraph/KnowledgeGraphState.tsx
@@ -44,7 +44,10 @@ export const KnowledgeGraphStateProvider = (props: { children: ReactNode }) => {
 
   const [selectedNodes, setSelectedNodes] = useState<NodeObject<GraphNode>[]>([]);
 
-  const [settings, setSettings] = useState<KnowledgeGraphSettings>({ graphMode: 'HIERARCHY' });
+  const [settings, setSettings] = useState<KnowledgeGraphSettings>({ 
+    graphMode: 'HIERARCHY',
+    legendExpanded: true
+  });
 
   const [showGraphSearch, setShowGraphSearch] = useState(false);
 

--- a/src/pages/knowledgegraph/Legend/Legend.tsx
+++ b/src/pages/knowledgegraph/Legend/Legend.tsx
@@ -24,7 +24,7 @@ export const Legend = (props: LegendProps) => {
   useEffect(() => {
     if (expanded && edgeLegendEl.current)
       setEdgeLegendHeight(edgeLegendEl.current.scrollHeight);      
-  }, [expanded]);
+  }, [expanded, settings.graphMode]);
 
   useEffect(() => {
     // If initial state is collapsed, set edgeLegend to display: none.
@@ -109,6 +109,24 @@ export const Legend = (props: LegendProps) => {
           <div className="pt-8">
             <h3 className="font-medium py-0.5">Edges</h3>
             <ul>
+              {settings.graphMode === 'RELATIONS' && (
+                <li className="flex gap-3 items-start py-2">
+                  <div 
+                    className="mt-2 h-0 w-14 flex-shrink-0 border-t-2 border-black" 
+                    style={{ borderColor: LINK_COLORS.HAS_RELATED_ANNOTATION_IN }} />
+
+                  <div>
+                    <h4 className="font-medium">
+                      Relationship
+                    </h4>
+
+                    <p className="text-muted-foreground text-xs">
+                      Connections based on Relationships between your annotations.
+                    </p>
+                  </div>
+                </li>
+              )}
+
               <li className="flex gap-3 items-start py-2">
                 <div 
                   className="mt-2 h-0 w-14 flex-shrink-0 border-t-2 border-black border-dashed" 

--- a/src/pages/knowledgegraph/Legend/Legend.tsx
+++ b/src/pages/knowledgegraph/Legend/Legend.tsx
@@ -1,4 +1,9 @@
-import { NODE_COLORS } from '../Styles';
+import { useEffect, useRef, useState } from 'react';
+import { Maximize2, Minimize2 } from 'lucide-react';
+import { useSpring, animated } from '@react-spring/web';
+import { Button } from '@/ui/Button';
+import { NODE_COLORS, LINK_COLORS } from '../Styles';
+import { useKnowledgeGraphSettings } from '../KnowledgeGraphState';
 
 interface LegendProps {
 
@@ -8,32 +13,149 @@ interface LegendProps {
 
 export const Legend = (props: LegendProps) => {
 
-  return (
-    <div className="absolute bottom-7 left-7 text-sm bg-white/70 backdrop-blur-sm px-1 py-0.5 rounded">
-      <ul className="flex gap-8">
-        <li className="flex gap-2 items-center">
-          <span 
-            style={{ backgroundColor: NODE_COLORS['IMAGE']}} 
-            className="block w-[12px] h-[12px] rounded-full"/>
-          <span>Image</span>
-        </li>
+  const { settings, setSettings } = useKnowledgeGraphSettings();
 
-        {props.includeFolders && (
+  const expanded = settings.legendExpanded;
+
+  const edgeLegendEl = useRef<HTMLDivElement>(null);
+
+  const [edgeLegendHeight, setEdgeLegendHeight] = useState(0);
+
+  useEffect(() => {
+    if (expanded && edgeLegendEl.current)
+      setEdgeLegendHeight(edgeLegendEl.current.scrollHeight);      
+  }, [expanded]);
+
+  useEffect(() => {
+    // If initial state is collapsed, set edgeLegend to display: none.
+    if (!expanded)
+      edgeLegendEl.current.style.display = 'none';
+  }, []);
+
+  const containerBase =
+    'group border border-transparent absolute bottom-4 left-4 max-w-[400px] text-sm bg-white/70 backdrop-blur-sm hover:border-inherit';
+
+  const containerClass = expanded 
+    ? containerBase + ' rounded-lg p-3.5'
+    : containerBase + ' rounded-full p-4 pr-14';
+
+  const toggleBase =
+    'rounded-full absolute right-1.5 text-muted-foreground hidden group-hover:flex';
+
+  const toggleClass = expanded ? toggleBase + ' top-1.5': toggleBase + ' top-0 my-auto bottom-0';
+
+  const edgeLegendSpring = useSpring({
+    height: expanded ? edgeLegendHeight || 'auto' : 0,
+    opacity: expanded ? 1 : 0,
+    config: { tension: 500, friction: expanded ? 20 : 40 },
+    onRest: () => {
+      if (!expanded) edgeLegendEl.current.style.display = 'none';
+    }
+  });
+
+  const onToggle = () => {
+    edgeLegendEl.current.style.display = 'block';
+    setSettings(settings => ({
+      ...settings,
+      legendExpanded: !settings.legendExpanded
+    }));
+  }
+
+  return (
+    <div className={containerClass}>
+      <Button 
+        size="icon" 
+        variant="ghost" 
+        className={toggleClass}
+        onClick={onToggle}>
+        {expanded ? (
+          <Minimize2 className="h-4 w-4" />
+        ) : (
+          <Maximize2 className="h-4 w-4" />
+        )}
+      </Button>
+
+      <div>
+        {expanded && (<h3 className="font-medium pb-1.5">Nodes</h3>)}
+
+        <ul className="flex gap-8 text-muted-foreground text-xs">
           <li className="flex gap-2 items-center">
             <span 
-              style={{ backgroundColor: NODE_COLORS['FOLDER']}} 
+              style={{ backgroundColor: NODE_COLORS['ENTITY_TYPE']}} 
               className="block w-[12px] h-[12px] rounded-full" />
-            <span>Sub-Folder</span>
+            <span>Entity Class</span>
           </li>
-        )}
 
-        <li className="flex gap-2 items-center">
-          <span 
-            style={{ backgroundColor: NODE_COLORS['ENTITY_TYPE']}} 
-            className="block w-[12px] h-[12px] rounded-full" />
-          <span>Entity Class</span>
-        </li>
-      </ul>
+          {props.includeFolders && (
+            <li className="flex gap-2 items-center">
+              <span 
+                style={{ backgroundColor: NODE_COLORS['FOLDER']}} 
+                className="block w-[12px] h-[12px] rounded-full" />
+              <span>Sub-Folder</span>
+            </li>
+          )}
+
+          <li className="flex gap-2 items-center">
+            <span 
+              style={{ backgroundColor: NODE_COLORS['IMAGE']}} 
+              className="block w-[12px] h-[12px] rounded-full"/>
+            <span>Image</span>
+          </li>
+        </ul>
+      </div>
+
+      <animated.div style={edgeLegendSpring}>
+        <div ref={edgeLegendEl}>
+          <div className="pt-8">
+            <h3 className="font-medium py-0.5">Edges</h3>
+            <ul>
+              <li className="flex gap-3 items-start py-2">
+                <div 
+                  className="mt-2 h-0 w-14 flex-shrink-0 border-t-2 border-black border-dashed" 
+                  style={{ borderColor: LINK_COLORS.IS_PARENT_TYPE_OF }} />
+
+                <div>
+                  <h4 className="font-medium">
+                    Entity class hierarchy
+                  </h4>
+
+                  <p className="text-muted-foreground text-xs">
+                    Links between parent- and child classes in your Entity data model.
+                  </p>
+                </div>
+              </li>
+
+              <li className="flex gap-3 items-start py-2">
+                <div 
+                  className="mt-2 h-0 w-14 flex-shrink-0 border-t-2 border-black border-dashed" 
+                  style={{ borderColor: LINK_COLORS.FOLDER_CONTAINS_SUBFOLDER }} />
+
+                <div>
+                  <h4 className="font-medium">Folder structure</h4>
+                  <p className="text-muted-foreground text-xs">
+                    File structure of sub-folders and image files in your 
+                    project.
+                  </p>
+                </div>
+              </li>
+
+              <li className="flex gap-3 items-start py-2">
+                <div 
+                  className="mt-2 h-0 w-14 flex-shrink-0 border-t-4 border-black" 
+                  style={{ borderColor: LINK_COLORS.HAS_ENTITY_ANNOTATION }} />
+
+                <div>
+                  <h4 className="font-medium">Entity Tags</h4>
+                  <p className="text-muted-foreground text-xs">
+                    Connections between images and Entity Classes, based on 
+                    the tags in your annotations.
+                  </p>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </animated.div>
     </div>
   )
 

--- a/src/pages/knowledgegraph/Types.ts
+++ b/src/pages/knowledgegraph/Types.ts
@@ -78,6 +78,8 @@ export type GraphLinkPrimitiveType =
 
 export interface KnowledgeGraphSettings {
 
+  graphMode: 'HIERARCHY' | 'RELATIONS';
+
   hideIsolatedNodes?: boolean;
 
   hideAllLabels?: boolean;
@@ -86,7 +88,7 @@ export interface KnowledgeGraphSettings {
 
   includeFolders?: boolean;
 
-  graphMode: 'HIERARCHY' | 'RELATIONS';
+  legendExpanded?: boolean;
 
 }
 


### PR DESCRIPTION
## In this PR

Extends the Knowledge Graph legend:
- Legend entries for different types of edges
- Shows entry for relationship only when in __Relations__ mode
- Can be toggled between expanded and collapsed state
- State remains persistent across page changes