### PR TITLE
KG Search: AND/OR Condition Chaining

### DIFF
--- a/src/pages/knowledgegraph/GraphSearch/GraphSearch.tsx
+++ b/src/pages/knowledgegraph/GraphSearch/GraphSearch.tsx
@@ -14,6 +14,7 @@ import {
   GraphNode, 
   KnowledgeGraphSettings,
   ObjectType, 
+  Operator, 
   Sentence
 } from '../Types';
 import { 
@@ -42,7 +43,7 @@ interface GraphSearchProps {
 
 }
 
-const EMPTY_CONDITION: Condition = { sentence: {} };
+const EMPTY_CONDITION: Condition = { operator: 'AND', sentence: {} };
 
 export const GraphSearch = (props: GraphSearchProps) => {
 
@@ -93,7 +94,7 @@ export const GraphSearch = (props: GraphSearchProps) => {
   
   const onChange = (current: Partial<Sentence>, next: Partial<Sentence>, matches?: string[]) => {
     const updated = conditions.map(condition => 
-        condition.sentence === current ? ({ sentence : next, matches }) : condition);
+        condition.sentence === current ? ({ operator: condition.operator, sentence : next, matches }) : condition);
 
     setConditions(updated);
   }
@@ -115,6 +116,11 @@ export const GraphSearch = (props: GraphSearchProps) => {
     } else {
       setConditions([]);
     }
+  }
+
+  const onSelectOperator = (sentence: Partial<Sentence>, operator: Operator) => {
+    const next = conditions.map(c => c.sentence === sentence ? ({...c, operator }) : c);
+    setConditions(next);
   }
 
   const onClearAll = () => {
@@ -142,9 +148,9 @@ export const GraphSearch = (props: GraphSearchProps) => {
         </Button>
       </div>
 
-      <div className="p-2 pr-6 pb-2">
+      <div className="px-3 pr-6 pb-2">
         <div className="text-xs flex items-center gap-2">
-          <span className="w-12 text-right">
+          <span className="w-14 text-right">
             Find
           </span>
           
@@ -177,15 +183,35 @@ export const GraphSearch = (props: GraphSearchProps) => {
           </Select>
         </div>
 
-        {conditions.map(({ sentence }, idx) => (
+        {conditions.map(({ operator, sentence }, idx) => (
           <div 
             className="flex flex-nowrap gap-2 pt-2 text-xs items-center"
             key={idx}>
             
             {(idx === 0) ? (
-              <div className="w-12" />
+              <div className="w-14" />
             ) : (
-              <div className="w-12 text-right self-start pt-1">and</div>
+              <div className="w-14">
+                <Select 
+                  value={operator || 'AND'}
+                  onValueChange={op => onSelectOperator(sentence, op as Operator)}>
+                  <SelectTrigger className="w-16 rounded-none border-r-0 px-2 py-1 h-auto bg-white shadow-none">
+                    <span className="text-xs">
+                      <SelectValue />
+                    </span>
+                  </SelectTrigger>
+
+                  <SelectContent>
+                    <SelectItem
+                      className="text-xs" 
+                      value="AND">and</SelectItem>
+
+                    <SelectItem
+                      className="text-xs" 
+                      value="OR">or</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
             )}
 
             <GraphSearchConditionBuilder 

--- a/src/pages/knowledgegraph/GraphSearch/GraphSearchConditionBuilder.tsx
+++ b/src/pages/knowledgegraph/GraphSearch/GraphSearchConditionBuilder.tsx
@@ -136,7 +136,7 @@ export const GraphSearchConditionBuilder = (props: GraphSearchConditionBuilderPr
 
           <SelectTrigger className={`${selectStyle} border-l`}>
             <span className="overflow-hidden text-ellipsis text-xs">
-              <SelectValue />
+              <SelectValue placeholder={'\u00A0'} />
             </span>
           </SelectTrigger>
 

--- a/src/pages/knowledgegraph/Types.ts
+++ b/src/pages/knowledgegraph/Types.ts
@@ -184,8 +184,10 @@ export interface Condition {
 
   matches?: string[];
 
-  // operator: 'AND' | 'OR';
+  operator: Operator;
 
 }
+
+export type Operator = 'AND' | 'OR';
 
 


### PR DESCRIPTION
## In this PR

Previously, when defining multiple graph search conditions, these conditions were AND-chained. In other words, each condition was evaluated individually, and the intersection of the individual results formed the final result.

This PR introduces a dropdown toggle allowing users to choose between AND and OR chaining of search conditions, as requested in #95. 

Note that nested logical expressions or grouping of conditions (as you would normally do with parentheses to combine AND/OR statements) are __not currently supported__. Instead, a sequence of conditions is evaluated as though all preceding conditions are grouped. For example:

```
A and B and C or D and E
```

is interpreted as 

```
((((A and B) and C) or D) and E)
```
