### PR TITLE
IIIF Simple Image Support

### DIFF
--- a/src/pages/annotate/WorkspaceSection/AnnotatableImage.tsx
+++ b/src/pages/annotate/WorkspaceSection/AnnotatableImage.tsx
@@ -104,8 +104,6 @@ export const AnnotatableImage = (props: AnnotatableImageProps) => {
     minZoomLevel: 0.1,
     maxZoomLevel: 100
   }), [image.id]);
-
-  console.log('opts', options);
   
   return (
     <Annotorious id={props.image.id}>

--- a/src/pages/annotate/WorkspaceSection/AnnotatableImage.tsx
+++ b/src/pages/annotate/WorkspaceSection/AnnotatableImage.tsx
@@ -101,10 +101,11 @@ export const AnnotatableImage = (props: AnnotatableImageProps) => {
       dblClickToZoom: false
     },
     showNavigationControl: false,
-    crossOriginPolicy: 'Anonymous',
     minZoomLevel: 0.1,
     maxZoomLevel: 100
   }), [image.id]);
+
+  console.log('opts', options);
   
   return (
     <Annotorious id={props.image.id}>

--- a/src/utils/cozy-iiif/utils/canvas.ts
+++ b/src/utils/cozy-iiif/utils/canvas.ts
@@ -31,8 +31,8 @@ export const getThumbnailURL = (canvas: Canvas, images: CozyImageResource[] = []
     if (image.type === 'dynamic' || image.type === 'level0') {
       return getImageURLFromService(image.service, w, h);
     } else if (image.type === 'static') {
-      // TODO
-      console.error('Static image canvas: unspported');
+      // console.warn('Static image canvas');
+      return image.url;
     }    
   }
 }

--- a/src/utils/getImageSnippetWorker.js
+++ b/src/utils/getImageSnippetWorker.js
@@ -1,7 +1,7 @@
 self.onmessage = function(e) {
-  const { image, annotation } = e.data;
+  const { blob, annotation } = e.data;
   
-  cropImage(image, annotation)
+  cropImage(blob, annotation)
     .then(snippet => { 
       self.postMessage({ snippet });
       self.close();
@@ -9,14 +9,14 @@ self.onmessage = function(e) {
     .catch(error => self.postMessage({ error: error.message }));
 };
 
-function cropImage(image, annotation, maxWidth = 800, maxHeight = 800) {
+function cropImage(blob, annotation, maxWidth = 800, maxHeight = 800) {
   return new Promise((resolve, reject) => {
     const { bounds } = annotation.target.selector.geometry;
 
     const width = bounds.maxX - bounds.minX;
     const height = bounds.maxY - bounds.minY;
 
-    createImageBitmap(new Blob([image.data]))
+    createImageBitmap(blob)
       .then(imageBitmap => {
         const canvas = new OffscreenCanvas(width, height);
         

--- a/src/utils/iiif/getLabelWithFallback.ts
+++ b/src/utils/iiif/getLabelWithFallback.ts
@@ -7,11 +7,15 @@ export const getCanvasLabelWithFallback = (canvas: CozyCanvas) => {
   const firstImage = canvas.images[0];
   if (!firstImage) return 'Unnamed (empty)';
 
-  if (firstImage.type === 'dynamic') 
+  if (firstImage.type === 'dynamic')
     return  `Unnamed (Image API v${firstImage.majorVersion})`;
 
   if (firstImage.type === 'level0')
     return  `Unnamed (Image API v${firstImage.majorVersion} Lvl 0)`;
 
-  return 'Unnamed';
+  if (firstImage.type === 'static')
+    return 'Unnamed (static image)';
+
+  // Should never happen
+  return 'Unnamed (unknown)';
 }


### PR DESCRIPTION
## In this PR

This PR adds full support for IIIF Simple Image manifests, which point to a static (JPEG or PNG) image instead of an image service. Snippet cropping is performed on the client, by fetching the image from the URL, and then performing a crop on the image data using the normal crop worker.

__Note that the server where the image is hosted must have CORS enabled.__ While browsers are able to __display__ an image from a 3rd-party source, JavaScript is not allowed to access the image data! This means cropping cannot work for an image without CORS.