### PR TITLE
Annotation List: User-Defined Order

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "@annotorious/plugin-tools": "^1.0.2",
         "@annotorious/react": "3.1.5",
         "@annotorious/react-manifold": "3.1.5",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
         "@neodrag/react": "2.3.0",
         "@radix-ui/react-accordion": "^1.2.3",
         "@radix-ui/react-alert-dialog": "^1.1.6",
@@ -65,7 +67,7 @@
         "uuid": "^11.1.0"
       },
       "devDependencies": {
-        "@tailwindcss/postcss": "^4.0.12",
+        "@tailwindcss/postcss": "^4.0.13",
         "@types/chroma-js": "^3.1.1",
         "@types/node": "^22.13.10",
         "@types/openseadragon": "^3.0.10",
@@ -76,7 +78,7 @@
         "@types/wicg-file-system-access": "^2023.10.5",
         "@vitejs/plugin-react": "^4.3.4",
         "postcss": "^8.5.3",
-        "tailwindcss": "^4.0.12",
+        "tailwindcss": "^4.0.13",
         "typescript": "^5.8.2",
         "vite": "^6.2.1",
         "vite-plugin-babel-macros": "^1.0.6",
@@ -111,12 +113,13 @@
       }
     },
     "node_modules/@annotorious/annotorious": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@annotorious/annotorious/-/annotorious-3.1.5.tgz",
-      "integrity": "sha512-t7tYQYop3BRv+C24SB4xk+MOUhvRVlPTT0QWiDLaTcWtl2X6+muFju32Yk0L4NwhSdJdy1yA6v6X+BQ7M9FNBA==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@annotorious/annotorious/-/annotorious-3.1.7.tgz",
+      "integrity": "sha512-fXPni+ie0lo7cNESDVEZfFYTAdGYo6jhsW74pIOyKfDoGDsusg/Y1TCAEIEdYktw5eWZh3bQ/BG45vvGuFYVAQ==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
-        "@annotorious/core": "3.1.5",
+        "@annotorious/core": "3.1.7",
         "rbush": "^4.0.1",
         "uuid": "^11.1.0"
       },
@@ -125,10 +128,11 @@
       }
     },
     "node_modules/@annotorious/core": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@annotorious/core/-/core-3.1.5.tgz",
-      "integrity": "sha512-98DnfyaaY7WfWBp+mMB2gF475m+ZO2kA7LGNxrMRgHQJBBaPdckrxDHbK9BDlZuX2ZWxrHkKh+q5glKsaOJIew==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@annotorious/core/-/core-3.1.7.tgz",
+      "integrity": "sha512-eGYvbIOZI0pX7sYMijMBkAtxrKXhMv5CcIEqdmwhYW2B7v2fWgqAzyBtTEPDHTNUOQxvOf4KD3QnQTyXyReTWQ==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3",
         "nanoevents": "^9.1.0",
@@ -140,13 +144,14 @@
       }
     },
     "node_modules/@annotorious/openseadragon": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@annotorious/openseadragon/-/openseadragon-3.1.5.tgz",
-      "integrity": "sha512-LBwGgqY6UhhCI1Gi4ECA2HBzFwmeaXeNyOFbT0U9PCV83zVU0o+MadhudDw8DwCHgn23DIGP9QKd8iSD0NKrdA==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@annotorious/openseadragon/-/openseadragon-3.1.7.tgz",
+      "integrity": "sha512-vcDnqIZmF4DbvnMI8i7YkAmI2EN+fL5RmojYraLFTB6euUYAgDT2vXN6uOyPmmxtmmb4oANA2Nf37hgyoeTWQg==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
-        "@annotorious/annotorious": "3.1.5",
-        "@annotorious/core": "3.1.5",
+        "@annotorious/annotorious": "3.1.7",
+        "@annotorious/core": "3.1.7",
         "pixi.js": "^7.4.2",
         "uuid": "^11.1.0"
       },
@@ -286,6 +291,53 @@
         "react-dom": "16.8.0 || >=17.x || >=18.x|| >=19.x"
       }
     },
+    "node_modules/@annotorious/react/node_modules/@annotorious/annotorious": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@annotorious/annotorious/-/annotorious-3.1.5.tgz",
+      "integrity": "sha512-t7tYQYop3BRv+C24SB4xk+MOUhvRVlPTT0QWiDLaTcWtl2X6+muFju32Yk0L4NwhSdJdy1yA6v6X+BQ7M9FNBA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@annotorious/core": "3.1.5",
+        "rbush": "^4.0.1",
+        "uuid": "^11.1.0"
+      },
+      "funding": {
+        "url": "https://steadyhq.com/rainer-simon"
+      }
+    },
+    "node_modules/@annotorious/react/node_modules/@annotorious/core": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@annotorious/core/-/core-3.1.5.tgz",
+      "integrity": "sha512-98DnfyaaY7WfWBp+mMB2gF475m+ZO2kA7LGNxrMRgHQJBBaPdckrxDHbK9BDlZuX2ZWxrHkKh+q5glKsaOJIew==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "nanoevents": "^9.1.0",
+        "nanoid": "^5.1.3",
+        "uuid": "^11.1.0"
+      },
+      "funding": {
+        "url": "https://steadyhq.com/rainer-simon"
+      }
+    },
+    "node_modules/@annotorious/react/node_modules/@annotorious/openseadragon": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@annotorious/openseadragon/-/openseadragon-3.1.5.tgz",
+      "integrity": "sha512-LBwGgqY6UhhCI1Gi4ECA2HBzFwmeaXeNyOFbT0U9PCV83zVU0o+MadhudDw8DwCHgn23DIGP9QKd8iSD0NKrdA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@annotorious/annotorious": "3.1.5",
+        "@annotorious/core": "3.1.5",
+        "pixi.js": "^7.4.2",
+        "uuid": "^11.1.0"
+      },
+      "funding": {
+        "url": "https://steadyhq.com/rainer-simon"
+      },
+      "peerDependencies": {
+        "openseadragon": "^3.0.0 || ^4.0.0 || ^5.0.0"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.26.2",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
@@ -312,22 +364,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.9.tgz",
-      "integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
+      "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.9",
+        "@babel/generator": "^7.26.10",
         "@babel/helper-compilation-targets": "^7.26.5",
         "@babel/helper-module-transforms": "^7.26.0",
-        "@babel/helpers": "^7.26.9",
-        "@babel/parser": "^7.26.9",
+        "@babel/helpers": "^7.26.10",
+        "@babel/parser": "^7.26.10",
         "@babel/template": "^7.26.9",
-        "@babel/traverse": "^7.26.9",
-        "@babel/types": "^7.26.9",
+        "@babel/traverse": "^7.26.10",
+        "@babel/types": "^7.26.10",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -343,14 +395,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.9.tgz",
-      "integrity": "sha512-kEWdzjOAUMW4hAyrzJ0ZaTOu9OmpyDIQicIh0zg0EEcEkYXZb2TjtBhnHi2ViX7PKwZqF4xwqfAm299/QMP3lg==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.10.tgz",
+      "integrity": "sha512-rRHT8siFIXQrAYOYqZQVsAr8vJ+cBNqcVAY6m5V8/4QqzaPl+zDBe6cLEPRDuNOUf3ww8RfJVlOyQMoSI+5Ang==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.26.9",
-        "@babel/types": "^7.26.9",
+        "@babel/parser": "^7.26.10",
+        "@babel/types": "^7.26.10",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -449,27 +501,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.9.tgz",
-      "integrity": "sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.10.tgz",
+      "integrity": "sha512-UPYc3SauzZ3JGgj87GgZ89JVdC5dj0AoetR5Bw6wj4niittNyFh6+eOGonYvJ1ao6B8lEa3Q3klS7ADZ53bc5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/types": "^7.26.10"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
-      "integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.10.tgz",
+      "integrity": "sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.9"
+        "@babel/types": "^7.26.10"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -543,9 +595,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.9.tgz",
-      "integrity": "sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -570,17 +622,17 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.9.tgz",
-      "integrity": "sha512-ZYW7L+pL8ahU5fXmNbPF+iZFHCv5scFak7MZ9bwaRPLUhHh7QQEMjZUg0HevihoqCM5iSYHN61EyCoZvqC+bxg==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.10.tgz",
+      "integrity": "sha512-k8NuDrxr0WrPH5Aupqb2LCVURP/S0vBEn5mK6iH+GIYob66U5EtoZvcdudR2jQ4cmTwhEwW1DLB+Yyas9zjF6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.9",
-        "@babel/parser": "^7.26.9",
+        "@babel/generator": "^7.26.10",
+        "@babel/parser": "^7.26.10",
         "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.9",
+        "@babel/types": "^7.26.10",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -589,9 +641,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
-      "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.10.tgz",
+      "integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -600,6 +652,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -3163,44 +3268,44 @@
       ]
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.0.12.tgz",
-      "integrity": "sha512-a6J11K1Ztdln9OrGfoM75/hChYPcHYGNYimqciMrvKXRmmPaS8XZTHhdvb5a3glz4Kd4ZxE1MnuFE2c0fGGmtg==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.0.13.tgz",
+      "integrity": "sha512-P9TmtE9Vew0vv5FwyD4bsg/dHHsIsAuUXkenuGUc5gm8fYgaxpdoxIKngCyEMEQxyCKR8PQY5V5VrrKNOx7exg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "enhanced-resolve": "^5.18.1",
         "jiti": "^2.4.2",
-        "tailwindcss": "4.0.12"
+        "tailwindcss": "4.0.13"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.0.12.tgz",
-      "integrity": "sha512-DWb+myvJB9xJwelwT9GHaMc1qJj6MDXRDR0CS+T8IdkejAtu8ctJAgV4r1drQJLPeS7mNwq2UHW2GWrudTf63A==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.0.13.tgz",
+      "integrity": "sha512-pTH3Ex5zAWC9LbS+WsYAFmkXQW3NRjmvxkKJY3NP1x0KHBWjz0Q2uGtdGMJzsa0EwoZ7wq9RTbMH1UNPceCpWw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.0.12",
-        "@tailwindcss/oxide-darwin-arm64": "4.0.12",
-        "@tailwindcss/oxide-darwin-x64": "4.0.12",
-        "@tailwindcss/oxide-freebsd-x64": "4.0.12",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.0.12",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.0.12",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.0.12",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.0.12",
-        "@tailwindcss/oxide-linux-x64-musl": "4.0.12",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.0.12",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.0.12"
+        "@tailwindcss/oxide-android-arm64": "4.0.13",
+        "@tailwindcss/oxide-darwin-arm64": "4.0.13",
+        "@tailwindcss/oxide-darwin-x64": "4.0.13",
+        "@tailwindcss/oxide-freebsd-x64": "4.0.13",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.0.13",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.0.13",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.0.13",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.0.13",
+        "@tailwindcss/oxide-linux-x64-musl": "4.0.13",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.0.13",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.0.13"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.0.12.tgz",
-      "integrity": "sha512-dAXCaemu3mHLXcA5GwGlQynX8n7tTdvn5i1zAxRvZ5iC9fWLl5bGnjZnzrQqT7ttxCvRwdVf3IHUnMVdDBO/kQ==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.0.13.tgz",
+      "integrity": "sha512-+9zmwaPQ8A9ycDcdb+hRkMn6NzsmZ4YJBsW5Xqq5EdOu9xlIgmuMuJauVzDPB5BSbIWfhPdZ+le8NeRZpl1coA==",
       "cpu": [
         "arm64"
       ],
@@ -3215,9 +3320,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.0.12.tgz",
-      "integrity": "sha512-vPNI+TpJQ7sizselDXIJdYkx9Cu6JBdtmRWujw9pVIxW8uz3O2PjgGGzL/7A0sXI8XDjSyRChrUnEW9rQygmJQ==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.0.13.tgz",
+      "integrity": "sha512-Bj1QGlEJSjs/205CIRfb5/jeveOqzJ4pFMdRxu0gyiYWxBRyxsExXqaD+7162wnLP/EDKh6S1MC9E/1GwEhLtA==",
       "cpu": [
         "arm64"
       ],
@@ -3232,9 +3337,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.0.12.tgz",
-      "integrity": "sha512-RL/9jM41Fdq4Efr35C5wgLx98BirnrfwuD+zgMFK6Ir68HeOSqBhW9jsEeC7Y/JcGyPd3MEoJVIU4fAb7YLg7A==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.0.13.tgz",
+      "integrity": "sha512-lRTkxjTpMGXhLLM5GjZ0MtjPczMuhAo9j7PeSsaU6Imkm7W7RbrXfT8aP934kS7cBBV+HKN5U19Z0WWaORfb8Q==",
       "cpu": [
         "x64"
       ],
@@ -3249,9 +3354,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.0.12.tgz",
-      "integrity": "sha512-7WzWiax+LguJcMEimY0Q4sBLlFXu1tYxVka3+G2M9KmU/3m84J3jAIV4KZWnockbHsbb2XgrEjtlJKVwHQCoRA==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.0.13.tgz",
+      "integrity": "sha512-p/YLyKhs+xFibVeAPlpMGDVMKgjChgzs12VnDFaaqRSJoOz+uJgRSKiir2tn50e7Nm4YYw35q/DRBwpDBNo1MQ==",
       "cpu": [
         "x64"
       ],
@@ -3266,9 +3371,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.0.12.tgz",
-      "integrity": "sha512-X9LRC7jjE1QlfIaBbXjY0PGeQP87lz5mEfLSVs2J1yRc9PSg1tEPS9NBqY4BU9v5toZgJgzKeaNltORyTs22TQ==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.0.13.tgz",
+      "integrity": "sha512-Ua/5ydE/QOTX8jHuc7M9ICWnaLi6K2MV/r+Ws2OppsOjy8tdlPbqYainJJ6Kl7ofm524K+4Fk9CQITPzeIESPw==",
       "cpu": [
         "arm"
       ],
@@ -3283,9 +3388,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.0.12.tgz",
-      "integrity": "sha512-i24IFNq2402zfDdoWKypXz0ZNS2G4NKaA82tgBlE2OhHIE+4mg2JDb5wVfyP6R+MCm5grgXvurcIcKWvo44QiQ==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.0.13.tgz",
+      "integrity": "sha512-/W1+Q6tBAVgZWh/bhfOHo4n7Ryh6E7zYj4bJd9SRbkPyLtRioyK3bi6RLuDj57sa7Amk/DeomSV9iycS0xqIPA==",
       "cpu": [
         "arm64"
       ],
@@ -3300,9 +3405,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.0.12.tgz",
-      "integrity": "sha512-LmOdshJBfAGIBG0DdBWhI0n5LTMurnGGJCHcsm9F//ISfsHtCnnYIKgYQui5oOz1SUCkqsMGfkAzWyNKZqbGNw==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.0.13.tgz",
+      "integrity": "sha512-GQj6TWevNxwsYw20FdT2r2d1f7uiRsF07iFvNYxPIvIyPEV74eZ0zgFEsAH1daK1OxPy+LXdZ4grV17P5tVzhQ==",
       "cpu": [
         "arm64"
       ],
@@ -3317,9 +3422,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.0.12.tgz",
-      "integrity": "sha512-OSK667qZRH30ep8RiHbZDQfqkXjnzKxdn0oRwWzgCO8CoTxV+MvIkd0BWdQbYtYuM1wrakARV/Hwp0eA/qzdbw==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.0.13.tgz",
+      "integrity": "sha512-sQRH09faifF9w9WS6TKDWr1oLi4hoPx0EIWXZHQK/jcjarDpXGQ2DbF0KnALJCwWBxOIP/1nrmU01fZwwMzY3g==",
       "cpu": [
         "x64"
       ],
@@ -3334,9 +3439,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.0.12.tgz",
-      "integrity": "sha512-uylhWq6OWQ8krV8Jk+v0H/3AZKJW6xYMgNMyNnUbbYXWi7hIVdxRKNUB5UvrlC3RxtgsK5EAV2i1CWTRsNcAnA==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.0.13.tgz",
+      "integrity": "sha512-Or1N8DIF3tP+LsloJp+UXLTIMMHMUcWXFhJLCsM4T7MzFzxkeReewRWXfk5mk137cdqVeUEH/R50xAhY1mOkTQ==",
       "cpu": [
         "x64"
       ],
@@ -3351,9 +3456,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.0.12.tgz",
-      "integrity": "sha512-XDLnhMoXZEEOir1LK43/gHHwK84V1GlV8+pAncUAIN2wloeD+nNciI9WRIY/BeFTqES22DhTIGoilSO39xDb2g==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.0.13.tgz",
+      "integrity": "sha512-u2mQyqCFrr9vVTP6sfDRfGE6bhOX3/7rInehzxNhHX1HYRIx09H3sDdXzTxnZWKOjIg3qjFTCrYFUZckva5PIg==",
       "cpu": [
         "arm64"
       ],
@@ -3368,9 +3473,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.0.12.tgz",
-      "integrity": "sha512-I/BbjCLpKDQucvtn6rFuYLst1nfFwSMYyPzkx/095RE+tuzk5+fwXuzQh7T3fIBTcbn82qH/sFka7yPGA50tLw==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.0.13.tgz",
+      "integrity": "sha512-sOEc4iCanp1Yqyeu9suQcEzfaUcHnqjBUgDg0ZXpjUMUwdSi37S1lu1RGoV1BYInvvGu3y3HHTmvsSfDhx2L8w==",
       "cpu": [
         "x64"
       ],
@@ -3385,18 +3490,18 @@
       }
     },
     "node_modules/@tailwindcss/postcss": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.0.12.tgz",
-      "integrity": "sha512-r59Sdr8djCW4dL3kvc4aWU8PHdUAVM3O3te2nbYzXsWwKLlHPCuUoZAc9FafXb/YyNDZOMI7sTbKTKFmwOrMjw==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.0.13.tgz",
+      "integrity": "sha512-zTmnPGDYb2HKClTBTBwB+lLQH+Rq4etnQXFXs2lisRyXryUnoJIBByFTljkaK9F1d7o14h6t4NJIlfbZuOHR+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
-        "@tailwindcss/node": "4.0.12",
-        "@tailwindcss/oxide": "4.0.12",
-        "lightningcss": "^1.29.1",
+        "@tailwindcss/node": "4.0.13",
+        "@tailwindcss/oxide": "4.0.13",
+        "lightningcss": "1.29.2",
         "postcss": "^8.4.41",
-        "tailwindcss": "4.0.12"
+        "tailwindcss": "4.0.13"
       }
     },
     "node_modules/@techstark/opencv-js": {
@@ -7146,9 +7251,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.12.tgz",
-      "integrity": "sha512-bT0hJo91FtncsAMSsMzUkoo/iEU0Xs5xgFgVC9XmdM9bw5MhZuQFjPNl6wxAE0SiQF/YTZJa+PndGWYSDtuxAg==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.13.tgz",
+      "integrity": "sha512-gbvFrB0fOsTv/OugXWi2PtflJ4S6/ctu6Mmn3bCftmLY/6xRsQVEJPgIIpABwpZ52DpONkCA3bEj5b54MHxF2Q==",
       "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "@tailwindcss/postcss": "^4.0.12",
+    "@tailwindcss/postcss": "^4.0.13",
     "@types/chroma-js": "^3.1.1",
     "@types/node": "^22.13.10",
     "@types/openseadragon": "^3.0.10",
@@ -19,7 +19,7 @@
     "@types/wicg-file-system-access": "^2023.10.5",
     "@vitejs/plugin-react": "^4.3.4",
     "postcss": "^8.5.3",
-    "tailwindcss": "^4.0.12",
+    "tailwindcss": "^4.0.13",
     "typescript": "^5.8.2",
     "vite": "^6.2.1",
     "vite-plugin-babel-macros": "^1.0.6",
@@ -31,6 +31,8 @@
     "@annotorious/plugin-tools": "^1.0.2",
     "@annotorious/react": "3.1.5",
     "@annotorious/react-manifold": "3.1.5",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "@neodrag/react": "2.3.0",
     "@radix-ui/react-accordion": "^1.2.3",
     "@radix-ui/react-alert-dialog": "^1.1.6",

--- a/src/pages/annotate/Annotate.tsx
+++ b/src/pages/annotate/Annotate.tsx
@@ -70,7 +70,7 @@ export const Annotate = () => {
       <AnnotoriousManifold>
         <OSDViewerManifold>
           <RelationEditorRoot>
-            <SmartSelectionRoot>
+            {/* <SmartSelectionRoot> */}
               <SavingState.Root>
                 <main className="absolute top-0 left-0 h-full right-[340px] flex flex-col">
                   <HeaderSection
@@ -96,17 +96,17 @@ export const Annotate = () => {
                     </div>
                   )}
 
-                  {isSmartPanelOpen && (
+                  {/* isSmartPanelOpen && (
                     <SmartSelectionPanel 
                       mode={mode} 
                       onChangeMode={setMode} 
                       onClosePanel={onCloseSmartPanel} />
-                  )}
+                  ) */}
                 </main>
 
                 <SidebarSection />
               </SavingState.Root>
-            </SmartSelectionRoot>
+            {/* </SmartSelectionRoot> */}
           </RelationEditorRoot>
         </OSDViewerManifold>
       </AnnotoriousManifold>

--- a/src/pages/annotate/SidebarSection/AnnotationList/AnnotationList.tsx
+++ b/src/pages/annotate/SidebarSection/AnnotationList/AnnotationList.tsx
@@ -1,17 +1,18 @@
 import { useCallback, useMemo, useState } from 'react';
-import { ImageAnnotation, AnnotoriousOpenSeadragonAnnotator } from '@annotorious/react';
+import { ImageAnnotation, AnnotoriousOpenSeadragonAnnotator, W3CImageAnnotation } from '@annotorious/react';
 import { AnnotationListItem } from './AnnotationListItem';
-import { useAnnotations, useAnnotoriousManifold } from '@annotorious/react-manifold';
+import { useAnnotoriousManifold } from '@annotorious/react-manifold';
 import { useStore } from '@/store';
 import { SelectFilter } from './SelectFilter';
-import { DEFAULT_SORTING, SelectSortOrder } from './SelectSortOrder';
+import { SortableAnnotationList } from './sortable';
+import { DEFAULT_SORTING, SelectListOrder } from './SelectListOrder';
+import { useSortableAnnotations } from './useSortableAnnotations';
 import {
   Accordion,
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
 } from '@/ui/Accordion';
-import { SortableAnnotationList } from './SortableAnnotationList';
 
 interface AnnotationListProps {
 
@@ -25,18 +26,18 @@ export const AnnotationList = (props: AnnotationListProps) => {
 
   const store = useStore();
 
-  const annotations = useAnnotations<ImageAnnotation>();
+  const { annotations, updateOrder } = useSortableAnnotations();
 
-  const flattened = useMemo(() => Array.from(annotations.values())
-    .reduce<ImageAnnotation[]>((all, annotations) => ([...all, ...annotations]), []), [annotations]);
-
-  const [sorting, setSorting] = useState<((a: ImageAnnotation, b: ImageAnnotation) => number) | undefined>(
+  const [sorting, setSorting] = useState<((a: W3CImageAnnotation, b: W3CImageAnnotation) => number) | undefined>(
     () => DEFAULT_SORTING
   );
 
-  const [filter, setFilter] = useState<((a: ImageAnnotation) => boolean) | undefined>();
+  const flattened = useMemo(() => Array.from(annotations.values())
+    .reduce<W3CImageAnnotation[]>((all, annotations) => ([...all, ...annotations]), []), [annotations]);
 
-  const onEdit = (annotation: ImageAnnotation) => () => {
+  const [filter, setFilter] = useState<((a: W3CImageAnnotation) => boolean) | undefined>();
+
+  const onEdit = (annotation: W3CImageAnnotation) => () => {
     manifold.setSelected(annotation.id);
 
     const annotator = manifold.findAnnotator(annotation.id);
@@ -45,14 +46,14 @@ export const AnnotationList = (props: AnnotationListProps) => {
     props.onEdit();
   }
 
-  const onDelete = (annotation: ImageAnnotation) => () =>
+  const onDelete = (annotation: W3CImageAnnotation) => () =>
     manifold.deleteAnnotation(annotation.id);
 
   const imageIds = Array.from(annotations.keys());
 
   const entityTypes = useMemo(() => { 
     const sources = new Set(flattened.reduce<string[]>((all, annotation) => {
-      const sources = annotation.bodies
+      const sources = (Array.isArray(annotation.body) ? annotation.body : [annotation.body])
         .filter(b => b.purpose === 'classifying' && 'source' in b)
         .map(b => (b as any).source);
 
@@ -80,7 +81,7 @@ export const AnnotationList = (props: AnnotationListProps) => {
   const listAnnotations = useCallback((imageId: string) => {
     const filtered = filter 
       ? annotations.get(imageId).filter(filter)
-      : annotations.get(imageId).filter(a => a.target.selector);
+      : annotations.get(imageId).filter(a => 'selector'  in a.target);
 
     return sorting ? filtered.slice().sort(sorting) : filtered;
   }, [filter, sorting, annotations]);
@@ -88,8 +89,8 @@ export const AnnotationList = (props: AnnotationListProps) => {
   return (
     <div className="py-3 px-2 bg-slate-100/50 grow h-full">
       <div className="text-xs text-muted-foreground flex justify-between mb-1 px-1.5">
-        <SelectSortOrder 
-          onSelect={sorting => setSorting(() => sorting)} />
+        <SelectListOrder 
+          onChangeOrdering={sorting => setSorting(() => sorting)} />
 
         <SelectFilter 
           entityTypes={entityTypes}
@@ -101,20 +102,20 @@ export const AnnotationList = (props: AnnotationListProps) => {
         {imageIds.length === 1 ? (
           <div className="py-2 grow">
             <ul className="space-y-2">
-              {/*
-              {listAnnotations(imageIds[0]).map(annotation => (
+              {sorting ? (listAnnotations(imageIds[0]).map(annotation => (
                 <li key={annotation.id}>
                   <AnnotationListItem 
                     annotation={annotation} 
                     onEdit={onEdit(annotation)}
                     onDelete={onDelete(annotation)} />
                 </li>
-              ))}
-              */}
-              <SortableAnnotationList 
-                annotations={listAnnotations(imageIds[0])} 
-                onEdit={onEdit} 
-                onDelete={onDelete} />
+              ))) : (
+                <SortableAnnotationList 
+                  annotations={listAnnotations(imageIds[0])} 
+                  onEdit={onEdit} 
+                  onDelete={onDelete} 
+                  onUpdateOrder={a => updateOrder(imageIds[0], a)} />
+              )}
             </ul> 
           </div>
         ) : (
@@ -131,15 +132,21 @@ export const AnnotationList = (props: AnnotationListProps) => {
 
                 <AccordionContent>
                   <ul className="space-y-2">
-                    {listAnnotations(sourceId).map(annotation => (
+                    {sorting ? (listAnnotations(sourceId).map(annotation => (
                       <li key={annotation.id}>
                         <AnnotationListItem 
                           annotation={annotation} 
                           onEdit={onEdit(annotation)}
                           onDelete={onDelete(annotation)} />
                       </li>
-                    ))}
-                  </ul>
+                    ))) : (
+                      <SortableAnnotationList 
+                        annotations={listAnnotations(sourceId)} 
+                        onEdit={onEdit} 
+                        onDelete={onDelete} 
+                        onUpdateOrder={a => updateOrder(sourceId, a)} />
+                    )}
+                  </ul> 
                 </AccordionContent>
               </AccordionItem>
             ))}

--- a/src/pages/annotate/SidebarSection/AnnotationList/AnnotationList.tsx
+++ b/src/pages/annotate/SidebarSection/AnnotationList/AnnotationList.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
-import { ImageAnnotation, AnnotoriousOpenSeadragonAnnotator, W3CImageAnnotation } from '@annotorious/react';
+import { Move } from 'lucide-react';
+import { AnnotoriousOpenSeadragonAnnotator, W3CImageAnnotation } from '@annotorious/react';
 import { AnnotationListItem } from './AnnotationListItem';
 import { useAnnotoriousManifold } from '@annotorious/react-manifold';
 import { useStore } from '@/store';
@@ -97,6 +98,14 @@ export const AnnotationList = (props: AnnotationListProps) => {
           relationshipNames={relationshipNames}
           onSelect={filter => setFilter(() => filter)} />
       </div>
+
+      {!sorting && (
+        <div className="px-1.5 py-3 border border-dashed border-slate-300/50 rounded mt-2.5 mb-1 text-muted-foreground/80 text-xs flex justify-center">
+          <span className="flex gap-1.5">
+            <Move className="size-3.5 mt-[1px]" /> Drag cards to change order
+          </span>
+        </div>
+      )}
 
       <div>
         {imageIds.length === 1 ? (

--- a/src/pages/annotate/SidebarSection/AnnotationList/AnnotationList.tsx
+++ b/src/pages/annotate/SidebarSection/AnnotationList/AnnotationList.tsx
@@ -11,6 +11,7 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from '@/ui/Accordion';
+import { SortableAnnotationList } from './SortableAnnotationList';
 
 interface AnnotationListProps {
 
@@ -100,6 +101,7 @@ export const AnnotationList = (props: AnnotationListProps) => {
         {imageIds.length === 1 ? (
           <div className="py-2 grow">
             <ul className="space-y-2">
+              {/*
               {listAnnotations(imageIds[0]).map(annotation => (
                 <li key={annotation.id}>
                   <AnnotationListItem 
@@ -108,7 +110,12 @@ export const AnnotationList = (props: AnnotationListProps) => {
                     onDelete={onDelete(annotation)} />
                 </li>
               ))}
-            </ul>
+              */}
+              <SortableAnnotationList 
+                annotations={listAnnotations(imageIds[0])} 
+                onEdit={onEdit} 
+                onDelete={onDelete} />
+            </ul> 
           </div>
         ) : (
           <Accordion className="py-2 grow" type="multiple">

--- a/src/pages/annotate/SidebarSection/AnnotationList/AnnotationListItem.tsx
+++ b/src/pages/annotate/SidebarSection/AnnotationList/AnnotationListItem.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react';
 import { Pencil, Trash2 } from 'lucide-react';
 import Moment from 'react-moment';
 import { useInView } from 'react-intersection-observer';
-import { AnnotoriousOpenSeadragonAnnotator, ImageAnnotation, W3CAnnotationBody } from '@annotorious/react';
+import { AnnotoriousOpenSeadragonAnnotator, W3CImageAnnotation, W3CAnnotationBody, W3CImageAnnotationTarget } from '@annotorious/react';
 import { useAnnotoriousManifold } from '@annotorious/react-manifold';
 import { AnnotationValuePreview } from '@/components/AnnotationValuePreview';
 import { ConfirmedDelete } from '@/components/ConfirmedDelete';
@@ -13,7 +13,7 @@ import { AnnotationListItemRelation } from './AnnotationListItemRelation';
 
 interface AnnotationListItemProps {
 
-  annotation: ImageAnnotation;
+  annotation: W3CImageAnnotation;
 
   onEdit(): void;
 
@@ -33,18 +33,20 @@ export const AnnotationListItem = (props: AnnotationListItemProps) => {
 
   const [confirmDelete, setConfirmDelete] = useState(false);
 
+  const bodies = (Array.isArray(props.annotation.body) ? props.annotation.body : [props.annotation.body])
+
   const entityTags: W3CAnnotationBody[] = 
-    props.annotation.bodies.filter(b => b.purpose === 'classifying') as unknown as W3CAnnotationBody[];
+    bodies.filter(b => b.purpose === 'classifying') as unknown as W3CAnnotationBody[];
 
   const relations = useMemo(() => store.getRelatedAnnotations(props.annotation.id), [props.annotation]);
 
-  const note = props.annotation.bodies.find(b => b.purpose === 'commenting');
+  const note = bodies.find(b => b.purpose === 'commenting');
 
   const isEmpty = !note && entityTags.length === 0;
 
   const timestamps = [
-    props.annotation.target.created,
-    ...props.annotation.bodies.map(b => b.created)
+    props.annotation.created,
+    ...bodies.map(b => b.created)
   ].filter(Boolean).map(d => new Date(d));
 
   const lastEdit = timestamps.length > 0 ? timestamps[timestamps.length - 1] : undefined;

--- a/src/pages/annotate/SidebarSection/AnnotationList/AnnotationListItemRelation.tsx
+++ b/src/pages/annotate/SidebarSection/AnnotationList/AnnotationListItemRelation.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { ImageAnnotation } from '@annotorious/react';
+import { W3CImageAnnotation } from '@annotorious/react';
 import { AnnotationThumbnail } from '@/components/AnnotationThumbnail';
 import { EntityBadge } from '@/components/EntityBadge';
 import { EntityType } from '@/model';
@@ -8,7 +8,7 @@ import { getEntityTypes } from '@/utils/annotation';
 
 interface AnnotationListItemRelationProps {
 
-  leftSideAnnotation: ImageAnnotation;
+  leftSideAnnotation: W3CImageAnnotation;
 
   sourceId: string;
 

--- a/src/pages/annotate/SidebarSection/AnnotationList/SelectFilter.tsx
+++ b/src/pages/annotate/SidebarSection/AnnotationList/SelectFilter.tsx
@@ -1,4 +1,4 @@
-import { ImageAnnotation } from '@annotorious/react';
+import { ImageAnnotation, W3CImageAnnotation } from '@annotorious/react';
 import { EntityType } from '@/model';
 import { useStore } from '@/store';
 import { 
@@ -17,7 +17,7 @@ interface SelectFilterOpts {
 
   relationshipNames: string[];
 
-  onSelect(filter: ((a: ImageAnnotation) => boolean) | undefined): void;
+  onSelect(filter: ((a: W3CImageAnnotation) => boolean) | undefined): void;
 
 }
 
@@ -26,27 +26,27 @@ export const SelectFilter = (props: SelectFilterOpts) => {
   const store = useStore();
 
   const onValueChange = (value: string) => {
-    let filter: ((a: ImageAnnotation) => boolean) = undefined;
+    let filter: ((a: W3CImageAnnotation) => boolean) = undefined;
 
     if (value === 'all_entity') {
       // Filter all annotations with any 'classifying' body
-      filter = (a: ImageAnnotation) =>
+      filter = (a: W3CImageAnnotation) =>
         a.bodies.some(b => b.purpose === 'classifying');
     } else if (value === 'all_relationship') {
       // Filter all annotations with related annotations
-      filter = (a: ImageAnnotation) => 
+      filter = (a: W3CImageAnnotation) => 
         store.getRelatedAnnotations(a.id).length > 0;
     } else if (value.startsWith('entity-')) { 
       // Filter annotations with the given 'classifying' source
       const id = value.substring('entity-'.length);
 
-      filter = (a: ImageAnnotation) =>
+      filter = (a: W3CImageAnnotation) =>
         a.bodies.some(b => b.purpose === 'classifying' && 'source' in b && b.source === id);
     } else if (value.startsWith('rel-')) {
       // Filter annotations with any relation of the given name
       const name = value.substring('rel-'.length);
 
-      filter = (a: ImageAnnotation) =>
+      filter = (a: W3CImageAnnotation) =>
         store.getRelatedAnnotations(a.id).some(([_, meta]) => meta?.body?.value === name);
     }
 

--- a/src/pages/annotate/SidebarSection/AnnotationList/SelectFilter.tsx
+++ b/src/pages/annotate/SidebarSection/AnnotationList/SelectFilter.tsx
@@ -1,4 +1,4 @@
-import { ImageAnnotation, W3CImageAnnotation } from '@annotorious/react';
+import { W3CImageAnnotation } from '@annotorious/react';
 import { EntityType } from '@/model';
 import { useStore } from '@/store';
 import { 
@@ -28,10 +28,12 @@ export const SelectFilter = (props: SelectFilterOpts) => {
   const onValueChange = (value: string) => {
     let filter: ((a: W3CImageAnnotation) => boolean) = undefined;
 
+    const bodies = (a: W3CImageAnnotation) => Array.isArray(a.body) ? a.body : [a.body];
+
     if (value === 'all_entity') {
       // Filter all annotations with any 'classifying' body
       filter = (a: W3CImageAnnotation) =>
-        a.bodies.some(b => b.purpose === 'classifying');
+        bodies(a).some(b => b.purpose === 'classifying');
     } else if (value === 'all_relationship') {
       // Filter all annotations with related annotations
       filter = (a: W3CImageAnnotation) => 
@@ -41,7 +43,7 @@ export const SelectFilter = (props: SelectFilterOpts) => {
       const id = value.substring('entity-'.length);
 
       filter = (a: W3CImageAnnotation) =>
-        a.bodies.some(b => b.purpose === 'classifying' && 'source' in b && b.source === id);
+        bodies(a).some(b => b.purpose === 'classifying' && 'source' in b && b.source === id);
     } else if (value.startsWith('rel-')) {
       // Filter annotations with any relation of the given name
       const name = value.substring('rel-'.length);

--- a/src/pages/annotate/SidebarSection/AnnotationList/SelectListOrder.tsx
+++ b/src/pages/annotate/SidebarSection/AnnotationList/SelectListOrder.tsx
@@ -37,7 +37,8 @@ export const SelectListOrder = (props: SelectListOrderProps) => {
   // Define inside SelectSortOrder, for datamodel closure
   const SORT_BY_FIRST_ENTITY = (a: W3CImageAnnotation, b: W3CImageAnnotation) => {
     const getFirstEntity = (anno: W3CImageAnnotation) => {
-      const tag = anno.bodies.find(b => b.purpose === 'classifying' && 'source' in b);
+      const bodies = Array.isArray(anno.body) ? anno.body : [anno.body];
+      const tag = bodies.find(b => b.purpose === 'classifying' && 'source' in b);
       if (tag) {
         return datamodel.getEntityType((tag as any).source);
       }

--- a/src/pages/annotate/SidebarSection/AnnotationList/SelectListOrder.tsx
+++ b/src/pages/annotate/SidebarSection/AnnotationList/SelectListOrder.tsx
@@ -1,4 +1,4 @@
-import { ImageAnnotation } from '@annotorious/react';
+import { W3CImageAnnotation } from '@annotorious/react';
 import { useDataModel } from '@/store';
 import { 
   Select, 
@@ -8,35 +8,35 @@ import {
   SelectValue 
 } from '@/ui/Select';
 
-interface SelectSortOrderProps {
+interface SelectListOrderProps {
 
-  onSelect(sort: ((a: ImageAnnotation, b: ImageAnnotation) => number)): void;
+  onChangeOrdering(sort?: ((a: W3CImageAnnotation, b: W3CImageAnnotation) => number)): void;
 
 }
 
-const SORT_BY_CREATED_ASCENDING = (a: ImageAnnotation, b: ImageAnnotation) => {
-  if (!a.target.created && !b.target.created) return 0;
-  if (!a.target.created) return 1;
-  if (!b.target.created) return -1;
-  return a.target.created.getTime() - b.target.created.getTime();
+const SORT_BY_CREATED_ASCENDING = (a: W3CImageAnnotation, b: W3CImageAnnotation) => {
+  if (!a.created && !b.created) return 0;
+  if (!a.created) return 1;
+  if (!b.created) return -1;
+  return new Date(a.created).getTime() - new Date(b.created).getTime();
 }
 
-const SORT_BY_CREATED_DESCENDING = (a: ImageAnnotation, b: ImageAnnotation) => {
-  if (!a.target.created && !b.target.created) return 0;
-  if (!a.target.created) return -1;
-  if (!b.target.created) return 1;
-  return b.target.created.getTime() - a.target.created.getTime();
+const SORT_BY_CREATED_DESCENDING = (a: W3CImageAnnotation, b: W3CImageAnnotation) => {
+  if (!a.created && !b.created) return 0;
+  if (!a.created) return -1;
+  if (!b.created) return 1;
+  return new Date(b.created).getTime() - new Date(a.created).getTime();
 }
 
 export const DEFAULT_SORTING = SORT_BY_CREATED_DESCENDING;
 
-export const SelectSortOrder = (props: SelectSortOrderProps) => {
+export const SelectListOrder = (props: SelectListOrderProps) => {
 
   const datamodel = useDataModel();
 
   // Define inside SelectSortOrder, for datamodel closure
-  const SORT_BY_FIRST_ENTITY = (a: ImageAnnotation, b: ImageAnnotation) => {
-    const getFirstEntity = (anno: ImageAnnotation) => {
+  const SORT_BY_FIRST_ENTITY = (a: W3CImageAnnotation, b: W3CImageAnnotation) => {
+    const getFirstEntity = (anno: W3CImageAnnotation) => {
       const tag = anno.bodies.find(b => b.purpose === 'classifying' && 'source' in b);
       if (tag) {
         return datamodel.getEntityType((tag as any).source);
@@ -55,11 +55,13 @@ export const SelectSortOrder = (props: SelectSortOrderProps) => {
   
   const onValueChange = (value: string) => {
     if (value === 'recent')
-      props.onSelect(SORT_BY_CREATED_DESCENDING);
+      props.onChangeOrdering(SORT_BY_CREATED_DESCENDING);
     else if (value === 'oldest')
-      props.onSelect(SORT_BY_CREATED_ASCENDING);
+      props.onChangeOrdering(SORT_BY_CREATED_ASCENDING);
     else if (value === 'entity')
-      props.onSelect(SORT_BY_FIRST_ENTITY);
+      props.onChangeOrdering(SORT_BY_FIRST_ENTITY);
+    else if (value === 'custom')
+      props.onChangeOrdering(undefined);
   }
 
   return (
@@ -74,6 +76,7 @@ export const SelectSortOrder = (props: SelectSortOrderProps) => {
           <SelectItem value="recent">most recent</SelectItem>
           <SelectItem value="oldest">oldest</SelectItem>
           <SelectItem value="entity">entity</SelectItem>
+          <SelectItem value="custom">custom order</SelectItem>
         </SelectContent>
       </Select>
     </div>

--- a/src/pages/annotate/SidebarSection/AnnotationList/SelectListOrder.tsx
+++ b/src/pages/annotate/SidebarSection/AnnotationList/SelectListOrder.tsx
@@ -1,5 +1,7 @@
+import { useEffect } from 'react';
 import { W3CImageAnnotation } from '@annotorious/react';
 import { useDataModel } from '@/store';
+import { usePersistentState } from '@/utils/usePersistentState';
 import { 
   Select, 
   SelectContent, 
@@ -34,6 +36,19 @@ export const SelectListOrder = (props: SelectListOrderProps) => {
 
   const datamodel = useDataModel();
 
+  const [value, setValue] = usePersistentState('immarkus:annotate:list:sort', 'recent');
+
+  useEffect(() => {
+    if (value === 'recent')
+      props.onChangeOrdering(SORT_BY_CREATED_DESCENDING);
+    else if (value === 'oldest')
+      props.onChangeOrdering(SORT_BY_CREATED_ASCENDING);
+    else if (value === 'entity')
+      props.onChangeOrdering(SORT_BY_FIRST_ENTITY);
+    else if (value === 'custom')
+      props.onChangeOrdering(undefined);
+  }, [value]);
+
   // Define inside SelectSortOrder, for datamodel closure
   const SORT_BY_FIRST_ENTITY = (a: W3CImageAnnotation, b: W3CImageAnnotation) => {
     const getFirstEntity = (anno: W3CImageAnnotation) => {
@@ -54,20 +69,9 @@ export const SelectListOrder = (props: SelectListOrderProps) => {
     return (firstEntityA.label || firstEntityA.id).localeCompare(firstEntityB.label || firstEntityB.id);
   }
   
-  const onValueChange = (value: string) => {
-    if (value === 'recent')
-      props.onChangeOrdering(SORT_BY_CREATED_DESCENDING);
-    else if (value === 'oldest')
-      props.onChangeOrdering(SORT_BY_CREATED_ASCENDING);
-    else if (value === 'entity')
-      props.onChangeOrdering(SORT_BY_FIRST_ENTITY);
-    else if (value === 'custom')
-      props.onChangeOrdering(undefined);
-  }
-
   return (
     <div className="flex text-xs">
-      Sort by <Select defaultValue="recent" onValueChange={onValueChange}>
+      Sort by <Select value={value} onValueChange={setValue}>
         <SelectTrigger 
           className="p-0 shadow-none font-medium border-none text-xs hover:underline bg-transparent h-auto ml-1.5">
           <SelectValue />

--- a/src/pages/annotate/SidebarSection/AnnotationList/SortableAnnotationList.tsx
+++ b/src/pages/annotate/SidebarSection/AnnotationList/SortableAnnotationList.tsx
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useState } from 'react';
+import { ImageAnnotation } from '@annotorious/react';
+import { SortableAnnotationListItem } from './SortableAnnotationListItem';
+import {
+  DndContext, 
+  DragOverlay,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+  DragStartEvent,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy
+} from '@dnd-kit/sortable';
+
+interface SortableAnnotationListProps {
+
+  annotations: ImageAnnotation[];
+
+  onEdit(annotation: ImageAnnotation): void;
+
+  onDelete(annotation: ImageAnnotation): void
+
+}
+
+export const SortableAnnotationList = (props: SortableAnnotationListProps) => {
+
+  const [activeId, setActiveId] = useState(null);
+
+  const [items, setItems] = useState<string[]>([]);
+
+  useEffect(() => {
+    setItems(props.annotations.map(a => a.id));
+  }, [props.annotations]);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  const handleDragStart = (event: DragStartEvent) => {
+    setActiveId(event.active.id);
+  }
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+    
+    if (active.id !== over.id) {
+      setItems((items) => {
+        const oldIndex = items.indexOf(active.id.valueOf() as string);
+        const newIndex = items.indexOf(over.id.valueOf() as string);
+        
+        return arrayMove(items, oldIndex, newIndex);
+      });
+    }
+
+    setActiveId(null);
+  }
+
+  const renderSortableItem = (id: string, not: boolean) => {
+    const annotation = props.annotations.find(a => a.id === id);
+
+    return (
+      <SortableAnnotationListItem
+        key={id}
+        isActive={not && id === activeId}
+        annotation={annotation}
+        onEdit={() => props.onEdit(annotation)}
+        onDelete={() => props.onDelete(annotation)} />
+    )
+  }
+
+  return (
+    <DndContext 
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}>
+      <SortableContext 
+        items={items}
+        strategy={verticalListSortingStrategy}>
+        {items.map(i => renderSortableItem(i, true))}
+      </SortableContext>
+
+      <DragOverlay>
+        {activeId ? renderSortableItem(activeId, false) : null}
+      </DragOverlay>
+    </DndContext>
+  )
+
+}

--- a/src/pages/annotate/SidebarSection/AnnotationList/SortableAnnotationListItem.tsx
+++ b/src/pages/annotate/SidebarSection/AnnotationList/SortableAnnotationListItem.tsx
@@ -1,0 +1,45 @@
+import { ReactNode } from 'react';
+import {useSortable} from '@dnd-kit/sortable';
+import {CSS} from '@dnd-kit/utilities';
+import { ImageAnnotation } from '@annotorious/react';
+import { AnnotationListItemRelation } from './AnnotationListItemRelation';
+import { AnnotationListItem } from './AnnotationListItem';
+
+interface SortableAnnotationListItemProps {
+
+  isActive: boolean;
+
+  annotation: ImageAnnotation;
+
+  onEdit(): void;
+
+  onDelete(): void;
+
+}
+
+export const SortableAnnotationListItem = (props: SortableAnnotationListItemProps) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+  } = useSortable({ 
+    id: props.annotation.id
+  });
+  
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: props.isActive ? 0.3 : undefined
+  };
+  
+  return (
+    <li ref={setNodeRef} style={style} {...attributes} {...listeners}>
+      <AnnotationListItem 
+        annotation={props.annotation} 
+        onEdit={props.onEdit} 
+        onDelete={props.onDelete} />
+    </li>
+  );
+}

--- a/src/pages/annotate/SidebarSection/AnnotationList/sortable/SortableAnnotationList.tsx
+++ b/src/pages/annotate/SidebarSection/AnnotationList/sortable/SortableAnnotationList.tsx
@@ -40,7 +40,10 @@ export const SortableAnnotationList = (props: SortableAnnotationListProps) => {
   ), [props.annotations.map(a => a.id).join(':')]);
 
   const sensors = useSensors(
-    useSensor(PointerSensor),
+    useSensor(PointerSensor, {
+      // This keeps the cards clickable
+      activationConstraint: { distance: 0 }
+    }),
     useSensor(KeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,
     })

--- a/src/pages/annotate/SidebarSection/AnnotationList/sortable/SortableAnnotationList.tsx
+++ b/src/pages/annotate/SidebarSection/AnnotationList/sortable/SortableAnnotationList.tsx
@@ -64,13 +64,13 @@ export const SortableAnnotationList = (props: SortableAnnotationListProps) => {
     setActiveId(undefined);
   }
 
-  const renderSortableItem = (id: string, not: boolean) => {
+  const renderSortableItem = (id: string, ghost?: boolean) => {
     const annotation = props.annotations.find(a => a.id === id);
 
     return (
       <SortableAnnotationListItem
         key={id}
-        isActive={not && id === activeId}
+        ghost={ghost}
         annotation={annotation}
         onEdit={() => props.onEdit(annotation)}
         onDelete={() => props.onDelete(annotation)} />
@@ -86,11 +86,11 @@ export const SortableAnnotationList = (props: SortableAnnotationListProps) => {
       <SortableContext 
         items={items}
         strategy={verticalListSortingStrategy}>
-        {items.map(i => renderSortableItem(i, true))}
+        {items.map(i => renderSortableItem(i, activeId === i))}
       </SortableContext>
 
       <DragOverlay>
-        {activeId ? renderSortableItem(activeId, false) : null}
+        {activeId ? renderSortableItem(activeId) : null}
       </DragOverlay>
     </DndContext>
   )

--- a/src/pages/annotate/SidebarSection/AnnotationList/sortable/SortableAnnotationListItem.tsx
+++ b/src/pages/annotate/SidebarSection/AnnotationList/sortable/SortableAnnotationListItem.tsx
@@ -5,7 +5,7 @@ import { AnnotationListItem } from '../AnnotationListItem';
 
 interface SortableAnnotationListItemProps {
 
-  isActive: boolean;
+  ghost?: boolean;
 
   annotation: W3CImageAnnotation;
 
@@ -30,7 +30,7 @@ export const SortableAnnotationListItem = (props: SortableAnnotationListItemProp
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-    opacity: props.isActive ? 0.3 : undefined
+    opacity: props.ghost ? 0.3 : undefined
   };
   
   return (

--- a/src/pages/annotate/SidebarSection/AnnotationList/sortable/SortableAnnotationListItem.tsx
+++ b/src/pages/annotate/SidebarSection/AnnotationList/sortable/SortableAnnotationListItem.tsx
@@ -1,15 +1,13 @@
-import { ReactNode } from 'react';
 import {useSortable} from '@dnd-kit/sortable';
 import {CSS} from '@dnd-kit/utilities';
-import { ImageAnnotation } from '@annotorious/react';
-import { AnnotationListItemRelation } from './AnnotationListItemRelation';
-import { AnnotationListItem } from './AnnotationListItem';
+import { W3CImageAnnotation } from '@annotorious/react';
+import { AnnotationListItem } from '../AnnotationListItem';
 
 interface SortableAnnotationListItemProps {
 
   isActive: boolean;
 
-  annotation: ImageAnnotation;
+  annotation: W3CImageAnnotation;
 
   onEdit(): void;
 
@@ -18,6 +16,7 @@ interface SortableAnnotationListItemProps {
 }
 
 export const SortableAnnotationListItem = (props: SortableAnnotationListItemProps) => {
+  
   const {
     attributes,
     listeners,
@@ -35,11 +34,16 @@ export const SortableAnnotationListItem = (props: SortableAnnotationListItemProp
   };
   
   return (
-    <li ref={setNodeRef} style={style} {...attributes} {...listeners}>
+    <li 
+      ref={setNodeRef} 
+      style={style} 
+      {...attributes} 
+      {...listeners}>
       <AnnotationListItem 
         annotation={props.annotation} 
         onEdit={props.onEdit} 
         onDelete={props.onDelete} />
     </li>
-  );
+  )
+
 }

--- a/src/pages/annotate/SidebarSection/AnnotationList/sortable/index.ts
+++ b/src/pages/annotate/SidebarSection/AnnotationList/sortable/index.ts
@@ -1,0 +1,2 @@
+export * from './SortableAnnotationList';
+export * from './SortableAnnotationListItem';

--- a/src/pages/annotate/SidebarSection/AnnotationList/useSortableAnnotations.ts
+++ b/src/pages/annotate/SidebarSection/AnnotationList/useSortableAnnotations.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useState } from 'react';
+import { W3CImageAnnotation } from '@annotorious/react';
+import { useAnnotoriousManifold } from '@annotorious/react-manifold';
+import { useStore } from '@/store';
+
+export const useSortableAnnotations = () => {
+
+  const { sources } = useAnnotoriousManifold();
+
+  const store = useStore();
+
+  const [annotations, setAnnotations] = useState<Map<string, W3CImageAnnotation[]>>(new Map());
+
+  useEffect(() => {    
+    const p = sources.reduce<Promise<[string, W3CImageAnnotation[]][]>>((p, sourceId) => 
+      p.then(agg =>
+        store.getAnnotations(sourceId, { type: 'image' }).then(annotations => ([
+          ...agg, 
+          [sourceId, annotations as W3CImageAnnotation[]]
+        ]))
+      )
+    , Promise.resolve([]));
+
+    p.then(arr => setAnnotations(new Map(arr)));
+    
+  }, [sources.join(':'), store]);
+
+  const updateOrder = useCallback((sourceId: string, ids: string[]) => {
+    const before = [...annotations.get(sourceId)];
+
+    // Optimistic update
+    const after = ids.map(id => before.find(a => a.id === id));
+    setAnnotations(current => new Map(current).set(sourceId, after));
+
+    store.bulkUpsertAnnotation(sourceId, after).catch(error => {
+      console.error(error);
+      setAnnotations(current => new Map(current).set(sourceId, before));
+    });
+  }, [annotations]);
+
+  return { annotations, updateOrder };
+
+}

--- a/src/pages/annotate/WorkspaceSection/AnnotatableImage.tsx
+++ b/src/pages/annotate/WorkspaceSection/AnnotatableImage.tsx
@@ -130,7 +130,7 @@ export const AnnotatableImage = (props: AnnotatableImageProps) => {
         <AnnotoriousPlugin
           plugin={SelectorPack} />
 
-        <SmartSelection />
+        {/* <SmartSelection /> */}
 
         {ENABLE_CONNECTOR_PLUGIN ? (
           <OSDConnectorPlugin 

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -569,13 +569,12 @@ export const loadStore = (
 
     // All current annotations for the given source (image or entire manifest)
     const currentAnnotations = await _getAnnotations(normalizedId);
-    console.log('current', currentAnnotations);
 
     // Keep annotations that are not updated
     const updatedIds = new Set(annotations.map(a => a.id));
     const unchanged = currentAnnotations.filter(a => !updatedIds.has(a.id));
 
-    const next = [...unchanged, ...annotations];
+    const next = [...annotations, ...unchanged];
 
     // Update cache
     cachedAnnotations.set(_normalizeSourceId(sourceId), next);

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -562,21 +562,28 @@ export const loadStore = (
   }));
 
   const bulkUpsertAnnotation = async (
-    imageId: string, 
+    sourceId: string, 
     annotations: W3CAnnotation[]
   ): Promise<void> => {
-    // Upsert each annotation in sequence
-    const next = await annotations.reduce<Promise<W3CAnnotation[]>>((promise, annotation) => {
-      return promise.then(() => _upsertOneAnnotation(imageId, annotation)).then(next => {
-        return next;
-      })
-    }, Promise.resolve([]));
+    const normalizedId = _normalizeSourceId(sourceId);
 
-    const img = images.find(i => i.id === imageId);
-    if (img) {
-      const fileHandle = await getAnnotationsFile(img);
-      await writeJSONFile(fileHandle, next);
-    }
+    // All current annotations for the given source (image or entire manifest)
+    const currentAnnotations = await _getAnnotations(normalizedId);
+    console.log('current', currentAnnotations);
+
+    // Keep annotations that are not updated
+    const updatedIds = new Set(annotations.map(a => a.id));
+    const unchanged = currentAnnotations.filter(a => !updatedIds.has(a.id));
+
+    const next = [...unchanged, ...annotations];
+
+    // Update cache
+    cachedAnnotations.set(_normalizeSourceId(sourceId), next);
+
+    // Write to file
+    const source = _findSource(normalizedId);
+    const fileHandle = await getAnnotationsFile(source);
+    return writeJSONFile(fileHandle, next);
   }
 
   const upsertFolderMetadata = (idOrHandle: string | FileSystemDirectoryHandle, annotation: W3CAnnotation): Promise<void> => {

--- a/src/utils/usePersistentState.ts
+++ b/src/utils/usePersistentState.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+
+export const usePersistentState = <T>(key: string, defaultValue?: T) => {
+
+  const [value, setValue] = useState<T>(defaultValue);
+
+  useEffect(() => {
+    const saved = localStorage.getItem(key);
+    
+    if (saved) {
+      try {
+        setValue(JSON.parse(saved) as T);
+      } catch (error) {
+        console.error('Error parsing stored state', error);
+      }
+    }
+  }, [key]);
+
+  useEffect(() => {
+    if (value === undefined)
+      localStorage.removeItem(key);
+    else
+      localStorage.setItem(key, JSON.stringify(value));
+  }, [value]);
+
+  return [value, setValue] as const;
+
+}


### PR DESCRIPTION
## In this PR

This PR introduces drag-and-drop re-ordering of the annotation list (see #169).
- A new "mode" named __custom order__ is available in the dropdown.
- After picking that mode, annotation cards can be re-ordered using drag and drop.
- The order is reflected in the web annotation data structure JSON files–changing the order in the list will also sort the annotations in the JSON file accordingly, making it the "natural" (unsorted) order of the dataset.
- For convenience the current sort mode is persisted in local storage. This way, the user won't have to manually switch to their preferred ordering each time when opening the list, but will get the same order they last used.

<img src="https://github.com/user-attachments/assets/ea84057e-e550-469d-9a71-344e960438f2" width="360">
