### PR TITLE
IIIF Metadata Search (Beta)

### DIFF
--- a/src/pages/knowledgegraph/GraphSearch/GraphSearch.tsx
+++ b/src/pages/knowledgegraph/GraphSearch/GraphSearch.tsx
@@ -13,6 +13,7 @@ import {
   GraphNode, 
   GraphNodeType, 
   KnowledgeGraphSettings,
+  NestedConditionSentence,
   Operator, 
   Sentence
 } from '../Types';
@@ -103,9 +104,11 @@ export const GraphSearch = (props: GraphSearchProps) => {
     if ('Attribute' in sentence && sentence.Attribute) {
       // SimpleConditionSentence
       return Boolean(sentence.Comparator);
+    } else if ('data' in sentence) {
+      return Boolean(sentence.data);
     } else {
       // NestedConditionSentence
-      return Boolean(sentence.Value);
+      return Boolean((sentence as NestedConditionSentence).Value);
     }
   }
   

--- a/src/pages/knowledgegraph/GraphSearch/GraphSearchConditionBuilder.tsx
+++ b/src/pages/knowledgegraph/GraphSearch/GraphSearchConditionBuilder.tsx
@@ -73,7 +73,7 @@ export const GraphSearchConditionBuilder = (props: GraphSearchConditionBuilderPr
       { label: 'with IIIF metadata', value: 'WITH_IIIF_METADATA' }
     ], [props.objectType, props.settings]);
 
-  const showAddSubCondition = sentence.Value && sentence.ConditionType === 'WITH_ENTITY';
+  const showAddSubCondition = sentence.ConditionType === 'WITH_ENTITY' && 'Value' in sentence;
 
   const onAddSubcondition = () => {
     const s = sentence as NestedConditionSentence;
@@ -163,7 +163,7 @@ export const GraphSearchConditionBuilder = (props: GraphSearchConditionBuilderPr
         ) : sentence.ConditionType === 'WITH_NOTE' ? (
           <Combobox
             className={selectStyle}
-            value={sentence.Value}
+            value={(sentence as SimpleConditionSentence).Value}
             options={valueOptions} 
             onChange={value => updateSentence({
               Attribute: undefined,
@@ -171,10 +171,7 @@ export const GraphSearchConditionBuilder = (props: GraphSearchConditionBuilderPr
             })} />
         ) : sentence.ConditionType === 'WITH_IIIF_METADATA' && (
           <IIIFFolderMetadataSearch 
-            onChange={value => updateSentence({
-              Attribute: undefined,
-              Value:  value
-            })} />
+            onChange={data => updateSentence({ data })} />
         )}
 
         {'Attribute' in sentence && sentence.Attribute && 
@@ -190,7 +187,7 @@ export const GraphSearchConditionBuilder = (props: GraphSearchConditionBuilderPr
           (sentence.ConditionType === 'WITH_ENTITY') || (sentence.ConditionType === 'WITH_RELATIONSHIP')) && (
             <Combobox 
               className={selectStyle}
-              value={sentence.Value}
+              value={(sentence as SimpleConditionSentence).Value}
               options={valueOptions} 
               onChange={value => updateSentence({ Value: value })} />
           )

--- a/src/pages/knowledgegraph/GraphSearch/GraphSearchConditionBuilder.tsx
+++ b/src/pages/knowledgegraph/GraphSearch/GraphSearchConditionBuilder.tsx
@@ -2,9 +2,9 @@ import { useEffect, useMemo } from 'react';
 import { CirclePlus, Trash2 } from 'lucide-react';
 import { W3CAnnotation } from '@annotorious/react';
 import { Combobox } from '@/components/Combobox';
-import { Image } from '@/model';
 import { GraphSearchSubConditionBuilder } from './GraphSearchSubConditionBuilder';
 import { useGraphSearch } from './useGraphSearch';
+import { IIIFFolderMetadataSearch } from './iiif';
 import { 
   Comparator, 
   ConditionType, 
@@ -69,7 +69,8 @@ export const GraphSearchConditionBuilder = (props: GraphSearchConditionBuilderPr
       { label: 'with relationship', value: 'WITH_RELATIONSHIP' }
     ] : [
       // props.object type === 'FOLDER'
-      { label: 'where', value: 'WHERE' }
+      { label: 'where', value: 'WHERE' },
+      { label: 'with IIIF metadata', value: 'WITH_IIIF_METADATA' }
     ], [props.objectType, props.settings]);
 
   const showAddSubCondition = sentence.Value && sentence.ConditionType === 'WITH_ENTITY';
@@ -150,7 +151,7 @@ export const GraphSearchConditionBuilder = (props: GraphSearchConditionBuilderPr
           </SelectContent>
         </Select>
 
-        {sentence.ConditionType === 'WHERE' && (
+        {sentence.ConditionType === 'WHERE' ? (
           <Combobox
             className={selectStyle}
             value={(sentence as SimpleConditionSentence).Attribute}
@@ -159,9 +160,7 @@ export const GraphSearchConditionBuilder = (props: GraphSearchConditionBuilderPr
               Attribute: value,
               Value: undefined 
             })} />
-        )}
-
-        {sentence.ConditionType === 'WITH_NOTE' && (
+        ) : sentence.ConditionType === 'WITH_NOTE' ? (
           <Combobox
             className={selectStyle}
             value={sentence.Value}
@@ -169,6 +168,12 @@ export const GraphSearchConditionBuilder = (props: GraphSearchConditionBuilderPr
             onChange={value => updateSentence({
               Attribute: undefined,
               Value: value
+            })} />
+        ) : sentence.ConditionType === 'WITH_IIIF_METADATA' && (
+          <IIIFFolderMetadataSearch 
+            onChange={value => updateSentence({
+              Attribute: undefined,
+              Value:  value
             })} />
         )}
 

--- a/src/pages/knowledgegraph/GraphSearch/GraphSearchConditionBuilder.tsx
+++ b/src/pages/knowledgegraph/GraphSearch/GraphSearchConditionBuilder.tsx
@@ -4,10 +4,11 @@ import { W3CAnnotation } from '@annotorious/react';
 import { Combobox } from '@/components/Combobox';
 import { GraphSearchSubConditionBuilder } from './GraphSearchSubConditionBuilder';
 import { useGraphSearch } from './useGraphSearch';
-import { IIIFFolderMetadataSearch } from './iiif';
+import { IIIFFolderMetadataSearch, IIIFMetadataIndexRecord } from './iiif';
 import { 
   Comparator, 
   ConditionType, 
+  CustomSentence, 
   DropdownOption,
   Graph,
   GraphNodeType,
@@ -171,6 +172,7 @@ export const GraphSearchConditionBuilder = (props: GraphSearchConditionBuilderPr
             })} />
         ) : sentence.ConditionType === 'WITH_IIIF_METADATA' && (
           <IIIFFolderMetadataSearch 
+            value={(sentence as CustomSentence).data as IIIFMetadataIndexRecord}
             onChange={data => updateSentence({ data })} />
         )}
 

--- a/src/pages/knowledgegraph/GraphSearch/iiif/IIIFFolderMetadataSearch.tsx
+++ b/src/pages/knowledgegraph/GraphSearch/iiif/IIIFFolderMetadataSearch.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from 'react';
+import { ChevronDown, Search } from 'lucide-react';
+import { CozyMetadata } from 'cozy-iiif';
+import { Command, CommandEmpty, CommandItem, CommandList } from '@/ui/Command';
+import { Spinner } from '@/components/Spinner';
+import { Button } from '@/ui/Button';
+import { Popover,PopoverContent, PopoverTrigger } from '@/ui/Popover';
+import { DropdownOption } from '../../Types';
+import { useManifestMetadataSearch } from './useManifestMetadataSearch';
+
+interface IIIFFolderMetadataSearchProps {
+  
+  onChange(value: DropdownOption): void;
+
+}
+
+export const IIIFFolderMetadataSearch = (props: IIIFFolderMetadataSearchProps) => {
+
+  const { loading, search } = useManifestMetadataSearch();
+
+  const [open, setOpen] = useState(false);
+
+  const [query, setQuery] = useState('');
+
+  const [options, setOptions] = useState<CozyMetadata[]>([]);
+
+  useEffect(() => setOptions(search(query)), [query]);
+
+  const onSelect = (option: CozyMetadata) => {
+    console.log('selected', option);
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          disabled={loading}
+          variant="outline"
+          role="combobox"
+          aria-expanded={options.length > 0}
+          className="rounded-none min-w-32 max-w-40 text-xs font-normal overflow-hidden relative px-2 py-1 h-auto bg-white shadow-none border-l-0 whitespace-nowrap text-ellipsis">
+          {loading ? (
+            <div className="grow flex justify-center">
+              <Spinner className="w-3 h-3 text-muted-foreground" />
+            </div>
+          ) : (
+            <div className="grow" />
+          )}
+          <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+
+      <PopoverContent 
+        align="start"
+        className="min-w-[80px] max-w-[60vw] w-auto p-0 overflow-hidden">
+        <Command>
+          <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
+            <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+            <input 
+              className="flex h-auto w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+              placeholder="Search..." 
+              value={query}
+              onChange={evt => setQuery(evt.target.value)} />
+          </div>
+
+          <CommandList className="p-1">
+            <CommandEmpty 
+              className="text-xs font-normal flex justify-center py-2 text-muted-foreground">
+              No matches
+            </CommandEmpty>
+
+            {options.map(option => (
+              <CommandItem 
+                key={`${option.label}:${option.value}`}
+                className="block text-xs overflow-hidden whitespace-nowrap text-ellipsis"
+                value={JSON.stringify(option)}
+                // Warning: cmdk trims the values, possibly breaking them!
+                onSelect={() => onSelect(option)}>
+                <strong>{option.label}</strong>:{option.value}
+              </CommandItem>
+            ))}          
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+
+}

--- a/src/pages/knowledgegraph/GraphSearch/iiif/IIIFFolderMetadataSearch.tsx
+++ b/src/pages/knowledgegraph/GraphSearch/iiif/IIIFFolderMetadataSearch.tsx
@@ -7,6 +7,8 @@ import { Popover,PopoverContent, PopoverTrigger } from '@/ui/Popover';
 import { IIIFMetadataIndexRecord, useManifestMetadataSearch } from './useManifestMetadataSearch';
 
 interface IIIFFolderMetadataSearchProps {
+
+  value?: IIIFMetadataIndexRecord;
   
   onChange(data: IIIFMetadataIndexRecord): void;
 
@@ -37,10 +39,14 @@ export const IIIFFolderMetadataSearch = (props: IIIFFolderMetadataSearchProps) =
           variant="outline"
           role="combobox"
           aria-expanded={options.length > 0}
-          className="rounded-none min-w-32 max-w-40 text-xs font-normal overflow-hidden relative px-2 py-1 h-auto bg-white shadow-none border-l-0 whitespace-nowrap text-ellipsis">
+          className="rounded-none min-w-32 justify-start max-w-40 text-xs font-normal overflow-hidden relative px-2 py-1 h-auto bg-white shadow-none border-l-0 whitespace-nowrap text-ellipsis">
           {loading ? (
             <div className="grow flex justify-center">
               <Spinner className="w-3 h-3 text-muted-foreground" />
+            </div>
+          ) : props.value ? (
+            <div>
+              <strong>{props.value.data.label}:</strong> {props.value.data.value}
             </div>
           ) : (
             <div className="grow" />

--- a/src/pages/knowledgegraph/GraphSearch/iiif/IIIFFolderMetadataSearch.tsx
+++ b/src/pages/knowledgegraph/GraphSearch/iiif/IIIFFolderMetadataSearch.tsx
@@ -1,16 +1,14 @@
 import { useEffect, useState } from 'react';
 import { ChevronDown, Search } from 'lucide-react';
-import { CozyMetadata } from 'cozy-iiif';
 import { Command, CommandEmpty, CommandItem, CommandList } from '@/ui/Command';
 import { Spinner } from '@/components/Spinner';
 import { Button } from '@/ui/Button';
 import { Popover,PopoverContent, PopoverTrigger } from '@/ui/Popover';
-import { DropdownOption } from '../../Types';
-import { useManifestMetadataSearch } from './useManifestMetadataSearch';
+import { IIIFMetadataIndexRecord, useManifestMetadataSearch } from './useManifestMetadataSearch';
 
 interface IIIFFolderMetadataSearchProps {
   
-  onChange(value: DropdownOption): void;
+  onChange(data: IIIFMetadataIndexRecord): void;
 
 }
 
@@ -22,12 +20,13 @@ export const IIIFFolderMetadataSearch = (props: IIIFFolderMetadataSearchProps) =
 
   const [query, setQuery] = useState('');
 
-  const [options, setOptions] = useState<CozyMetadata[]>([]);
+  const [options, setOptions] = useState<IIIFMetadataIndexRecord[]>([]);
 
   useEffect(() => setOptions(search(query)), [query]);
 
-  const onSelect = (option: CozyMetadata) => {
-    console.log('selected', option);
+  const onSelect = (option: IIIFMetadataIndexRecord) => {
+    setOpen(false);
+    props.onChange(option);
   }
 
   return (
@@ -52,7 +51,7 @@ export const IIIFFolderMetadataSearch = (props: IIIFFolderMetadataSearchProps) =
 
       <PopoverContent 
         align="start"
-        className="min-w-[80px] max-w-[60vw] w-auto p-0 overflow-hidden">
+        className="min-w-[80px] max-w-72 w-auto p-0 overflow-hidden">
         <Command>
           <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
             <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
@@ -71,12 +70,12 @@ export const IIIFFolderMetadataSearch = (props: IIIFFolderMetadataSearchProps) =
 
             {options.map(option => (
               <CommandItem 
-                key={`${option.label}:${option.value}`}
+                key={option.stringified}
                 className="block text-xs overflow-hidden whitespace-nowrap text-ellipsis"
                 value={JSON.stringify(option)}
                 // Warning: cmdk trims the values, possibly breaking them!
                 onSelect={() => onSelect(option)}>
-                <strong>{option.label}</strong>:{option.value}
+                <strong>{option.data.label}</strong>: {option.data.value}
               </CommandItem>
             ))}          
           </CommandList>

--- a/src/pages/knowledgegraph/GraphSearch/iiif/index.ts
+++ b/src/pages/knowledgegraph/GraphSearch/iiif/index.ts
@@ -1,0 +1,1 @@
+export * from './IIIFFolderMetadataSearch'

--- a/src/pages/knowledgegraph/GraphSearch/iiif/index.ts
+++ b/src/pages/knowledgegraph/GraphSearch/iiif/index.ts
@@ -1,1 +1,2 @@
 export * from './IIIFFolderMetadataSearch'
+export * from './useManifestMetadataSearch';

--- a/src/pages/knowledgegraph/GraphSearch/iiif/useManifestMetadataSearch.ts
+++ b/src/pages/knowledgegraph/GraphSearch/iiif/useManifestMetadataSearch.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import Fuse from 'fuse.js';
+import { CozyManifest, CozyMetadata } from 'cozy-iiif';
+import { useStore } from '@/store';
+import { fetchManifests } from '@/utils/iiif';
+
+const buildIndex = (manifests: CozyManifest[]) => {
+  const metadata = manifests
+    .flatMap(m => m.getMetadata())
+    .reduce<CozyMetadata[]>((distinctFields, meta) => {
+      const exists = distinctFields.some(({ label, value })=>
+        label.toLowerCase() === meta.label.toLowerCase() && value.toLowerCase() === meta.value.toLowerCase());
+      return exists ? distinctFields : [...distinctFields, meta ];
+    }, []);
+
+  const fuse = new Fuse<CozyMetadata>(metadata, { 
+    keys: ['label', 'value'],
+    shouldSort: true,
+    threshold: 0.6,
+    includeScore: true,
+    useExtendedSearch: true
+  });
+
+  return fuse;  
+}
+
+export const useManifestMetadataSearch = () => {
+
+  const store = useStore();
+
+  const [loading, setLoading] = useState(true);
+
+  const [fuse, setFuse] = useState<Fuse<CozyMetadata> | undefined>();
+
+  useEffect(() => {
+    const uris = store.iiifResources.map(r => r.uri);
+
+    // Fetches all manifests, using cached versions if possbile,
+    // or throttled HTTP downloads if not.
+    fetchManifests(uris).then(manifests => {
+      setLoading(false);
+      setFuse(buildIndex(manifests));
+    });
+  }, [store]);
+
+  const search = (query: string, limit: number = 10) => {
+    if (!fuse) return [];
+    return fuse.search(query, { limit }).map(result => result.item);
+  }
+
+  return { 
+    loading,
+    search
+  }
+
+}

--- a/src/pages/knowledgegraph/GraphSearch/useGraphSearch.ts
+++ b/src/pages/knowledgegraph/GraphSearch/useGraphSearch.ts
@@ -150,7 +150,7 @@ export const useGraphSearch = (
     } else if (sentence.ConditionType === 'WITH_IIIF_METADATA') {
       const data = (sentence as CustomSentence).data as IIIFMetadataIndexRecord;
       if (data) {
-        const folderIds = data.manifests.map(m => m.id);
+        const folderIds = data.manifests.map(m => `iiif:${m.id}`);
         setMatches(folderIds);
       }
     }

--- a/src/pages/knowledgegraph/GraphSearch/useGraphSearch.ts
+++ b/src/pages/knowledgegraph/GraphSearch/useGraphSearch.ts
@@ -1,7 +1,9 @@
 import { useStore } from '@/store';
 import { useEffect, useState } from 'react';
 import { W3CAnnotation } from '@annotorious/react';
+import { IIIFMetadataIndexRecord } from './iiif';
 import { 
+  CustomSentence,
   DropdownOption, 
   Graph,
   GraphNodeType,
@@ -116,15 +118,19 @@ export const useGraphSearch = (
         setMatches(imageIds);
       }
     } else if (sentence.ConditionType === 'WITH_NOTE') {
-      if (!sentence.Value) {
+      const s = sentence as SimpleConditionSentence;
+
+      if (!s.Value) {
         const notes = listAllNotes(annotations);
         setValueOptions(notes.map(n => ({ label: n, value: n })));
       } else {
-        const imageIds = findImagesByNote(annotations, sentence.Value.value);
+        const imageIds = findImagesByNote(annotations, s.Value.value);
         setMatches(imageIds);
       }
     } else if (sentence.ConditionType === 'WITH_RELATIONSHIP') {
-      if (!sentence.Value) {
+      const s = sentence as SimpleConditionSentence;
+
+      if (!s.Value) {
         const relations = store.listAllRelations();
 
         const distinctRelationships = relations.reduce<string[]>((all, [_, meta]) => {
@@ -135,17 +141,17 @@ export const useGraphSearch = (
         setValueOptions(distinctRelationships);
       } else {
         if (objectType === 'IMAGE') {
-          findImagesByRelationship(store, sentence.Value.value).then(setMatches);
+          findImagesByRelationship(store, s.Value.value).then(setMatches);
         } else if (objectType === 'ENTITY_TYPE') {
-          const entityIds = findEntityTypesByRelationship(graph, sentence.Value.value);
+          const entityIds = findEntityTypesByRelationship(graph, s.Value.value);
           setMatches(entityIds);
         }
       }
     } else if (sentence.ConditionType === 'WITH_IIIF_METADATA') {
-      if (!sentence.Value) {
-        // 
-      } else {
-        // findFolderByIIIFMetadata(graph, setence.Value.value);
+      const data = (sentence as CustomSentence).data as IIIFMetadataIndexRecord;
+      if (data) {
+        const folderIds = data.manifests.map(m => m.id);
+        setMatches(folderIds);
       }
     }
   }, [annotations, graph, objectType, sentence]);

--- a/src/pages/knowledgegraph/GraphSearch/useGraphSearch.ts
+++ b/src/pages/knowledgegraph/GraphSearch/useGraphSearch.ts
@@ -141,6 +141,12 @@ export const useGraphSearch = (
           setMatches(entityIds);
         }
       }
+    } else if (sentence.ConditionType === 'WITH_IIIF_METADATA') {
+      if (!sentence.Value) {
+        // 
+      } else {
+        // findFolderByIIIFMetadata(graph, setence.Value.value);
+      }
     }
   }, [annotations, graph, objectType, sentence]);
 

--- a/src/pages/knowledgegraph/Types.ts
+++ b/src/pages/knowledgegraph/Types.ts
@@ -130,6 +130,12 @@ export interface SimpleConditionSentence extends BaseSentence {
 
 }
 
+export interface CustomSentence extends BaseSentence {
+
+  data: any;
+
+}
+
 export interface NestedConditionSentence extends BaseSentence {
 
   Value: DropdownOption;
@@ -138,7 +144,7 @@ export interface NestedConditionSentence extends BaseSentence {
 
 }
 
-export type Sentence = SimpleConditionSentence | NestedConditionSentence;
+export type Sentence = SimpleConditionSentence | NestedConditionSentence | CustomSentence;
 
 export type Comparator = 'IS' | 'IS_NOT_EMPTY';
 

--- a/src/pages/knowledgegraph/Types.ts
+++ b/src/pages/knowledgegraph/Types.ts
@@ -118,7 +118,7 @@ export interface BaseSentence {
 
 }
 
-export type ConditionType = 'WHERE' | 'WITH_ENTITY' | 'WITH_NOTE' | 'WITH_RELATIONSHIP';
+export type ConditionType = 'WHERE' | 'WITH_ENTITY' | 'WITH_NOTE' | 'WITH_RELATIONSHIP' | 'WITH_IIIF_METADATA';
 
 export interface SimpleConditionSentence extends BaseSentence {
 


### PR DESCRIPTION
## In this PR

This PR introduces a first beta version for searching the knowledge graph based on manifest metadata (#183).

- All manifests must be fetched via HTTP before the graph search can start. 
- Fetching is cached and throttled.
- After fetching is complete metadata (field names and values) are indexed into FuseJS for fuzzy & type-tolerant searching.