### PR TITLE
New Property Type: Number Range

### DIFF
--- a/src/components/EntityTypeEditor/Editor/Editor.tsx
+++ b/src/components/EntityTypeEditor/Editor/Editor.tsx
@@ -72,6 +72,7 @@ export const Editor = (props: EditorProps) => {
       d.type === 'geocoordinate' ||
       d.type === 'measurement' ||
       d.type === 'number' ||
+      d.type === 'range' ||
       d.type === 'text' ||
       d.type === 'uri');
 
@@ -82,7 +83,6 @@ export const Editor = (props: EditorProps) => {
 
   const onSave = () => {
     const valid = validate();
-
     if (valid) {
       if (props.entityType) { // Update existing
         model.updateEntityType(valid)

--- a/src/components/EntityTypeEditor/Editor/EntityPreview/EntityPreview.tsx
+++ b/src/components/EntityTypeEditor/Editor/EntityPreview/EntityPreview.tsx
@@ -12,6 +12,7 @@ import {
   MeasurementField, 
   NumberField, 
   PropertyValidation, 
+  RangeField, 
   TextField, 
   URIField 
 } from '@/components/PropertyFields';
@@ -114,6 +115,11 @@ export const EntityPreview = (props: EntityPreviewProps) => {
                   id={property.name}
                   className="bg-white" 
                   definition={property} />  
+              ) : property.type === 'range' ? (
+                <RangeField 
+                  id={property.name} 
+                  className="bg-white" 
+                  definition={property} />
               ) : property.type === 'text' ? (
                 <TextField 
                   id={property.name}

--- a/src/components/MetadataForm/MetadataForm.tsx
+++ b/src/components/MetadataForm/MetadataForm.tsx
@@ -10,6 +10,7 @@ import {
   GeoCoordinatesField, 
   MeasurementField, 
   NumberField, 
+  RangeField, 
   TextField, 
   URIField 
 } from '@/components/PropertyFields';
@@ -154,6 +155,12 @@ export const MetadataForm = (props: MetadataFormProps) => {
               <NumberField
                 id={definition.name}
                 definition={definition} 
+                value={getValue(definition)}
+                onChange={value => onChangeValue(definition, value)} />
+            ) : definition.type === 'range' ? (
+              <RangeField
+                id={definition.name}
+                definition={definition}
                 value={getValue(definition)}
                 onChange={value => onChangeValue(definition, value)} />
             ) : definition.type === 'text' ? (

--- a/src/components/MetadataSchemaEditor/MetadataSchemaPreview.tsx
+++ b/src/components/MetadataSchemaEditor/MetadataSchemaPreview.tsx
@@ -1,5 +1,5 @@
 import { MetadataSchema } from '@/model';
-import { EnumField, ExternalAuthorityField, GeoCoordinatesField, MeasurementField, NumberField, PropertyValidation, TextField, URIField } from '../PropertyFields';
+import { EnumField, ExternalAuthorityField, GeoCoordinatesField, MeasurementField, NumberField, PropertyValidation, RangeField, TextField, URIField } from '../PropertyFields';
 
 interface MetadataSchemaPreviewProps {
 
@@ -45,6 +45,11 @@ export const MetadataSchemaPreview = (props: MetadataSchemaPreviewProps) => {
                   definition={definition} />
               ) : definition.type === 'number' ? (
                 <NumberField
+                  id={definition.name}
+                  className="bg-white"
+                  definition={definition} />
+              ) : definition.type === 'range' ? (
+                <RangeField
                   id={definition.name}
                   className="bg-white"
                   definition={definition} />

--- a/src/components/MetadataTable/MetadataTable.tsx
+++ b/src/components/MetadataTable/MetadataTable.tsx
@@ -1,4 +1,4 @@
-import { CaseSensitive, Database, Hash, Link2, List, MapPin, Ruler } from 'lucide-react';
+import { CaseSensitive, ChevronsLeftRightEllipsis, Database, Hash, Link2, List, MapPin, Ruler } from 'lucide-react';
 import { PropertyListTooltip } from '@/components/PropertyListTooltip';
 import { MetadataSchema, PropertyDefinition } from '@/model';
 import { MetadataTableActions } from './MetadataTableActions';
@@ -60,19 +60,21 @@ export const MetadataTable = (props: MetadataTableProps) => {
                       className="align-middle inline-flex bg-muted-foreground/40 text-dark text-xs whitespace-nowrap
                         mx-0.5 mb-1 py-0.5 px-1.5 rounded-full items-center" style={{ fontSize: '0.65rem'}}>
                       {property.type === 'enum' ? (
-                        <List className="w-3 h-3 mr-0.5" />
+                        <List className="size-3 mr-0.5" />
                       ): property.type === 'external_authority' ? (
-                        <Database className="w-3 h-3 mr-1" />
+                        <Database className="size-3 mr-1" />
                       ) : property.type === 'geocoordinate' ? (
-                        <MapPin className="w-3 h-3 mr-0.5" />
+                        <MapPin className="size-3 mr-0.5" />
                       ) : property.type === 'measurement' ? (
-                        <Ruler className="w-3 h-3 mr-1" />
+                        <Ruler className="size-3 mr-1" />
                       ) : property.type === 'number' ? (
-                        <Hash className="w-3 h-3 mr-0.5" />
+                        <Hash className="size-3 mr-0.5" />
+                      ) : property.type === 'range' ? (
+                        <ChevronsLeftRightEllipsis className="size-3.5 mr-0.5" />
                       ) : property.type === 'text' ? (
-                        <CaseSensitive className="w-4 h-4 mr-0.5" />
+                        <CaseSensitive className="size-4 mr-0.5" />
                       ) : property.type === 'uri' ? (
-                        <Link2 className="w-3 h-3 mr-0.5" />
+                        <Link2 className="size-3 mr-0.5" />
                       ) : null}
                       {property.name}
                     </span>    

--- a/src/components/PropertyDefinitionEditor/PropertyDefinitionEditor.tsx
+++ b/src/components/PropertyDefinitionEditor/PropertyDefinitionEditor.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { CaseSensitive, Database, Hash, Link2, List, MapPin, Palette, Ruler, Spline } from 'lucide-react';
+import { CaseSensitive, ChevronsLeftRightEllipsis, Database, Hash, Link2, List, MapPin, Palette, Ruler, Spline } from 'lucide-react';
 import { DialogDescription } from '@radix-ui/react-dialog';
 import { PropertyDefinition } from '@/model';
 import { Button } from '@/ui/Button';
@@ -119,6 +119,9 @@ export const PropertyDefinitionEditor = (props: PropertyDefinitionEditorProps) =
                 </SelectItem>
                 <SelectItem value="enum">
                   <List className="inline w-4 h-4 mr-1.5 mb-0.5" /> Options
+                </SelectItem>
+                <SelectItem value="range">
+                  <ChevronsLeftRightEllipsis className="inline w-4 h-4 mr-1.5 mb-0.5" /> Number Range
                 </SelectItem>
                 <SelectItem value="uri">
                   <Link2 className="inline w-4 h-4 mr-1.5 mb-0.5" /> URI

--- a/src/components/PropertyDefinitionEditor/PropertyPreview.tsx
+++ b/src/components/PropertyDefinitionEditor/PropertyPreview.tsx
@@ -8,6 +8,7 @@ import {
   MeasurementField,
   NumberField, 
   PropertyValidation, 
+  RangeField, 
   TextField, 
   URIField 
 } from '@/components/PropertyFields';
@@ -72,6 +73,11 @@ export const PropertyPreview = (props: PropertyPreviewProps) => {
                 id={preview.name}
                 className="bg-white"
                 definition={preview} />   
+            ) : preview.type === 'range' ? (
+              <RangeField
+                id={preview.name}
+                className="bg-white"
+                definition={preview} />
             ) : preview.type === 'text' ? (
               <TextField 
                 id={preview.name}

--- a/src/components/PropertyFields/RangeField/RangeField.tsx
+++ b/src/components/PropertyFields/RangeField/RangeField.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from 'react';
+import { CopyPlus } from 'lucide-react';
+import { PropertyDefinition } from '@/model';
+import { Label } from '@/ui/Label';
+import { InfoTooltip } from '../InfoTooltip';
+import { useValidation } from '../PropertyValidation';
+import { RangeFieldInput } from './RangeFieldInput';
+import { InheritedFrom } from '../InheritedFrom';
+
+interface RangeFieldProps {
+
+  id: string;
+
+  className?: string;
+
+  definition: PropertyDefinition;
+
+  value?: [number, number];
+
+  onChange?(value?: [number | undefined, number | undefined] | [number | undefined, number | undefined ][]): void;
+
+}
+
+const stringify = (ranges?: [number, number] | [number, number][]): [string, string][] => {
+  if (!ranges) return [['', '']];
+
+  if (Array.isArray(ranges[0])) {
+    // [number, number][]
+    return (ranges as [number, number][])
+      .map(coord => coord.map((c: number) => c?.toString() || '')) as [string, string][];
+  } else {
+    // [number, number]
+    const str = (ranges as [number, number]).map(c => c?.toString() || '') as [string, string];
+    return [str];
+  }
+}
+
+
+export const RangeField = (props: RangeFieldProps) => {
+
+  const { definition } = props;
+
+  const [values, setValues] = useState<([string, string] | undefined)[]>(stringify(props.value));
+
+  const { showErrors, isValid } = useValidation(values => {
+    const nonEmpty = values.filter(v => v && (v[0] || v[1]));
+    
+    const isValidRange = (val: [string, string]) => {
+      if (!val) return true;
+
+      if (!val[0] && !val[1]) return true;
+        
+      const start = parseFloat(val[0]);
+      const end = parseFloat(val[1]);
+
+      return !isNaN(start) || !isNaN(end);
+    }
+
+    return nonEmpty.length === 0 || nonEmpty.every(isValidRange);
+  }, [values]);
+
+  useEffect(() => {
+    if (!props.onChange) return;
+
+    if (isValid) {
+      const validRanges = values
+        .filter(c => c && (c[0] || c[1]))
+        .map(([startStr, endStr]) => { 
+          // At least one must be a number - start or end
+          const start = parseFloat(startStr);
+          const end = parseFloat(endStr);
+
+          return [
+            isNaN(start) ? undefined : start,
+            isNaN(end) ? undefined : end
+          ]
+        });
+
+      if (validRanges.length > 1)
+        props.onChange(validRanges as [number | undefined, number | undefined][]);
+      else 
+        props.onChange(validRanges[0] as [number | undefined, number | undefined]);
+    } else {
+      console.log('not valid');
+      props.onChange();
+    }
+  }, [values, isValid]);
+
+  const error = showErrors && !isValid && 'must be valid range';
+
+  const onChange = (idx: number, updated: [string, string]) =>
+    setValues(current => current.map((v, i) => i === idx ? updated : v));
+
+  const onAppendField = () =>
+    setValues(current => [...current, undefined]);
+
+  return (
+    <div className="mb-8">
+      <div className="flex items-end justify-between pr-1 mb-1.5">
+        <div className="flex items-center gap-1">
+          <Label
+            className="ml-0.5">
+            {definition.name}
+          </Label>
+
+          {definition.description && (
+            <InfoTooltip description={definition.description} />
+          )}
+
+          {error && (<span className="text-xs text-red-600 ml-1">{error}</span>)}
+        </div>
+
+        <InheritedFrom definition={definition} />
+      </div>
+
+      <div className="flex flex-col gap-2 justify-end">
+        {values.map((value, idx) => (
+          <RangeFieldInput
+            key={`${idx}`}
+            className={props.className}
+            definition={definition} 
+            error={Boolean(error)}
+            index={idx}
+            value={value}
+            onChange={value => onChange(idx, value)}/>
+        ))}
+
+        {props.definition.multiple && (
+          <button 
+            className="self-end flex gap-1 items-center text-xs text-muted-foreground mt-0.5 mr-0.5"
+            type="button"
+            onClick={onAppendField}>
+            <CopyPlus className="h-3.5 w-3.5 mb-0.5 mr-0.5" /> Add value
+          </button>
+        )}
+      </div>
+    </div>
+  )
+
+}

--- a/src/components/PropertyFields/RangeField/RangeFieldInput.tsx
+++ b/src/components/PropertyFields/RangeField/RangeFieldInput.tsx
@@ -1,0 +1,50 @@
+import { Input } from '@/ui/Input';
+import { cn } from '@/ui/utils';
+import { PropertyDefinition } from '@/model';
+import { InheritedFrom } from '../InheritedFrom';
+
+interface RangeFieldInputProps {
+
+  className?: string;
+
+  definition?: PropertyDefinition;
+
+  error?: boolean;
+
+  index: number;
+
+  value?: [string, string];
+
+  onChange(arg?: [string, string]): void;
+
+}
+
+export const RangeFieldInput = (props: RangeFieldInputProps) => {
+
+  const [startStr, endStr] = props.value ? props.value : ['', ''];
+
+  const className = cn(props.className, (props.error ? 'mt-0.5 outline-red-500 border-red-500' : 'mt-0.5'));
+
+  return (
+    <div className="flex items-center gap-2.5">
+      <Input 
+        className={className} 
+        placeholder="Start..."
+        value={startStr} 
+        onChange={evt => props.onChange([evt.target.value, endStr])} />
+
+      –
+
+      <Input 
+        className={className} 
+        placeholder="End..."
+        value={endStr} 
+        onChange={evt => props.onChange([startStr, evt.target.value])} />
+
+      <InheritedFrom 
+        className="mr-1"
+        definition={props.definition} />
+    </div>
+  )
+
+}

--- a/src/components/PropertyFields/RangeField/index.ts
+++ b/src/components/PropertyFields/RangeField/index.ts
@@ -1,0 +1,1 @@
+export * from './RangeField';

--- a/src/components/PropertyFields/index.ts
+++ b/src/components/PropertyFields/index.ts
@@ -4,6 +4,7 @@ export * from './ExternalAuthorityField';
 export * from './GeoCoordinatesField';
 export * from './MeasurementField';
 export * from './NumberField';
+export * from './RangeField';
 export * from './TextField';
 export * from './URIField';
 export * from './PropertyValidation';

--- a/src/components/PropertyTypeIcon/PropertyTypeIcon.tsx
+++ b/src/components/PropertyTypeIcon/PropertyTypeIcon.tsx
@@ -1,5 +1,5 @@
 import { PropertyDefinition } from '@/model';
-import { CaseSensitive, Database, Hash, Link2, List, MapPin, Ruler, Spline } from 'lucide-react';
+import { CaseSensitive, ChevronsLeftRightEllipsis, Database, Hash, Link2, List, MapPin, Ruler, Spline } from 'lucide-react';
 import { cn } from '@/ui/utils';
 
 interface PropertyTypeIconProps {
@@ -32,6 +32,9 @@ export const PropertyTypeIcon = (props: PropertyTypeIconProps) => {
           className={cn('w-4.5 h-3.5 px-0.5', className)} />
       ) : type === 'number' ? (
         <Hash 
+          className={cn('w-4.5 h-3.5 px-0.5', className)} />
+      ) : type === 'range' ? (
+        <ChevronsLeftRightEllipsis
           className={cn('w-4.5 h-3.5 px-0.5', className)} />
       ) : type === 'text' ? (
         <CaseSensitive 

--- a/src/model/PropertyDefinition.ts
+++ b/src/model/PropertyDefinition.ts
@@ -18,6 +18,7 @@ export type PrimitivePropertyDefinition = BasePropertyDefinition & {
     | 'geocoordinate' 
     | 'measurement'
     | 'number'
+    | 'range'
     | 'uri'
 
 }

--- a/src/pages/annotate/SidebarSection/CurrentSelection/PropertiesFormSection/PropertiesFormSection.tsx
+++ b/src/pages/annotate/SidebarSection/CurrentSelection/PropertiesFormSection/PropertiesFormSection.tsx
@@ -8,6 +8,7 @@ import {
   GeoCoordinatesField, 
   MeasurementField, 
   NumberField, 
+  RangeField, 
   TextField, 
   URIField 
 } from '@/components/PropertyFields';
@@ -74,6 +75,12 @@ export const PropertiesFormSection = (props: PropertiesFormSectionProps) => {
             <NumberField
               id={key}
               definition={property} 
+              value={props.values[key]}
+              onChange={value => props.onChange(key, value)} />
+          ) : property.type === 'range' ? (
+            <RangeField
+              id={key}
+              definition={property}
               value={props.values[key]}
               onChange={value => props.onChange(key, value)} />
           ) : property.type === 'text' ? (

--- a/src/pages/datamodel/EntityTypes/EntityTypesTable/EntityTypesTable.tsx
+++ b/src/pages/datamodel/EntityTypes/EntityTypesTable/EntityTypesTable.tsx
@@ -103,7 +103,7 @@ export const EntityTypesTable = (props: EntityTypesTableProps) => {
           ) : property.type === 'number' ? (
             <Hash className="w-3 h-3 mr-0.5" />
           ) : property.type === 'range' ? (
-            <ChevronsLeftRightEllipsis className="w-3 h-3 mr-0.5" />
+            <ChevronsLeftRightEllipsis className="size-3.5 mr-0.5" />
           ) : property.type === 'text' ? (
             <CaseSensitive className="w-4 h-4 mr-0.5" />
           ) : property.type === 'uri' ? (

--- a/src/pages/datamodel/EntityTypes/EntityTypesTable/EntityTypesTable.tsx
+++ b/src/pages/datamodel/EntityTypes/EntityTypesTable/EntityTypesTable.tsx
@@ -9,6 +9,7 @@ import { EntityTypeActions } from './EntityTypeActions';
 import { 
   CaseSensitive, 
   ChevronRight, 
+  ChevronsLeftRightEllipsis, 
   CopyPlus, 
   Database, 
   Hash, 
@@ -101,6 +102,8 @@ export const EntityTypesTable = (props: EntityTypesTableProps) => {
             <Ruler className="w-3 h-3 mr-1" />
           ) : property.type === 'number' ? (
             <Hash className="w-3 h-3 mr-0.5" />
+          ) : property.type === 'range' ? (
+            <ChevronsLeftRightEllipsis className="w-3 h-3 mr-0.5" />
           ) : property.type === 'text' ? (
             <CaseSensitive className="w-4 h-4 mr-0.5" />
           ) : property.type === 'uri' ? (


### PR DESCRIPTION
Introduces a new schema property type: **number range**

- Numeric start and end value
- Both values are optional, so users can choose to describe open intervals
- Usable like any other property type, for Entity Classes and Image-/Folder-Metadata schemas