### PR TITLE
Annotation view: IIIF Manifest Metadata 

### DIFF
--- a/src/components/IIIFMetadataList/IIIFMetadataList.tsx
+++ b/src/components/IIIFMetadataList/IIIFMetadataList.tsx
@@ -4,6 +4,8 @@ interface IIIFMetadataListProps {
 
   metadata: CozyMetadata[];
 
+  emptyMessage?: string;
+
 }
 
 export const IIIFMetadataList = (props: IIIFMetadataListProps) => {
@@ -25,7 +27,7 @@ export const IIIFMetadataList = (props: IIIFMetadataListProps) => {
     </ul>
   ) : (
     <div className="flex items-center justify-center h-full min-h-16 text-muted-foreground text-sm">
-      No IIIF Metadata
+      {props.emptyMessage || 'No IIIF Metadata'}
     </div>
   )
 

--- a/src/pages/annotate/SidebarSection/ImageMetadata/ImageMetadataSection.tsx
+++ b/src/pages/annotate/SidebarSection/ImageMetadata/ImageMetadataSection.tsx
@@ -4,12 +4,12 @@ import { W3CAnnotationBody } from '@annotorious/react';
 import { CanvasInformation, Image } from '@/model';
 import { useImageMetadata } from '@/store';
 import { Button } from '@/ui/Button';
+import { IIIFIcon } from '@/components/IIIFIcon';
 import { IIIFMetadataList } from '@/components/IIIFMetadataList';
 import { ImageMetadataForm, hasChanges } from '@/components/MetadataForm';
 import { PropertyValidation } from '@/components/PropertyFields';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/ui/Tabs';
 import { useCanvas, useIIIFResource } from '@/utils/iiif/hooks';
-import { IIIFIcon } from '@/components/IIIFIcon';
 
 interface ImageMetadataSectionProps {
 

--- a/src/pages/images/MetadataDrawer/MetadataDrawer.tsx
+++ b/src/pages/images/MetadataDrawer/MetadataDrawer.tsx
@@ -17,7 +17,7 @@ interface MetadataDrawerProps {
 
 export const MetadataDrawer = (props: MetadataDrawerProps) => {
 
-  const previous = useRef<OverviewItem | undefined>();
+  const previous = useRef<OverviewItem | undefined>(null);
 
   const isInitial = useRef(true);
 


### PR DESCRIPTION
## In this PR

In the Annotation View, the metadata sidebar now includes another tab for the IIIF manifest metadata (in addition to the IIIF canvas metadata).