### PR TITLE
Importing IIIF Manifests Multiple Times

### DIFF
--- a/src/pages/images/IIIFImporter/IIIFImporter.tsx
+++ b/src/pages/images/IIIFImporter/IIIFImporter.tsx
@@ -53,8 +53,9 @@ export const IIIFImporter = (props: IIIFImporterProps) => {
       return;
     }
 
-    // IMMARKUS can't currently import a manifest twice!
-    generateShortId(uri).then(id => {
+    // IMMARKUS will only allow the same manifest once per folder!
+    const idSeed = props.folderId ? `${props.folderId}/${uri}` : uri;
+    generateShortId(idSeed).then(id => {
       // ID is derived from the URI–check if it already exists
       const existing = Boolean(store.getIIIFResource(id));
       if (existing) {
@@ -73,7 +74,7 @@ export const IIIFImporter = (props: IIIFImporterProps) => {
           });
       }
     });
-  }, [uri]);
+  }, [props.folderId, uri]);
 
   const onSubmit = (evt: React.FormEvent) => {
     evt.preventDefault();
@@ -81,7 +82,8 @@ export const IIIFImporter = (props: IIIFImporterProps) => {
     if (!parseResult || parseResult.type === 'error') return;
 
     if (parseResult.type === 'manifest') {
-      generateShortId(uri).then(id => {
+      const idSeed = props.folderId ? `${props.folderId}/${uri}` : uri;
+      generateShortId(idSeed).then(id => {
         const { resource } = parseResult;
 
         const info: IIIFResourceInformation = {

--- a/src/pages/images/IIIFImporter/ImportFromCollection.tsx
+++ b/src/pages/images/IIIFImporter/ImportFromCollection.tsx
@@ -90,8 +90,9 @@ export const ImportFromCollection = (props: ImportFromCollectionProps) => {
 
     setImporting(true);
 
-    const importOne = (manifest: CozyCollectionItem) =>
-      generateShortId(manifest.id).then(id => {
+    const importOne = (manifest: CozyCollectionItem) => {
+      const idSeed = props.folderId ? `${props.folderId}/${manifest.id}` : manifest.id;
+      return generateShortId(idSeed).then(id => {
         const exists = Boolean(store.getIIIFResource(id));
         if (exists) {
           return Promise.reject(new Error(`${manifest.getLabel()} already exists in your project. IMMARKUS is currently not able to import the same manifest into a project more than once.`));
@@ -99,6 +100,7 @@ export const ImportFromCollection = (props: ImportFromCollectionProps) => {
           return Cozy.parseURL(manifest.id).then(parsed => ({ id, parsed }));
         }
       });
+    }
 
     selected.reduce<Promise<ParseResult[]>>((promise, manifest) => promise.then(results => {
       return importOne(manifest).then(parsed => {

--- a/src/store/utils.ts
+++ b/src/store/utils.ts
@@ -70,7 +70,7 @@ export const writeJSONFile = (handle: FileSystemFileHandle, data: any) => {
     return performWrite();
 
   return Promise.resolve();
-};
+}
 
 export const generateShortId = (str: string) => {
   return crypto.subtle.digest('SHA-256', new TextEncoder().encode(str))
@@ -83,6 +83,50 @@ export const generateShortId = (str: string) => {
     
       return shortId;
     });
+}
+
+export const fileExistsInDirectory = async (
+  dirHandle: FileSystemDirectoryHandle,
+  filename: string
+): Promise<boolean> => {
+  try {
+    await dirHandle.getFileHandle(filename);
+    return true;
+  } catch (error) {
+    // File doesn't exist
+    return false;
+  }
+};
+
+/**
+ * Note that the FileSystem API does not seem to include a method
+ * to simply rename a file directly. Therefore, we have to write a
+ * new file, and delete the old one.
+ */
+export const renameFile = async (
+  dirHandle: FileSystemDirectoryHandle,
+  oldFilename: string,
+  newFilename: string
+): Promise<void> => {
+  try {
+    const oldFileHandle = await dirHandle.getFileHandle(oldFilename);
+
+    // Read old file
+    const oldFile = await oldFileHandle.getFile();
+    const content = await oldFile.arrayBuffer();
+    
+    const newFile = await dirHandle.getFileHandle(newFilename, { create: true });
+    const writable = await newFile.createWritable();
+    
+    await writable.write(content);
+    await writable.close();
+    
+    // Remove the original file
+    await dirHandle.removeEntry(oldFilename);
+  } catch (error) {
+    console.error('Error renaming file:', error);
+    throw error;
+  }
 }
 
 export const hasSelector = (annotation: W3CAnnotation) => {


### PR DESCRIPTION
## In this PR

This PR enables users to import the same IIIF manifest into the project multiple times, as long as each import goes into a different folder.

#### Background
Previously, each manifest imported into IMMARKUS was assigned a globally unique ID based solely on its URI. This meant that attempting to import the same manifest more than once—regardless of the folder—would cause an ID conflict.

#### What's Changed

With this PR, the unique ID assigned to each imported manifest is now derived from:

- The manifest's URI, and
- The folder in IMMARKUS where it's being imported

Therefore, it's now possible to import the same manifest into multiple folders without conflict. (Important: you still cannot import the same manifest more than once into the same folder.)