### PR TITLE
OCR Service Generator Info

### DIFF
--- a/src/pages/annotate/SidebarSection/CurrentSelection/Note/NoteForm.tsx
+++ b/src/pages/annotate/SidebarSection/CurrentSelection/Note/NoteForm.tsx
@@ -1,3 +1,5 @@
+import { ScanText } from 'lucide-react';
+import { User } from '@annotorious/react';
 import { Textarea } from '@/ui/Textarea';
 
 interface NoteProps {
@@ -5,6 +7,8 @@ interface NoteProps {
   autoFocus?: boolean;
 
   id: string;
+
+  creator?: User; 
 
   value: string;
 
@@ -14,9 +18,18 @@ interface NoteProps {
 
 export const Note = (props: NoteProps) => {
 
+  const { creator } = props;
+
+  const hasGenerator = creator?.name && 'type' in creator;
+
   return (
-    <div className="mt-4">
-      <Textarea 
+    <div className="mt-3">
+      {hasGenerator && (
+        <div className="text-[11px] flex gap-1 items-center justify-end mb-1.5 mr-0.5 text-muted-foreground/80">
+          {creator.name} <ScanText className="size-3.5 mb-[1px]" /> 
+        </div>
+      )}
+      <Textarea
         autoFocus={props.autoFocus}
         id={props.id}
         rows={4}

--- a/src/pages/annotate/SidebarSection/CurrentSelection/PropertiesForm/PropertiesForm.tsx
+++ b/src/pages/annotate/SidebarSection/CurrentSelection/PropertiesForm/PropertiesForm.tsx
@@ -252,6 +252,7 @@ export const PropertiesForm = (props: PropertiesFormProps) => {
             <Note
               autoFocus={schemaBodies.length === 0}
               id={noteKey}
+              creator={note?.creator}
               value={formState[noteKey]}
               onChange={value => onChangeFormValue(noteKey, value)} />
           )}

--- a/src/pages/annotate/SmartTools/Transcribe/Transcribe.tsx
+++ b/src/pages/annotate/SmartTools/Transcribe/Transcribe.tsx
@@ -4,6 +4,7 @@ import { useAnnotoriousManifold } from '@annotorious/react-manifold';
 import { LoadedImage } from '@/model';
 import { useStore } from '@/store';
 import { TranscriptionDialog } from './TranscriptionDialog';
+import { AnnotationBatch } from './Types';
 import {
   Select,
   SelectContent,
@@ -31,8 +32,21 @@ export const Transcribe = (props: TranscribeProps) => {
 
   const manifold = useAnnotoriousManifold();
 
-  const onImportAnnotations = (annotations: ImageAnnotation[], image: LoadedImage) => {
+  const onImportAnnotations = (batches: AnnotationBatch[], image: LoadedImage) => {
     if (!store) return; // Should never happen
+
+    const annotations = batches.reduce<ImageAnnotation[]>((all, batch) => 
+      ([...all, ...batch.annotations.map(a => ({
+        ...a,
+        bodies: a.bodies.map(b => ({
+          ...b,
+          creator: {
+            type: batch.generator.type || 'Software',
+            ...batch.generator
+          },
+          created: new Date()
+        })),
+      }))]), []);
 
     // Add image annotations (internal data model!) to the annotator as a 'Remote' action
     const anno = manifold.getAnnotator(image.id);

--- a/src/pages/annotate/SmartTools/Transcribe/Types.ts
+++ b/src/pages/annotate/SmartTools/Transcribe/Types.ts
@@ -1,3 +1,6 @@
+import { Generator } from "@/services";
+import { ImageAnnotation } from "@annotorious/react";
+
 export interface OCROptions {
 
   serviceId: string;
@@ -14,3 +17,11 @@ export type ProcessingState = 'cropping'
   | 'success_empty'
   | 'compressing_failed' 
   | 'ocr_failed';
+
+export interface AnnotationBatch {
+
+  annotations: ImageAnnotation[];
+
+  generator: Generator;
+  
+}

--- a/src/services/Types.ts
+++ b/src/services/Types.ts
@@ -92,9 +92,30 @@ export type ServiceConfigParameter =
 
 export interface ServiceConnector {
 
-  submit(image: File | string, options?: Record<string, any>): any;
+  submit(image: File | string, options?: Record<string, any>): Promise<ServiceConnectorResponse>;
 
   parseResponse: ServiceCrosswalk;
+
+}
+
+export interface ServiceConnectorResponse<T extends unknown = any> {
+
+  data: T; 
+
+  generator: Generator;
+
+}
+
+export interface Generator {
+
+  id: string;
+
+  /** Defaults to 'Software' **/
+  type?: string;
+
+  name: string;
+
+  homepage?: string; 
 
 }
 

--- a/src/services/connectors/anthropic-claude/submit.ts
+++ b/src/services/connectors/anthropic-claude/submit.ts
@@ -12,7 +12,13 @@ export const submit = (image: File | string, options?: Record<string, any>) => {
     apiKey,
     'https://api.anthropic.com/v1',
     'claude-opus-4-20250514',
-    { 'anthropic-dangerous-direct-browser-access': 'true' }
+    { 
+      id: 'claude-opus-4-20250514',
+      name: 'OpenAI Claude Opus 4 (claude-opus-4-20250514)',
+      homepage: 'https://www.anthropic.com/api'
+    }, { 
+      'anthropic-dangerous-direct-browser-access': 'true' 
+    }
   );
 
 }

--- a/src/services/connectors/azure-cv/submit.ts
+++ b/src/services/connectors/azure-cv/submit.ts
@@ -1,10 +1,14 @@
 import { ApiKeyCredentials } from '@azure/ms-rest-js';
 import { ComputerVisionClient } from '@azure/cognitiveservices-computervision';
 import type { GetReadResultResponse } from '@azure/cognitiveservices-computervision/esm/models';
+import { Generator, ServiceConnectorResponse } from '@/services/Types';
 
 const sleep = (duration: number) => new Promise(resolve => setTimeout(resolve, duration));
 
-export const submit = (image: File | string, options: Record<string, any> = {}) => {
+export const submit = (
+  image: File | string, 
+  options: Record<string, any> = {}
+): Promise<ServiceConnectorResponse> => {
   const endpoint = options['endpoint'];
   const key = options['key'];
 
@@ -33,7 +37,15 @@ export const submit = (image: File | string, options: Record<string, any> = {}) 
       } while (result.status === 'running' || result.status === 'notStarted');
 
       if (result.status === 'succeeded') {
-        resolve(result.analyzeResult);
+        const data = result.analyzeResult;
+        
+        const generator: Generator = {
+          id: 'ms-azure-computervision',
+          name: 'MS Azure Computervision',
+          homepage: 'https://azure.microsoft.com/en-us/products/ai-services/ai-vision'
+        };
+
+        resolve({ data, generator });
       } else {
         reject(result);
       }

--- a/src/services/connectors/google-gemini/submit.ts
+++ b/src/services/connectors/google-gemini/submit.ts
@@ -1,8 +1,18 @@
+import { ServiceConnectorResponse } from '@/services/Types';
 import { fileToBase64, urlToBase64 } from '@/services/utils';
 import { GoogleGenAI, Type } from '@google/genai';
 
-export const submit = (image: File | string, options?: Record<string, any>) => {
+export const submit = (
+  image: File | string, 
+  options?: Record<string, any>
+): Promise<ServiceConnectorResponse>  => {
   const apiKey = options['api-key'];
+
+  const generator = {
+    id: 'gemini-2.0-flash',
+    name: 'Google Gemini (gemini-2.0-flash)',
+    homepage: 'https://gemini.google.com/app'
+  };
 
   const ai = new GoogleGenAI({ apiKey });
 
@@ -23,7 +33,7 @@ export const submit = (image: File | string, options?: Record<string, any>) => {
           required: ['transcription']
         }
       }
-    });
+    }).then(data => ({ data, generator }));
 
     if (typeof image === 'string') {
       return urlToBase64(image).then(submit);

--- a/src/services/connectors/google-vision/submit.ts
+++ b/src/services/connectors/google-vision/submit.ts
@@ -1,9 +1,19 @@
+import { ServiceConnectorResponse } from '@/services/Types';
 import { fileToBase64, urlToBase64 } from '@/services/utils';
 
-export const submit = (image: File | string, options?: Record<string, any>) => {
+export const submit = (
+  image: File | string, 
+  options?: Record<string, any>
+): Promise<ServiceConnectorResponse> => {
   if (!options || !options['api-key']) throw new Error('Missing API key');
 
   const apiKey = options['api-key'];
+
+  const generator = {
+    id: 'google-vision',
+    name: 'Google Cloud Vision API',
+    homepage: 'https://cloud.google.com/vision'
+  };
 
   const submit = (base64?: string) => {
     const payload = {
@@ -37,7 +47,7 @@ export const submit = (image: File | string, options?: Record<string, any>) => {
           throw new Error(message);
         });
       }
-    });
+    }).then(data => ({ data, generator }));
   }
 
   if (typeof image === 'string') {

--- a/src/services/connectors/kluster-ai/submit.ts
+++ b/src/services/connectors/kluster-ai/submit.ts
@@ -1,13 +1,23 @@
+import { ServiceConnectorResponse } from '@/services/Types';
 import { fileToBase64 } from '@/services/utils';
 import { OpenAI } from 'openai';
 
-export const submit = (image: File | string, options: Record<string, any> = {}) => {
+export const submit = (
+  image: File | string, 
+  options: Record<string, any> = {}
+): Promise<ServiceConnectorResponse> => {
   const model = options['model'];
   const key = options['api-key'];
 
   // Should never happen
   if (!model || !key)
     throw new Error('Missing access configuration');
+
+  const generator = {
+    id: model,
+    name: `kluster.ai (${model})`,
+    homepage: 'https://www.kluster.ai/'
+  };
 
   const client = new OpenAI({
     apiKey: key,
@@ -36,7 +46,7 @@ Find every word, label, title, number, and text element. Put all the text in a s
           }
         }]
       }]
-    });
+    }).then(data => ({ data, generator }));
 
   if (typeof image === 'string') {
     return submit(image);

--- a/src/services/connectors/ocr-space/submit.ts
+++ b/src/services/connectors/ocr-space/submit.ts
@@ -1,3 +1,4 @@
+import { ServiceConnectorResponse } from "@/services/Types";
 
 const { VITE_OCR_SPACE_KEY } = import.meta.env;
 
@@ -12,11 +13,20 @@ interface OCRSpaceOptions {
 const isOCRSpaceOptions = (opts: Record<string, any>): opts is OCRSpaceOptions => 
   typeof opts.language === 'string';
 
-export const submit = (image: File | string, options?: Record<string, any>) => {
+export const submit = (
+  image: File | string, 
+  options?: Record<string, any>
+): Promise<ServiceConnectorResponse> => {
   if (!isOCRSpaceOptions(options)) {
     console.error(options);
     return Promise.reject('Invalid OCR options');
   }
+
+  const generator = {
+    id: 'ocr-space',
+    name: 'OCR.space',
+    homepage: 'https://ocr.space'
+  };
   
   const formData  = new FormData();
   formData.append('apikey', VITE_OCR_SPACE_KEY);
@@ -32,5 +42,5 @@ export const submit = (image: File | string, options?: Record<string, any>) => {
   return fetch('https://api.ocr.space/parse/image', {
     method: 'POST',
     body: formData
-  }).then(res => res.json());
+  }).then(res => res.json()).then(data => ({ data, generator }));
 }

--- a/src/services/connectors/openai/submit.ts
+++ b/src/services/connectors/openai/submit.ts
@@ -1,12 +1,22 @@
+import { ServiceConnectorResponse } from '@/services/Types';
 import { fileToBase64, urlToBase64 } from '@/services/utils';
 import OpenAI from 'openai';
 import { zodTextFormat } from 'openai/helpers/zod';
 import { z } from 'zod';
 
-export const submit = (image: File | string, options?: Record<string, any>) => {
+export const submit = (
+  image: File | string, 
+  options?: Record<string, any>
+): Promise<ServiceConnectorResponse> => {
   const apiKey = options['api-key'];
 
   const openai = new OpenAI({ apiKey, dangerouslyAllowBrowser: true });
+
+  const generator = {
+    id: 'gpt-4.1',
+    name: 'OpenAI GPT (gpt-4.1)',
+    homepage: 'https://openai.com/index/openai-api/'
+  };
 
   const Transcription = z.object({ text: z.string() });
 
@@ -27,7 +37,7 @@ export const submit = (image: File | string, options?: Record<string, any>) => {
       text: {
         format: zodTextFormat(Transcription, 'transcriptions')
       }
-    });
+    }).then(data => ({ data, generator }));
 
     if (typeof image === 'string') {
       return urlToBase64(image).then(base64 =>  

--- a/src/services/connectors/volcano-engine/submit.ts
+++ b/src/services/connectors/volcano-engine/submit.ts
@@ -11,7 +11,12 @@ export const submit = (image: File | string, options: Record<string, any> = {}) 
     image,
     key,
     'https://ark.cn-beijing.volces.com/api/v3',
-    'doubao-1.5-vision-pro-250328'
+    'doubao-1.5-vision-pro-250328',
+     {
+      id: 'doubao-1.5-vision-pro-250328',
+      name: 'VolcEngine (doubao-1.5-vision-pro-250328)',
+      homepage: 'https://www.volcengine.com/'
+    }
   );
 
 }

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -3,7 +3,7 @@ import OpenAI from 'openai';
 import { HeadersLike } from 'node_modules/openai/internal/headers.mjs';
 import { ShapeType } from '@annotorious/react';
 import type { AnnotationBody, ImageAnnotation } from '@annotorious/react';
-import { PageTransform, Region } from './Types';
+import { Generator, PageTransform, Region, ServiceConnectorResponse } from './Types';
 
 export const fileToBase64 = (file: Blob): Promise<string> => new Promise((resolve, reject) => {
   const reader = new FileReader();
@@ -27,8 +27,9 @@ export const submitOpenAICompatible = (
   apiKey: string,
   baseURL: string,
   model: string,
+  generator: Generator,
   defaultHeaders?: HeadersLike
-) => {
+): Promise<ServiceConnectorResponse> => {
   const client = new OpenAI({ 
     apiKey, 
     baseURL,
@@ -56,7 +57,7 @@ export const submitOpenAICompatible = (
           }
         }]
       }]
-    });
+    }).then((data: any) => ({ generator, data } as ServiceConnectorResponse));
 
   if (typeof image === 'string') {
     return urlToBase64(image).then(base64 =>  


### PR DESCRIPTION
## In this PR

Transcription services now add generator info to the annotation, via the annotation body's `creator` field (cf #233). To identify the body as a machine-generated note, the creator `type` is set to `Software`. 

When selecting annotation with `Software` creator, the creator name (typically the service name and/or model) is displayed above the Note field.

Note that the `creator` info is automatically dropped as soon as the user manually edits the annotation!