### PR TITLE
External Authorities: Multiple Endpoints

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -20,7 +20,10 @@
     "name": "CBDB",
     "description": "China Biographical Database Project",
     "type": "IFRAME",
-    "search_pattern": "https://input.cbdb.fas.harvard.edu/cbdbapi/person.php?name={{query}}"
+    "search_pattern": { 
+      "/^\\d+$/": "https://input.cbdb.fas.harvard.edu/cbdbapi/person.php?id={{query}}",
+      "*": "https://input.cbdb.fas.harvard.edu/cbdbapi/person.php?name={{query}}"
+    }
   }, {
     "name": "DILA (Person)",
     "description": "Buddhist Studies Authority Database Project (Person Search)",

--- a/src/components/PropertyDefinitionEditor/ExternalAuthorityOptions/ExternalAuthorityOptions.tsx
+++ b/src/components/PropertyDefinitionEditor/ExternalAuthorityOptions/ExternalAuthorityOptions.tsx
@@ -33,8 +33,14 @@ export const ExternalAuthorityOptions = (props: ExternalAuthorityOptionsProps) =
   const isSelected = (authority: ExternalAuthority) =>
     Boolean((props.definition.authorities || []).find(a => a === authority.name));
 
-  const hasValidConfiguration = (a: ExternalAuthority) =>
-    Boolean(a.name) && a.search_pattern?.includes('{{query}}') && a.type === 'IFRAME';
+  const hasValidConfiguration = (a: ExternalAuthority) => {
+    const hasValidSearchPattern = a.search_pattern && a.type === 'IFRAME' && (
+      (typeof a.search_pattern === 'string' && a.search_pattern.includes('{{query}}')) || 
+      typeof a.search_pattern === 'object' && Object.values(a.search_pattern).every(url => url.includes('{{query}}'))
+    );
+
+    return Boolean(a.name) && hasValidSearchPattern;
+  }
 
   return (
     <div className="bg-muted px-2 py-3 mt-2 rounded-md text-sm">

--- a/src/model/ExternalAuthority.ts
+++ b/src/model/ExternalAuthority.ts
@@ -6,10 +6,20 @@ export interface ExternalAuthority {
 
   type: 'IFRAME';
 
-  search_pattern?: string;
+  search_pattern?: string | Object;
 
   external_url_pattern?: string;
 
   canonical_id_pattern?: string;
 
+}
+
+export const findMatchingPattern = (patternObject: object, value: string) => {
+  const match = Object.entries(patternObject).find(([ key ]) => {
+    if (key === "*") return false;
+    const pattern = key.slice(1, -1);
+    return new RegExp(pattern).test(value);
+  });
+  
+  return match ? match[1] : patternObject["*"];
 }


### PR DESCRIPTION
## In this PR

It is now possible to configure the search URLs for External Authorities, so that different endpoints are chosen based on RegEx input patterns.

Accordingly, the CBDB endpoint was configured to use:

- The ID lookup endpoint for numeric input
- The name search endpoint otherwise