### PR TITLE
Repair Relocated Manifests

### DIFF
--- a/src/components/FixRelocatedManifest/FixRelocatedManifest.tsx
+++ b/src/components/FixRelocatedManifest/FixRelocatedManifest.tsx
@@ -22,7 +22,10 @@ export const FixRelocatedManifest = (props: FixRelocatedManifestProps) => {
 
   return (
     <>
-      <DropdownMenuItem onSelect={() => setIsRepairDialogOpen(true)}>
+      <DropdownMenuItem onSelect={e => {
+        e.preventDefault();
+        setIsRepairDialogOpen(true)
+      }}>
         Fix Relocated Manifest
       </DropdownMenuItem>
 

--- a/src/components/FixRelocatedManifest/FixRelocatedManifest.tsx
+++ b/src/components/FixRelocatedManifest/FixRelocatedManifest.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+import { DropdownMenuItem } from '@/ui/DropdownMenu';
+import { IIIFManifestResource } from '@/model';
+import { useFixRelocatedManifest } from './useFixedRelocatedManifest';
+import { Dialog, DialogContent } from '@/ui/Dialog';
+
+interface FixRelocatedManifestProps {
+
+  manifest: IIIFManifestResource
+
+}
+
+export const FixRelocatedManifest = (props: FixRelocatedManifestProps) => {
+
+  const { fixRelocatedManifest } = useFixRelocatedManifest();
+
+  const [isRepairDialogOpen, setIsRepairDialogOpen] = useState(false);
+
+  const [newUrl, setNewUrl] = useState(''); 
+
+  const onRepair = () => fixRelocatedManifest(props.manifest, newUrl);
+
+  return (
+    <>
+      <DropdownMenuItem onSelect={() => setIsRepairDialogOpen(true)}>
+        Fix Relocated Manifest
+      </DropdownMenuItem>
+
+      <Dialog
+        open={isRepairDialogOpen}
+        onOpenChange={open => setIsRepairDialogOpen(open)}>
+        <DialogContent>
+          <input 
+            value={newUrl}
+            onChange={evt => setNewUrl(evt.target.value) }/>
+          <button onClick={() => onRepair()}>Ok</button>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+
+}

--- a/src/components/FixRelocatedManifest/index.ts
+++ b/src/components/FixRelocatedManifest/index.ts
@@ -1,0 +1,1 @@
+export * from './FixRelocatedManifest';

--- a/src/components/FixRelocatedManifest/useFixedRelocatedManifest.ts
+++ b/src/components/FixRelocatedManifest/useFixedRelocatedManifest.ts
@@ -1,0 +1,87 @@
+import murmur from 'murmurhash';
+import { W3CAnnotation } from '@annotorious/react';
+import { Cozy } from 'cozy-iiif';
+import { IIIFManifestResource, IIIFResourceInformation } from '@/model';
+import { useStore } from '@/store';
+import { generateShortId } from '@/store/utils';
+import { getCanvasLabelWithFallback } from '../../utils/iiif';
+
+export const useFixRelocatedManifest = () => {
+  const store = useStore();
+
+  const fixRelocatedManifest = (
+    manifest: IIIFManifestResource, 
+    newUrl: string
+  ) => {
+    const folder = manifest.path[manifest.path.length - 1];
+    console.log('Downloading manifest...');
+
+    const idSeed = folder ? `${folder}/${manifest.uri}` : manifest.uri;
+    generateShortId(idSeed).then(id  => {
+      Cozy.parseURL(newUrl)
+        .then(result => {
+          if (result.type !== 'manifest')
+            throw new Error('Not a manifest');
+
+          const newManifest = result.resource;
+
+          const info: IIIFResourceInformation = {
+            id,
+            name: newManifest.getLabel() || `IIIF Presentation API v${newManifest.majorVersion}`,
+            uri: newUrl,
+            importedAt: manifest.importedAt,
+            type: 'PRESENTATION_MANIFEST',
+            majorVersion: newManifest.majorVersion,
+            canvases: newManifest.canvases.map(canvas => ({
+              id: murmur.v3(canvas.id).toString(),
+              uri: canvas.id,
+              name: getCanvasLabelWithFallback(canvas),
+              manifestId: id
+            }))
+          }
+
+          // console.log('Previous ID was: ' + manifest.id);
+          // console.log('New manifest ID is: ' + id);
+
+          const p = manifest.canvases.reduce<Promise<Record<string, W3CAnnotation[]>>>((p, canvas, idx) => p.then(all => {
+            const oldId = `iiif:${manifest.id}:${canvas.id}`;
+            const newId = `iiif:${id}:${info.canvases[idx].id}`;
+
+            return store.getAnnotations(oldId).then(onThisCanvas => {
+              const mapped = onThisCanvas.map(a => ({
+                ...a, 
+                target: {
+                  // @ts-ignore
+                  ...a.target,
+                  source: newId
+                }
+              }));
+              return {...all, [newId]: mapped };
+            });
+          }), Promise.resolve({}));
+
+          p.then(mappedAnnotations => {
+            console.log('Importing new manifest');
+            return store.importIIIFResource(info, folder).then(() => {
+              console.log(`Transferring ${Object.values(mappedAnnotations).reduce<number>((a, b) => a + b.length, 0)} annotations`);
+              console.log(mappedAnnotations);
+              return Object.entries(mappedAnnotations).reduce<Promise<void>>((p, [imageId, annotations]) => p.then(() => {
+                return annotations.length > 0 ? store.bulkUpsertAnnotation(imageId, annotations) : Promise.resolve();
+              }), Promise.resolve());
+            })
+          }).then(() => {
+            console.log('Removing outdated manifest');
+            store.removeIIIFResource(manifest).then(() => console.log('Done.'));
+          });
+        })
+        .catch(error => {
+          console.error(error);
+        });
+    })
+
+    console.log('repairing', manifest, newUrl);
+  }
+
+  return { fixRelocatedManifest };
+
+}

--- a/src/pages/images/IIIFImporter/IIIFImporter.tsx
+++ b/src/pages/images/IIIFImporter/IIIFImporter.tsx
@@ -146,7 +146,7 @@ export const IIIFImporter = (props: IIIFImporterProps) => {
         <Button
           variant="link"
           className="text-muted-foreground flex items-center gap-1.5 p-0 h-auto font-normal ring-offset-2 rounded">
-          <CloudDownload className="size-[18px] pt-px" /> Import IIIF
+          <CloudDownload className="size-4.5 pt-px" /> Import IIIF
         </Button>
       </DialogTrigger>
 
@@ -188,7 +188,7 @@ export const IIIFImporter = (props: IIIFImporterProps) => {
               className="p-3 mt-6 items-start leading-relaxed
                 rounded text-destructive border border-destructive">
               <div className="font-semibold mb-2 flex gap-1.5">
-                <Ban className="size-3.5 mt-[3px]" /> Already Imported
+                <Ban className="size-3.5 mt-0.75" /> Already Imported
               </div>
 
               <div>

--- a/src/pages/images/ItemOverview/ItemGrid/IIIFManifestItem/IIIFManifestItemActions.tsx
+++ b/src/pages/images/ItemOverview/ItemGrid/IIIFManifestItem/IIIFManifestItemActions.tsx
@@ -49,8 +49,8 @@ export const IIIFManifestItemActions = (props: IIIFManifestItemActionsProps) => 
           <IIIFOpenInViewerAction manifest={props.resource as IIIFManifestResource} />
 
           <DropdownMenuItem onSelect={() => setConfirmDelete(true)}>          
-              <Trash2 className="size-4 mr-2 mb-px text-red-700/70" />
-              <span className="text-red-700 hover:text-red-700">Delete</span>
+            <Trash2 className="size-4 mr-2 mb-px text-red-700/70" />
+            <span className="text-red-700 hover:text-red-700">Delete</span>
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/src/pages/images/ItemOverview/ItemTable/ItemTableRowActions.tsx
+++ b/src/pages/images/ItemOverview/ItemTable/ItemTableRowActions.tsx
@@ -3,11 +3,13 @@ import { Link } from 'react-router-dom';
 import { FolderOpen, ImageIcon, Images, MoreHorizontal, NotebookPen, Trash2 } from 'lucide-react';
 import { Button } from '@/ui/Button';
 import { ConfirmedDelete } from '@/components/ConfirmedDelete';
+import { FixRelocatedManifest } from '@/components/FixRelocatedManifest';
 import { Folder, IIIFManifestResource, Image } from '@/model';
 import { useStore } from '@/store';
 import { isSingleImageManifest } from '@/utils/iiif';
 import { useCanvas } from '@/utils/iiif/hooks';
 import { OverviewItem } from '../../Types';
+import { IIIFOpenInViewerAction } from '../IIIFOpenInViewerAction';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -17,7 +19,6 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@/ui/DropdownMenu';
-import { IIIFOpenInViewerAction } from '../IIIFOpenInViewerAction';
 
 interface ItemTableRowActions {
 
@@ -167,11 +168,16 @@ export const ItemTableRowActions = (props: ItemTableRowActions) => {
           )}
 
           {isManifest && (
-            <DropdownMenuItem onSelect={() => setConfirmDelete(true)}>          
-                <Trash2 className="size-4 mr-2 mb-px text-red-700/70" />
-                <span className="text-red-700 hover:text-red-700">Delete</span>
-            </DropdownMenuItem>
+            <>
+              <DropdownMenuItem onSelect={() => setConfirmDelete(true)}>          
+                  <Trash2 className="size-4 mr-2 mb-px text-red-700/70" />
+                  <span className="text-red-700 hover:text-red-700">Delete</span>
+              </DropdownMenuItem>
+              
+              <FixRelocatedManifest manifest={props.data as IIIFManifestResource}/>
+            </>
           )}
+
         </DropdownMenuContent>
       </DropdownMenu>
 

--- a/src/pages/images/ItemOverview/ItemTable/ItemTableRowActions.tsx
+++ b/src/pages/images/ItemOverview/ItemTable/ItemTableRowActions.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { FolderOpen, ImageIcon, Images, MoreHorizontal, NotebookPen, Trash2 } from 'lucide-react';
 import { Button } from '@/ui/Button';
 import { ConfirmedDelete } from '@/components/ConfirmedDelete';
-import { FixRelocatedManifest } from '@/components/FixRelocatedManifest';
+// import { FixRelocatedManifest } from '@/components/FixRelocatedManifest';
 import { Folder, IIIFManifestResource, Image } from '@/model';
 import { useStore } from '@/store';
 import { isSingleImageManifest } from '@/utils/iiif';

--- a/src/pages/images/ItemOverview/ItemTable/ItemTableRowActions.tsx
+++ b/src/pages/images/ItemOverview/ItemTable/ItemTableRowActions.tsx
@@ -174,7 +174,7 @@ export const ItemTableRowActions = (props: ItemTableRowActions) => {
                   <span className="text-red-700 hover:text-red-700">Delete</span>
               </DropdownMenuItem>
               
-              <FixRelocatedManifest manifest={props.data as IIIFManifestResource}/>
+              {/* <FixRelocatedManifest manifest={props.data as IIIFManifestResource}/> */}
             </>
           )}
 


### PR DESCRIPTION
## In this PR

Adds a small internal utility to deal with "relocated" manifests where institutions change manifest location and (manifest + canvas) IDs.