### PR TITLE
Image Preview Popups for Annotation View

### DIFF
--- a/src/components/Thumbnail/Thumbnail.tsx
+++ b/src/components/Thumbnail/Thumbnail.tsx
@@ -1,9 +1,9 @@
+import { useMemo } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { CanvasInformation, FileImage, LoadedImage } from '@/model';
 import { useImages } from '@/store';
 import { Spinner } from '../Spinner';
 import { cn } from '@/ui/utils';
-import { useMemo } from 'react';
 
 interface ThumbnailProps {
 

--- a/src/components/Thumbnail/Thumbnail.tsx
+++ b/src/components/Thumbnail/Thumbnail.tsx
@@ -2,8 +2,8 @@ import { useMemo } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { CanvasInformation, FileImage, LoadedImage } from '@/model';
 import { useImages } from '@/store';
-import { Spinner } from '../Spinner';
 import { cn } from '@/ui/utils';
+import { Spinner } from '../Spinner';
 
 interface ThumbnailProps {
 

--- a/src/components/Thumbnail/Thumbnail.tsx
+++ b/src/components/Thumbnail/Thumbnail.tsx
@@ -2,12 +2,18 @@ import { useInView } from 'react-intersection-observer';
 import { CanvasInformation, FileImage, LoadedImage } from '@/model';
 import { useImages } from '@/store';
 import { Spinner } from '../Spinner';
+import { cn } from '@/ui/utils';
+import { useMemo } from 'react';
 
 interface ThumbnailProps {
 
   image: FileImage | CanvasInformation;
 
   delay?: number;
+
+  size?: number;
+
+  className?: string;
   
 }
 
@@ -19,16 +25,19 @@ const ThumbnailImage = (props: ThumbnailProps) => {
 
   const loaded = useImages(id, delay) as LoadedImage;
 
-  const url = loaded && (
+  const url = useMemo(() => loaded && (
     'data' in loaded 
       ? URL.createObjectURL(loaded.data) 
-      : loaded.canvas.getThumbnailURL(112));
+      : loaded.canvas.getThumbnailURL(props.size || 112)), [loaded, props.size]);
 
   return loaded ? (
     <img
       src={url}
       alt={image.name}
-      className="w-14 h-14 object-cover aspect-square rounded-sm shadow-sm border border-black/20" />
+      className={cn(
+        'size-full object-cover aspect-square rounded-sm shadow-sm border border-black/20',
+        props.className
+      )} />
   ) : (
     <Spinner className="w-3 h-3 text-muted-foreground/80" />
   )
@@ -40,7 +49,12 @@ export const Thumbnail = (props: ThumbnailProps) => {
   const { ref, inView } = useInView();
 
   return (
-    <div ref={ref} className="w-14 h-14 aspect-square bg-muted rounded-md flex justify-center items-center">
+    <div 
+      ref={ref} 
+      className={cn(
+        'w-14 h-14 aspect-square bg-muted rounded-md flex justify-center items-center relative',
+        props.className
+      )}>
       {inView && (
         <ThumbnailImage {...props} />
       )}

--- a/src/pages/annotate/HeaderSection/AddImage/AddImageListItems/ImageListItem.tsx
+++ b/src/pages/annotate/HeaderSection/AddImage/AddImageListItems/ImageListItem.tsx
@@ -2,6 +2,7 @@ import { Check, MessagesSquare } from 'lucide-react';
 import { IIIFIcon } from '@/components/IIIFIcon';
 import { Thumbnail } from '@/components/Thumbnail';
 import { CanvasInformation, FileImage } from '@/model';
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/ui/HoverCard';
 
 interface ImageListItemProps {
 
@@ -28,16 +29,28 @@ export const ImageListItem = (props: ImageListItemProps) => {
         disabled={isOpen}
         className="flex gap-3 w-full relative"
         onClick={onSelect}>
-        {isOpen ? (
-          <div className="relative">
-            <Thumbnail image={image} /> 
-            <div className="absolute w-full h-full top-0 left-0 bg-white/60 flex items-center justify-center">
-              <Check className="text-black h-10 w-10" />
-            </div>
-          </div>
-        ) : (
-          <Thumbnail image={image} /> 
-        )}
+        <div className="relative">
+          <HoverCard>
+            <HoverCardTrigger>
+              <Thumbnail image={image} /> 
+              {isOpen && (
+                <div className="absolute w-full h-full top-0 left-0 bg-white/60 flex items-center justify-center">
+                  <Check className="text-black h-10 w-10" />
+                </div>
+              )}
+            </HoverCardTrigger>
+
+            <HoverCardContent 
+              sideOffset={8}
+              className="z-999 p-0 border border-white shadow-xl overflow-hidden min-w-0 w-auto"
+              collisionPadding={20}>
+              <Thumbnail 
+                image={image} 
+                size={600}
+                className="h-auto w-auto aspect-auto max-w-100 max-h-100 border-0"/>
+            </HoverCardContent>
+          </HoverCard>
+        </div>
 
         {isIIIF && (
           <IIIFIcon
@@ -47,7 +60,7 @@ export const ImageListItem = (props: ImageListItemProps) => {
         
         <div className="grow line-clamp-3 overflow-hidden text-ellipsis text-left">
           <div className="py-1 space-y-1">
-            <div>{image.name}</div>
+            <div className="whitespace-nowrap truncate">{image.name}</div>
             {props.annotations > 0 && (
               <div className="flex gap-1 items-center text-muted-foreground">
                 <MessagesSquare className="size-3.5" /> {props.annotations}

--- a/src/pages/annotate/Pagination/ThumbnailStrip.tsx
+++ b/src/pages/annotate/Pagination/ThumbnailStrip.tsx
@@ -3,6 +3,7 @@ import { ChevronLeft, ChevronRight, ImageIcon, ImagePlus } from 'lucide-react';
 import { useTransition, animated, easings } from '@react-spring/web';
 import { Thumbnail } from '@/components/Thumbnail';
 import { CanvasInformation, FileImage, LoadedImage } from '@/model';
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/ui/HoverCard';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ui/Tooltip';
 import {
   ContextMenu,
@@ -105,22 +106,36 @@ export const ThumbnailStrip = (props: ThumbnailStripProps) => {
             className="shrink-0 inline-block mx-1.5">
             <ContextMenu>
               <ContextMenuTrigger>
-                <Tooltip>
+                <Tooltip delayDuration={50}>
                   <TooltipTrigger asChild>
                     <button
                       className={isSelected(image)  
                         ? 'block outline-2 outline-offset-2 rounded-sm outline-black' 
                         : 'block hover:outline-2 outline-offset-2 rounded-sm outline-black'}
                       onClick={() => onSelect(image)}>
-                      <Thumbnail 
-                        image={image} 
-                        delay={160} />
+                      <HoverCard>
+                        <HoverCardTrigger>
+                          <Thumbnail 
+                            image={image} 
+                            delay={160} />
+                        </HoverCardTrigger>
+
+                        <HoverCardContent 
+                          sideOffset={8}
+                          className="z-999 p-1 border shadow-xl overflow-hidden min-w-0 w-auto"
+                          collisionPadding={20}>
+                          <Thumbnail 
+                            image={image} 
+                            size={600}
+                            className="h-auto w-auto aspect-auto max-w-100 max-h-100 border-0"/>
+                        </HoverCardContent>
+                      </HoverCard>
                     </button>
                   </TooltipTrigger>
 
                   <TooltipContent
-                    side="bottom"
-                    sideOffset={6}>
+                    side="top"
+                    sideOffset={8}>
                     {image.name}
                   </TooltipContent>
                 </Tooltip>

--- a/src/pages/annotate/Pagination/ThumbnailStrip.tsx
+++ b/src/pages/annotate/Pagination/ThumbnailStrip.tsx
@@ -122,7 +122,7 @@ export const ThumbnailStrip = (props: ThumbnailStripProps) => {
 
                         <HoverCardContent 
                           sideOffset={8}
-                          className="z-999 p-1 border shadow-xl overflow-hidden min-w-0 w-auto"
+                          className="z-999 p-0 border border-white shadow-xl overflow-hidden min-w-0 w-auto"
                           collisionPadding={20}>
                           <Thumbnail 
                             image={image} 

--- a/src/ui/ContextMenu/context-menu.tsx
+++ b/src/ui/ContextMenu/context-menu.tsx
@@ -44,7 +44,7 @@ const ContextMenuSubContent = React.forwardRef<
   <ContextMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 min-w-32 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className
     )}
     {...props}
@@ -60,7 +60,7 @@ const ContextMenuContent = React.forwardRef<
     <ContextMenuPrimitive.Content
       ref={ref}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 min-w-32 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
       {...props}


### PR DESCRIPTION
## In this PR

See #309: this PR adds large-size hover card preview images for the small thumbnails in the annotation workspace:
- Navigation thumbnail strip
- 'Add Images' dialog