### PR TITLE
Duplicate Annotation

### DIFF
--- a/src/pages/annotate/SidebarSection/AnnotationList/AnnotationList.tsx
+++ b/src/pages/annotate/SidebarSection/AnnotationList/AnnotationList.tsx
@@ -1,9 +1,10 @@
 import { type MouseEvent, useCallback, useMemo, useState } from 'react';
 import { Move } from 'lucide-react';
-import { ImageAnnotation, type AnnotoriousOpenSeadragonAnnotator, type W3CImageAnnotation } from '@annotorious/react';
+import { v4 as uuidv4 } from 'uuid';
+import { ImageAnnotation, parseW3CImageAnnotation } from '@annotorious/react';
+import type { AnnotoriousOpenSeadragonAnnotator, W3CImageAnnotation } from '@annotorious/react';
 import { useAnnotoriousManifold, useSelection } from '@annotorious/react-manifold';
 import { useStore } from '@/store';
-import { cloneAnnotation } from '@/utils/annotation';
 import { Separator } from '@/ui/Separator';
 import { AnnotationListItem } from './AnnotationListItem';
 import { SelectFilter } from './SelectFilter';
@@ -27,6 +28,23 @@ interface AnnotationListProps {
 
   onChangeFilterState(filter?: FilterState): void;
 
+}
+
+const cloneAnnotation = (annotation: ImageAnnotation): ImageAnnotation => {
+  const id = uuidv4();
+
+  return {
+    id,
+    bodies: annotation.bodies.map(b => ({
+      ...b,
+      annotation: id
+    })),
+    target: {
+      ...annotation.target,
+      created: new Date(),
+      annotation: id
+    }
+  }
 }
 
 export const AnnotationList = (props: AnnotationListProps) => {
@@ -59,10 +77,12 @@ export const AnnotationList = (props: AnnotationListProps) => {
 
   const onDuplicate = (annotation: W3CImageAnnotation) => {
     const anno = manifold.findAnnotator(annotation.id);
-    if (!anno) return; // Should never happen
+    const parsed = parseW3CImageAnnotation(annotation).parsed;
 
-    const clone = cloneAnnotation(annotation) as W3CImageAnnotation;
-    anno.addAnnotation(clone);
+    if (!anno || !parsed) return; // Should never happen
+
+    const clone = cloneAnnotation(parsed);
+    anno.state.store.addAnnotation(clone);
   }
 
   const onDelete = (annotation: W3CImageAnnotation) =>

--- a/src/pages/annotate/SidebarSection/AnnotationList/AnnotationList.tsx
+++ b/src/pages/annotate/SidebarSection/AnnotationList/AnnotationList.tsx
@@ -1,10 +1,11 @@
 import { type MouseEvent, useCallback, useMemo, useState } from 'react';
 import { Move } from 'lucide-react';
-import type { AnnotoriousOpenSeadragonAnnotator, W3CImageAnnotation } from '@annotorious/react';
-import { AnnotationListItem } from './AnnotationListItem';
+import { ImageAnnotation, type AnnotoriousOpenSeadragonAnnotator, type W3CImageAnnotation } from '@annotorious/react';
 import { useAnnotoriousManifold, useSelection } from '@annotorious/react-manifold';
 import { useStore } from '@/store';
+import { cloneAnnotation } from '@/utils/annotation';
 import { Separator } from '@/ui/Separator';
+import { AnnotationListItem } from './AnnotationListItem';
 import { SelectFilter } from './SelectFilter';
 import { SortableAnnotationList } from './sortable';
 import { SelectAll } from './SelectAll';
@@ -20,17 +21,17 @@ import {
 
 interface AnnotationListProps {
 
+  filterState?: FilterState;
+
   onEdit(): void;
 
-  filterState?: FilterState;
-  
   onChangeFilterState(filter?: FilterState): void;
 
 }
 
 export const AnnotationList = (props: AnnotationListProps) => {
 
-  const manifold = useAnnotoriousManifold();
+  const manifold = useAnnotoriousManifold<ImageAnnotation, W3CImageAnnotation>();
 
   const { selected } = useSelection();
 
@@ -50,10 +51,18 @@ export const AnnotationList = (props: AnnotationListProps) => {
   const onEdit = (annotation: W3CImageAnnotation) => {
     manifold.setSelected(annotation.id);
 
-    const annotator = manifold.findAnnotator(annotation.id);
-    (annotator as AnnotoriousOpenSeadragonAnnotator).fitBounds(annotation, { padding: 200});
+    const annotator = manifold.findAnnotator(annotation.id) as AnnotoriousOpenSeadragonAnnotator<ImageAnnotation, W3CImageAnnotation>;
+    annotator.fitBounds(annotation, { padding: 200});
 
     props.onEdit();
+  }
+
+  const onDuplicate = (annotation: W3CImageAnnotation) => {
+    const anno = manifold.findAnnotator(annotation.id);
+    if (!anno) return; // Should never happen
+
+    const clone = cloneAnnotation(annotation) as W3CImageAnnotation;
+    anno.addAnnotation(clone);
   }
 
   const onDelete = (annotation: W3CImageAnnotation) =>
@@ -166,6 +175,7 @@ export const AnnotationList = (props: AnnotationListProps) => {
                     annotation={annotation} 
                     isSelected={isSelected(annotation)}
                     onEdit={() => onEdit(annotation)}
+                    onDuplicate={() => onDuplicate(annotation)}
                     onDelete={() => onDelete(annotation)} />
                 </li>
               ))) : (
@@ -201,6 +211,7 @@ export const AnnotationList = (props: AnnotationListProps) => {
                           annotation={annotation} 
                           isSelected={isSelected(annotation)}
                           onEdit={() => onEdit(annotation)}
+                          onDuplicate={() => onDuplicate(annotation)}
                           onDelete={() => onDelete(annotation)} />
                       </li>
                     ))) : (

--- a/src/pages/annotate/SidebarSection/AnnotationList/AnnotationListItem.tsx
+++ b/src/pages/annotate/SidebarSection/AnnotationList/AnnotationListItem.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, type MouseEvent } from 'react';
-import { Pencil, Trash2 } from 'lucide-react';
+import { CopyPlus, SquarePen, Trash2 } from 'lucide-react';
 import { format } from 'date-fns';
 import { useInView } from 'react-intersection-observer';
 import { DraggableAttributes } from '@dnd-kit/core';
@@ -10,9 +10,9 @@ import { AnnotationValuePreview } from '@/components/AnnotationValuePreview';
 import { ConfirmedDelete } from '@/components/ConfirmedDelete';
 import { EntityBadge } from '@/components/EntityBadge';
 import { useDataModel, useStore } from '@/store';
-import { Button } from '@/ui/Button';
 import { AnnotationListItemRelation } from './AnnotationListItemRelation';
 import { cn } from '@/ui/utils';
+import { TooltippedButton } from '@/components/TooltippedButton';
 
 interface AnnotationListItemProps {
 
@@ -21,6 +21,8 @@ interface AnnotationListItemProps {
   isSelected?: boolean;
 
   onEdit(): void;
+
+  onDuplicate(): void;
 
   onDelete(): void;
 
@@ -92,7 +94,7 @@ export const AnnotationListItem = (props: AnnotationListItemProps) => {
           className="w-full text-left"
           onClick={evt => onClick(evt, props.annotation.id)}
           {...(props.dragAttributes || {})}
-          {...(props.dragListeners || {})}>
+          {...(props.dragListeners || {})}>
           {entityTags.length > 0 && (
             <ul 
               className="line-clamp-1 mr-8 px-2 py-3">
@@ -148,21 +150,32 @@ export const AnnotationListItem = (props: AnnotationListItemProps) => {
           )}
 
           <div className="flex">
-            <Button 
+            <TooltippedButton 
               variant="ghost" 
               size="icon" 
-              className="rounded-full h-8 w-8 text-gray-400 hover:text-black"
+              className="h-8 w-8 text-gray-400 hover:text-black"
+              tooltip="Edit"
               onClick={props.onEdit}>
-              <Pencil className="h-3.5 w-3.5" />
-            </Button>
+              <SquarePen className="size-4" />
+            </TooltippedButton>
 
-            <Button 
+            <TooltippedButton 
               variant="ghost" 
               size="icon" 
-              className="rounded-full h-8 w-8 -ml-1.5 text-gray-400 hover:text-red-600"
+              className="h-8 w-8 text-gray-400 hover:text-black"
+              tooltip="Duplicate this annotation"
+              onClick={props.onDuplicate}>
+              <CopyPlus className="size-4" />
+            </TooltippedButton>
+
+            <TooltippedButton 
+              variant="ghost" 
+              size="icon" 
+              className="h-8 w-8 text-gray-400 hover:text-red-600"
+              tooltip="Delete"
               onClick={() => setConfirmDelete(true)}>
-              <Trash2 className="h-3.5 w-3.5" />
-            </Button>
+              <Trash2 className="size-4" />
+            </TooltippedButton>
           </div>
         </div>
       </div>

--- a/src/pages/annotate/SidebarSection/AnnotationList/useSortableAnnotations.ts
+++ b/src/pages/annotate/SidebarSection/AnnotationList/useSortableAnnotations.ts
@@ -23,10 +23,7 @@ export const useSortableAnnotations = () => {
       )
     , Promise.resolve([]));
 
-    p.then(arr => {
-      console.log('setting', new Map(arr));
-      setAnnotations(new Map(arr))
-    });
+    p.then(arr => setAnnotations(new Map(arr)));
   }, [store, unsortedAnnotations]);
 
   const updateOrder = useCallback((sourceId: string, ids: string[]) => {

--- a/src/pages/annotate/SidebarSection/AnnotationList/useSortableAnnotations.ts
+++ b/src/pages/annotate/SidebarSection/AnnotationList/useSortableAnnotations.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { W3CImageAnnotation } from '@annotorious/react';
-import { useAnnotoriousManifold } from '@annotorious/react-manifold';
+import { useAnnotations, useAnnotoriousManifold } from '@annotorious/react-manifold';
 import { useStore } from '@/store';
 
 export const useSortableAnnotations = () => {
@@ -8,6 +8,8 @@ export const useSortableAnnotations = () => {
   const { sources } = useAnnotoriousManifold();
 
   const store = useStore();
+
+  const unsortedAnnotations = useAnnotations();
 
   const [annotations, setAnnotations] = useState<Map<string, W3CImageAnnotation[]>>(new Map());
 
@@ -21,9 +23,11 @@ export const useSortableAnnotations = () => {
       )
     , Promise.resolve([]));
 
-    p.then(arr => setAnnotations(new Map(arr)));
-    
-  }, [sources.join(':'), store]);
+    p.then(arr => {
+      console.log('setting', new Map(arr));
+      setAnnotations(new Map(arr))
+    });
+  }, [store, unsortedAnnotations]);
 
   const updateOrder = useCallback((sourceId: string, ids: string[]) => {
     const before = [...annotations.get(sourceId)];

--- a/src/pages/annotate/SidebarSection/AnnotationList/useSortableAnnotations.ts
+++ b/src/pages/annotate/SidebarSection/AnnotationList/useSortableAnnotations.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { W3CImageAnnotation } from '@annotorious/react';
-import { useAnnotations, useAnnotoriousManifold } from '@annotorious/react-manifold';
+import { useAnnotoriousManifold } from '@annotorious/react-manifold';
 import { useStore } from '@/store';
 
 export const useSortableAnnotations = () => {
@@ -8,8 +8,6 @@ export const useSortableAnnotations = () => {
   const { sources } = useAnnotoriousManifold();
 
   const store = useStore();
-
-  const unsortedAnnotations = useAnnotations();
 
   const [annotations, setAnnotations] = useState<Map<string, W3CImageAnnotation[]>>(new Map());
 
@@ -24,7 +22,7 @@ export const useSortableAnnotations = () => {
     , Promise.resolve([]));
 
     p.then(arr => setAnnotations(new Map(arr)));
-  }, [store, unsortedAnnotations]);
+  }, [sources.join(':'), store]);
 
   const updateOrder = useCallback((sourceId: string, ids: string[]) => {
     const before = [...annotations.get(sourceId)];

--- a/src/store/hooks/useStore.ts
+++ b/src/store/hooks/useStore.ts
@@ -40,6 +40,9 @@ export const useStore = () => {
   const bulkUpsertAnnotation = useCallback((imageId: string, annotations: W3CAnnotation[]) =>
     set(store.bulkUpsertAnnotation(imageId, annotations)), []);
 
+  const upsertAnnotation = useCallback((imageId: string, annotation: W3CAnnotation) =>
+    set(store.upsertAnnotation(imageId, annotation)), []);
+
   const reactive = useMemo(() => store ? {
     ...store,
     bulkUpsertAnnotation,
@@ -47,6 +50,7 @@ export const useStore = () => {
     deleteRelation,
     importIIIFResource,
     removeIIIFResource,
+    upsertAnnotation,
     upsertRelation
   } : undefined, [store]);
 

--- a/src/utils/annotation.ts
+++ b/src/utils/annotation.ts
@@ -1,3 +1,4 @@
+import { v4 as uuidv4 } from 'uuid';
 import { W3CAnnotation, W3CAnnotationBody } from '@annotorious/react';
 
 /** Returns the 'classifying' bodies with the given Entity Type, if any **/
@@ -53,3 +54,10 @@ export const getLastEdit = (annotations: W3CAnnotation[]): Date | undefined => {
       ? new Date(Math.max(...timestamps.map(t => t.getTime())))
       : undefined
 }
+
+export const cloneAnnotation = (annotation: W3CAnnotation): W3CAnnotation => ({
+  ...annotation,
+  id: uuidv4(),
+  body: Array.isArray(annotation.body) ? [...annotation.body] : [annotation.body],
+  target: Array.isArray(annotation.target) ? [...annotation.target] : annotation.target
+});

--- a/src/utils/annotation.ts
+++ b/src/utils/annotation.ts
@@ -1,4 +1,3 @@
-import { v4 as uuidv4 } from 'uuid';
 import { W3CAnnotation, W3CAnnotationBody } from '@annotorious/react';
 
 /** Returns the 'classifying' bodies with the given Entity Type, if any **/
@@ -54,10 +53,3 @@ export const getLastEdit = (annotations: W3CAnnotation[]): Date | undefined => {
       ? new Date(Math.max(...timestamps.map(t => t.getTime())))
       : undefined
 }
-
-export const cloneAnnotation = (annotation: W3CAnnotation): W3CAnnotation => ({
-  ...annotation,
-  id: uuidv4(),
-  body: Array.isArray(annotation.body) ? [...annotation.body] : [annotation.body],
-  target: Array.isArray(annotation.target) ? [...annotation.target] : annotation.target
-});


### PR DESCRIPTION
## In this PR

This PR adds functionality to create an identical duplicate of an annotation. Use case: the user has created a complex shape and wants to do something with it (e.g. use it in a merge or subtract operation), while retaining a copy of the original.

The feature is provided via a "Duplicate" button on the annotation card in the annotation list.

The PR also fixes a small bug where the annotation list wasn't reactive, and didn't update if new annotations were created in the annotation interface.