### PR TITLE
i18n (1/5): shared components, navigation & test setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules/
 .DS_Store
 .env
 *.onnx
+test-results/
+playwright-report/

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,64 @@
+import { Page } from '@playwright/test';
+
+/**
+ * IMMARKUS requires picking a work folder via the File System Access API,
+ * which opens a native dialog Playwright cannot drive. This helper replaces
+ * window.showDirectoryPicker with an OPFS-backed directory (no dialog), and
+ * seeds it with one small PNG so image-dependent pages have content.
+ *
+ * Must be called BEFORE page.goto().
+ */
+export const mockWorkFolder = (page: Page) =>
+  page.addInitScript(async () => {
+    (window as any).showDirectoryPicker = async () => {
+      const root = await navigator.storage.getDirectory();
+      const dir = await root.getDirectoryHandle('e2e-work-folder', { create: true });
+
+      // Seed a sample image (idempotent)
+      let exists = true;
+      try { await dir.getFileHandle('sample.png'); } catch { exists = false; }
+      if (!exists) {
+        const canvas = new OffscreenCanvas(200, 150);
+        const ctx = canvas.getContext('2d')!;
+        ctx.fillStyle = '#1d4ed8';
+        ctx.fillRect(0, 0, 200, 150);
+        const blob = await canvas.convertToBlob({ type: 'image/png' });
+        const file = await dir.getFileHandle('sample.png', { create: true });
+        const writable = await (file as any).createWritable();
+        await writable.write(blob);
+        await writable.close();
+      }
+
+      // The app calls requestPermission() on handles restored from IndexedDB
+      (dir as any).requestPermission = async () => 'granted';
+      return dir;
+    };
+  });
+
+/** Force the UI language before the app boots (mirrors the detector's cache). */
+export const setLanguage = (page: Page, lang: 'en' | 'ja') =>
+  page.addInitScript(l => localStorage.setItem('immarkus.language', l), lang);
+
+/**
+ * Open the mocked work folder from the start page and wait for the app to
+ * land on the images overview.
+ */
+export const openWorkFolder = async (page: Page) => {
+  await page.getByRole('button').first().waitFor();
+  // First button on the start page CTA is "Open New Folder" / 「新しいフォルダを開く」
+  await page.locator('.cta button').first().click();
+  await page.waitForURL(/#\/?$|#\/images/, { timeout: 15000 });
+};
+
+/**
+ * Heuristic regression check: visible page text should not contain raw
+ * translation keys (e.g. "open.welcome" or "headerSection.addImage").
+ */
+export const findRawTranslationKeys = async (page: Page): Promise<string[]> => {
+  const text = await page.locator('body').innerText();
+  const matches = text.match(/\b[a-z][a-zA-Z]+\.[a-z][a-zA-Z]+(\.[a-zA-Z]+)*\b/g) || [];
+  // Filter obvious non-keys (file names, URLs, version strings)
+  return matches.filter(m =>
+    !/\.(png|jpe?g|json|xlsx|csv|tsx?|pdf|html)$/i.test(m) &&
+    !/^(www|github|localhost|e2e)\./.test(m));
+};

--- a/e2e/start.spec.ts
+++ b/e2e/start.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from '@playwright/test';
+import { findRawTranslationKeys, mockWorkFolder, openWorkFolder, setLanguage } from './helpers';
+
+test.describe('start page', () => {
+
+  test('renders English by default', async ({ page }) => {
+    await setLanguage(page, 'en');
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: 'Welcome to IMMARKUS' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Open New Folder' })).toBeVisible();
+    expect(await findRawTranslationKeys(page)).toEqual([]);
+  });
+
+  test('renders Japanese when selected', async ({ page }) => {
+    await setLanguage(page, 'ja');
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: 'IMMARKUS へようこそ' })).toBeVisible();
+    await expect(page.getByRole('button', { name: '新しいフォルダを開く' })).toBeVisible();
+    expect(await findRawTranslationKeys(page)).toEqual([]);
+  });
+
+  test('language switcher toggles and persists across reload', async ({ page }) => {
+    // No setLanguage here: addInitScript re-runs on reload and would
+    // overwrite the choice made through the UI. Playwright's default
+    // locale is en-US, so the app boots in English.
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: 'Welcome to IMMARKUS' })).toBeVisible();
+
+    await page.getByRole('combobox', { name: 'Language' }).click();
+    await page.getByRole('option', { name: '日本語' }).click();
+    await expect(page.getByRole('heading', { name: 'IMMARKUS へようこそ' })).toBeVisible();
+
+    await page.reload();
+    await expect(page.getByRole('heading', { name: 'IMMARKUS へようこそ' })).toBeVisible();
+  });
+
+  test('opens a work folder and lands in the translated app shell', async ({ page }) => {
+    await setLanguage(page, 'ja');
+    await mockWorkFolder(page);
+    await page.goto('/');
+    await openWorkFolder(page);
+
+    // Navigation sidebar localized
+    await expect(page.getByText('画像', { exact: true }).first()).toBeVisible({ timeout: 15000 });
+    expect(await findRawTranslationKeys(page)).toEqual([]);
+  });
+
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,7 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@tailwindcss/typography": "^0.5.20",
         "@tailwindcss/vite": "^4.3.0",
         "@types/chroma-js": "^3.1.2",
@@ -93,11 +94,13 @@
         "@types/react-autosuggest": "^10.1.11",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.2.0",
+        "playwright": "^1.60.0",
         "tailwindcss": "^4.3.0",
         "typescript": "^6.0.3",
         "vite": "^7.3.5",
         "vite-plugin-babel-macros": "^1.0.6",
-        "vite-plugin-static-copy": "^3.4.0"
+        "vite-plugin-static-copy": "^3.4.0",
+        "vitest": "^4.1.8"
       }
     },
     "node_modules/@annotorious/annotorious": {
@@ -1917,6 +1920,22 @@
         "url": "^0.11.0"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -3659,6 +3678,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
@@ -4001,6 +4027,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/chroma-js": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@types/chroma-js/-/chroma-js-3.1.2.tgz",
@@ -4022,6 +4059,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/earcut": {
       "version": "2.1.4",
@@ -4187,6 +4231,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -4346,6 +4503,16 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -4706,6 +4873,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chainsaw": {
@@ -5465,6 +5642,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
@@ -5560,6 +5744,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -5603,6 +5797,16 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend": {
@@ -7983,6 +8187,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -8184,6 +8402,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -8251,6 +8476,53 @@
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/polyclip-ts": {
       "version": "0.16.8",
@@ -9289,6 +9561,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/simplify-js": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/simplify-js/-/simplify-js-1.2.4.tgz",
@@ -9320,6 +9599,20 @@
       "resolved": "https://registry.npmjs.org/splaytree-ts/-/splaytree-ts-1.0.2.tgz",
       "integrity": "sha512-0kGecIZNIReCSiznK3uheYB8sbstLjCZLiwcQwbmLhgHJj2gz6OnSPkVzJQCMnmEz1BQ4gPK59ylhBoEWOhGNA==",
       "license": "BDS-3-Clause"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -9451,11 +9744,28 @@
         "node": ">=12.22"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinycolor2": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
       "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
@@ -9472,6 +9782,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tmp": {
@@ -10031,6 +10351,96 @@
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/void-elements": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
@@ -10063,6 +10473,23 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,12 @@
   "scripts": {
     "start": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:e2e": "playwright test"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/typography": "^0.5.20",
     "@tailwindcss/vite": "^4.3.0",
     "@types/chroma-js": "^3.1.2",
@@ -16,11 +19,13 @@
     "@types/react-autosuggest": "^10.1.11",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.2.0",
+    "playwright": "^1.60.0",
     "tailwindcss": "^4.3.0",
     "typescript": "^6.0.3",
     "vite": "^7.3.5",
     "vite-plugin-babel-macros": "^1.0.6",
-    "vite-plugin-static-copy": "^3.4.0"
+    "vite-plugin-static-copy": "^3.4.0",
+    "vitest": "^4.1.8"
   },
   "dependencies": {
     "@annotorious/plugin-boolean-operations": "^0.4.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  // All specs share one Vite dev server; more workers starve it and
+  // cause spurious timeouts (the annotate/graph pages are heavy).
+  workers: 2,
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'retain-on-failure'
+  },
+  webServer: {
+    command: 'npm start',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI
+  }
+});

--- a/src/components/AppNavigationSidebar/AppNavigationSidebar.tsx
+++ b/src/components/AppNavigationSidebar/AppNavigationSidebar.tsx
@@ -1,4 +1,5 @@
 import { Link, useLocation } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { useAnnotationViewState } from '@/pages';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/ui/Collapsible';
 import { 
@@ -30,21 +31,23 @@ import {
 import './AppNavigationSidebar.css';
 
 const NAV_ITEMS = [
-  { to: '/images',   icon: Image,   label: 'Images'   },
-  { to: '/annotate', icon: PanelsTopLeft, label: 'Workspace' },
-  { to: '/graph',    icon: Waypoints, label: 'Knowledge Graph' },
-  { to: '/model',    icon: ToyBrick,  label: 'Data Model' },
-  { to: '/export',   icon: Download,  label: 'Export'   },
-  { to: '/settings', icon: Settings2, label: 'Settings' },
+  { to: '/images',   icon: Image,   label: 'appNavigationSidebar.images'   },
+  { to: '/annotate', icon: PanelsTopLeft, label: 'appNavigationSidebar.workspace' },
+  { to: '/graph',    icon: Waypoints, label: 'appNavigationSidebar.knowledgeGraph' },
+  { to: '/model',    icon: ToyBrick,  label: 'appNavigationSidebar.dataModel' },
+  { to: '/export',   icon: Download,  label: 'appNavigationSidebar.export'   },
+  { to: '/settings', icon: Settings2, label: 'appNavigationSidebar.settings' },
 ];
 
 const ABOUT_ITEMS = [
-  { to: '/about',  label: 'IMMARKUS' },
-  { to: '/markus', label: 'X-MARKUS' },
-  { href: 'https://github.com/rsimon/immarkus/wiki', label: 'Help' },
+  { to: '/about',  label: 'appNavigationSidebar.immarkus' },
+  { to: '/markus', label: 'appNavigationSidebar.xmarkus' },
+  { href: 'https://github.com/rsimon/immarkus/wiki', label: 'appNavigationSidebar.help' },
 ];
 
 export const AppNavigationSidebar = () => {
+  const { t } = useTranslation('common');
+
   const { imageIds } = useAnnotationViewState();
 
   const { pathname } = useLocation();
@@ -72,10 +75,10 @@ export const AppNavigationSidebar = () => {
                       isActive={pathname.startsWith(to)}>
                       <Link to={to}>
                         <Icon />
-                        {label}
+                        {t(label)}
                       </Link>
                     </SidebarMenuButton>
-                    {label === 'Workspace' && (
+                    {to === '/annotate' && (
                       <SidebarMenuBadge>{imageIds.length}</SidebarMenuBadge>
                     )}
                   </SidebarMenuItem>
@@ -88,7 +91,7 @@ export const AppNavigationSidebar = () => {
                     <CollapsibleTrigger asChild>
                       <SidebarMenuButton>
                         <InfoIcon />
-                        About
+                        {t('appNavigationSidebar.about')}
                         <ChevronDown className="ml-auto transition-transform group-data-[state=open]/collapsible:rotate-180" />
                       </SidebarMenuButton>
                     </CollapsibleTrigger>
@@ -101,8 +104,8 @@ export const AppNavigationSidebar = () => {
                               asChild
                               isActive={to ? pathname === to : false}>
                               {href
-                                ? <a href={href} target="_blank" rel="noreferrer">{label}</a>
-                                : <Link to={to!}>{label}</Link>}
+                                ? <a href={href} target="_blank" rel="noreferrer">{t(label)}</a>
+                                : <Link to={to!}>{t(label)}</Link>}
                             </SidebarMenuSubButton>
                           </SidebarMenuSubItem>
                         ))}
@@ -120,7 +123,7 @@ export const AppNavigationSidebar = () => {
         <button
           className="flex items-center p-2.5"
           onClick={() => location.href = '/'}>
-          <LogOut size={18} className="mr-2" /> Exit
+          <LogOut size={18} className="mr-2" /> {t('appNavigationSidebar.exit')}
         </button>
       </SidebarFooter>
     </aside>

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useEffect, useState } from 'react';
 import { ChevronDown } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { useCommandState } from 'cmdk';
 import { cn } from '@/ui/utils';
 import { Button } from '@/ui/Button';
@@ -86,6 +87,8 @@ const ComboBoxStateListener = (props: ComboboxStateListenerProps) => {
 
 export const Combobox = <T extends ComboboxOption = ComboboxOption>(props: ComboboxProps<T>) => {
 
+  const { t } = useTranslation('common');
+
   const { value, placeholder } = props;
 
   const [open, setOpen] = useState(false);
@@ -127,12 +130,12 @@ export const Combobox = <T extends ComboboxOption = ComboboxOption>(props: Combo
         <Command>
           <CommandInput 
             className="h-auto py-2 text-xs"
-            placeholder="Search..." />
+            placeholder={t('combobox.searchPlaceholder')} />
           
           <CommandList className="p-1">
             <CommandEmpty 
               className="text-xs font-normal flex justify-center py-2 text-muted-foreground">
-              No matches
+              {t('combobox.noMatches')}
             </CommandEmpty>
 
             {props.options.map(option => (

--- a/src/components/ConfirmedDelete/ConfirmedDelete.tsx
+++ b/src/components/ConfirmedDelete/ConfirmedDelete.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react';
 import { Trash2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/ui/Button';
 import {
   AlertDialog,
@@ -38,6 +39,8 @@ interface DeleteButtonProps {
 
 export const ConfirmedDelete = (props: DeleteButtonProps) => {
 
+  const { t } = useTranslation('common');
+
   const isControlled = props.open !== undefined;
 
   return (
@@ -61,18 +64,18 @@ export const ConfirmedDelete = (props: DeleteButtonProps) => {
       
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>{props.title || 'Are you sure?'}</AlertDialogTitle>
+          <AlertDialogTitle>{props.title || t('confirmedDelete.title')}</AlertDialogTitle>
           <AlertDialogDescription>
             {props.message}
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogCancel>{t('confirmedDelete.cancel')}</AlertDialogCancel>
 
-          <AlertDialogAction 
+          <AlertDialogAction
             className="bg-destructive hover:bg-destructive/90"
             onClick={props.onConfirm}>
-            <Trash2 className="w-4 h-4 mr-2" /> Delete
+            <Trash2 className="w-4 h-4 mr-2" /> {t('confirmedDelete.delete')}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/src/components/CopyManifestURL/CopyManifestURL.tsx
+++ b/src/components/CopyManifestURL/CopyManifestURL.tsx
@@ -1,5 +1,6 @@
 import { type MouseEvent, useState } from 'react';
 import { ClipboardCheck } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { IIIFManifestResource } from '@/model';
 import { IIIFIcon } from '../IIIFIcon';
 
@@ -10,6 +11,8 @@ interface CopyManifestURLProps {
 }
 
 export const CopyManifestURL = (props: CopyManifestURLProps) => {
+
+  const { t } = useTranslation('common');
 
   const [copied, setCopied] = useState(false);
 
@@ -30,7 +33,7 @@ export const CopyManifestURL = (props: CopyManifestURLProps) => {
         <ClipboardCheck className="size-4 text-green-700" /> 
       ) : (
         <IIIFIcon color className="size-4" />
-      )} <span className="mt-px">Copy Manifest URL</span>
+      )} <span className="mt-px">{t('copyManifestURL.label')}</span>
     </button>
   )
 

--- a/src/components/DataModelImport/DataModelImport.tsx
+++ b/src/components/DataModelImport/DataModelImport.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { Trans, useTranslation } from 'react-i18next';
 import { AlertCircle, Check, XCircle } from 'lucide-react';
 import { EntityType, MetadataSchema, RelationshipType } from '@/model';
 import { useDataModel } from '@/store';
@@ -36,6 +37,8 @@ interface DataModelImportProps {
 }
 
 export const DataModelImport = (props: DataModelImportProps) => {
+
+  const { t } = useTranslation('common');
 
   const [open, setOpen] = useState(props.open);
 
@@ -93,15 +96,15 @@ export const DataModelImport = (props: DataModelImportProps) => {
       .then(() => {
         toast({
           // @ts-ignore
-          title: <ToastTitle className="flex"><Check size={18} className="mr-2" /> Success</ToastTitle>,
-          description: props.type === 'ENTITY_TYPES' 
-            ? `${items.length} entity classe${items.length > 1 ? 's' : ''} imported successfully.`
-            : `${items.length} schema${items.length > 1 ? 's' : ''} imported successfully.`
+          title: <ToastTitle className="flex"><Check size={18} className="mr-2" /> {t('dataModelImport.success')}</ToastTitle>,
+          description: props.type === 'ENTITY_TYPES'
+            ? t('dataModelImport.entityClassesImported', { count: items.length })
+            : t('dataModelImport.schemasImported', { count: items.length })
         });
       })
       .catch(error => {
         console.error(error);
-        onError('Error importing to data model');
+        onError(t('dataModelImport.importError'));
       });
   }
 
@@ -115,11 +118,13 @@ export const DataModelImport = (props: DataModelImportProps) => {
     toast({
       variant: 'destructive',
       // @ts-ignore
-      title: <ToastTitle className="flex"><XCircle size={18} className="mr-2" /> Error</ToastTitle>,
+      title: <ToastTitle className="flex"><XCircle size={18} className="mr-2" /> {t('dataModelImport.error')}</ToastTitle>,
       description: error
     });
 
-  const items = props.type === 'ENTITY_TYPES' ? 'classes' : 'schemas';
+  const items = props.type === 'ENTITY_TYPES'
+    ? t('dataModelImport.itemsClasses')
+    : t('dataModelImport.itemsSchemas');
 
   const isEmpty = 
     props.type === 'ENTITY_TYPES' ? model.entityTypes.length === 0 :
@@ -140,16 +145,16 @@ export const DataModelImport = (props: DataModelImportProps) => {
       <DialogContent className="p-0 my-8 rounded-lg">
         <div className="px-7 pt-6 pb-8 leading-relaxed">
           <h2 className="mb-2 font-semibold">
-            Import {props.type === 'ENTITY_TYPES' 
-              ? 'Entity Classes' : props.type === 'FOLDER_SCHEMAS' 
-              ? 'Folder Schemas' : props.type === 'IMAGE_SCHEMAS'
-              ? 'Image Schemas' : 'Relationship Types'}
+            {props.type === 'ENTITY_TYPES'
+              ? t('dataModelImport.title.entityTypes') : props.type === 'FOLDER_SCHEMAS'
+              ? t('dataModelImport.title.folderSchemas') : props.type === 'IMAGE_SCHEMAS'
+              ? t('dataModelImport.title.imageSchemas') : t('dataModelImport.title.relationshipTypes')}
           </h2>
 
           <div className="py-4">
             <div className="flex items-center gap-2 justify-between">
               <Label htmlFor="replace-existing">
-                Replace Current Model
+                {t('dataModelImport.replaceCurrentModel')}
               </Label>
 
               <Switch 
@@ -159,17 +164,17 @@ export const DataModelImport = (props: DataModelImportProps) => {
             </div>
 
             <p className="text-muted-foreground text-xs mt-1 pr-20">
-              You can either delete and replace your existing model, or add the 
-              imported {items} to your current model.
+              {t('dataModelImport.replaceHint', { items })}
             </p>
 
             {replace && !isEmpty && (
               <Alert variant="destructive" className="my-4">
                 <AlertCircle className="h-4 w-4" />
-                <AlertTitle className="text-sm">Warning</AlertTitle>
+                <AlertTitle className="text-sm">{t('dataModelImport.warning')}</AlertTitle>
                 <AlertDescription className="text-sm leading-relaxed">
-                  All current {props.type === 'ENTITY_TYPES' ? 'Entity Classes' : 'schemas'} will
-                  be deleted from your model.
+                  {props.type === 'ENTITY_TYPES'
+                    ? t('dataModelImport.replaceWarning.entityTypes')
+                    : t('dataModelImport.replaceWarning.schemas')}
                 </AlertDescription>
               </Alert>
             )}
@@ -177,12 +182,13 @@ export const DataModelImport = (props: DataModelImportProps) => {
 
           <div className={replace ? 'import-duplicates disabled my-2' : 'import-duplicates my-2'}>
             <Label htmlFor="replace-existing">
-              How to Handle Duplicate {props.type === 'ENTITY_TYPES' ? 'Classes' : 'Schemas'}
+              {props.type === 'ENTITY_TYPES'
+                ? t('dataModelImport.duplicatesTitle.entityTypes')
+                : t('dataModelImport.duplicatesTitle.schemas')}
             </Label>
 
             <p className="text-muted-foreground text-xs mt-1 mb-2">
-              Select how the import should merge {items} that 
-              already exist in your model.
+              {t('dataModelImport.duplicatesHint', { items })}
             </p>
 
             <div className="py-1">
@@ -196,10 +202,9 @@ export const DataModelImport = (props: DataModelImportProps) => {
                     id="keep" />
 
                   <div>
-                    <Label htmlFor="keep">Keep Existing</Label>
+                    <Label htmlFor="keep">{t('dataModelImport.keepExisting')}</Label>
                     <p className="text-xs text-muted-foreground">
-                      If the import contains {items} that 
-                      already exist in your model, keep the existing ones and discard the imported {items}.
+                      {t('dataModelImport.keepExistingHint', { items })}
                     </p>
                   </div>
                 </div>
@@ -211,10 +216,9 @@ export const DataModelImport = (props: DataModelImportProps) => {
                     id="replace" />
 
                   <div>
-                    <Label htmlFor="replace">Keep Imported</Label>
+                    <Label htmlFor="replace">{t('dataModelImport.keepImported')}</Label>
                     <p className="text-xs text-muted-foreground">
-                      If the import contains {items} that already exist in 
-                      your model, discard the existing ones and keep the imported {items}.
+                      {t('dataModelImport.keepImportedHint', { items })}
                     </p>
                   </div>
                 </div>
@@ -230,7 +234,7 @@ export const DataModelImport = (props: DataModelImportProps) => {
                 <Label 
                   htmlFor="presets"
                   className="inline-block text-xs mb-1.5 ml-0.5">
-                  Import from Preset
+                  {t('dataModelImport.importFromPreset')}
                 </Label>
 
                 <Select 
@@ -252,7 +256,7 @@ export const DataModelImport = (props: DataModelImportProps) => {
               </div>
 
               <p className="w-full text-xs py-4 text-center text-muted-foreground">
-                — or —
+                {t('dataModelImport.orSeparator')}
               </p>
             </>
           ) : (
@@ -265,8 +269,12 @@ export const DataModelImport = (props: DataModelImportProps) => {
             onUpload={importToModel} />
 
           <div className="text-center text-muted-foreground text-xs pt-2">
-            Use files downloaded 
-            from <Link className="text-black hover:underline" to="/export/model">Export / Data Model</Link>. 
+            <Trans
+              ns="common"
+              i18nKey="dataModelImport.useExportedFiles"
+              components={{
+                exportLink: <Link className="text-black hover:underline" to="/export/model" />
+              }} />
           </div>
         </div>
       </DialogContent>

--- a/src/components/DataModelImport/UploadButton.tsx
+++ b/src/components/DataModelImport/UploadButton.tsx
@@ -1,4 +1,5 @@
 import { ChangeEvent, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/ui/Button';
 import { EntityType } from '@/model';
 
@@ -13,6 +14,8 @@ interface UploadButtonProps {
 }
 
 export const UploadButton = (props: UploadButtonProps) => {
+
+  const { t } = useTranslation('common');
 
   const inputEl = useRef<HTMLInputElement>(null);
 
@@ -29,9 +32,9 @@ export const UploadButton = (props: UploadButtonProps) => {
           if (props.validation(content))
             props.onUpload(content);
           else
-            props.onError('Invalid data model format');
+            props.onError(t('dataModelImport.invalidFormat'));
         } catch (error) {
-          props.onError('Could not open the data file');
+          props.onError(t('dataModelImport.couldNotOpenFile'));
         }
       };
 
@@ -51,7 +54,7 @@ export const UploadButton = (props: UploadButtonProps) => {
 
       <Button 
         className="w-full"
-        onClick={() => inputEl.current.click()}>Upload Datamodel File</Button>
+        onClick={() => inputEl.current.click()}>{t('dataModelImport.uploadButton')}</Button>
     </>
   )
 

--- a/src/components/EntityBadge/EntityBadge.tsx
+++ b/src/components/EntityBadge/EntityBadge.tsx
@@ -1,4 +1,5 @@
 import { Cuboid } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { EntityType } from '@/model';
 import { DEFAULT_COLOR, getForegroundColor } from '@/utils/color';
 import { cn } from '@/ui/utils';
@@ -19,6 +20,8 @@ interface BadgeEntityProps {
 
 export const EntityBadge = (props: BadgeEntityProps) => {
 
+  const { t } = useTranslation('common');
+
   const { entityType } = props;
 
   const backgroundColor = entityType?.color || DEFAULT_COLOR;
@@ -31,7 +34,7 @@ export const EntityBadge = (props: BadgeEntityProps) => {
         color: getForegroundColor(backgroundColor)
       }}>
 
-      <Cuboid className="h-3.5 w-3.5 mr-1"/> <span className="truncate">{entityType?.label || entityType?.id || 'error'}</span>
+      <Cuboid className="h-3.5 w-3.5 mr-1"/> <span className="truncate">{entityType?.label || entityType?.id || t('entityBadge.error')}</span>
     </span>
   )
 

--- a/src/components/EntityTypeBrowser/EntityTypeBrowser.tsx
+++ b/src/components/EntityTypeBrowser/EntityTypeBrowser.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import ReactAutosuggest from 'react-autosuggest';
 import type { EntityType } from '@/model';
 import { useDataModel } from '@/store';
@@ -16,6 +17,8 @@ interface EntityTypeBrowserProps {
 }
 
 export const EntityTypeBrowser = (props: EntityTypeBrowserProps) => {
+
+  const { t } = useTranslation('common');
 
   const datamodel = useDataModel();
 
@@ -106,7 +109,7 @@ export const EntityTypeBrowser = (props: EntityTypeBrowserProps) => {
             </div>
           ) : (
             <div className="flex justify-center items-center p-6 text-sm text-muted-foreground">
-              No results
+              {t('entityTypeBrowser.noResults')}
             </div>
           )}
           renderInputComponent={inputProps => (

--- a/src/components/EntityTypeBrowser/EntityTypeBrowserDialog.tsx
+++ b/src/components/EntityTypeBrowser/EntityTypeBrowserDialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Cuboid } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { EntityTypeEditor } from '@/components/EntityTypeEditor';
 import { EntityType } from '@/model';
 import { Button } from '@/ui/Button';
@@ -17,6 +18,8 @@ interface EntityTypeBrowserDialogProps {
 }
 
 export const EntityTypeBrowserDialog = (props: EntityTypeBrowserDialogProps) => {
+
+  const { t } = useTranslation('common');
 
   const [selected, setSelected] = useState<EntityType | undefined>();
 
@@ -40,17 +43,17 @@ export const EntityTypeBrowserDialog = (props: EntityTypeBrowserDialogProps) => 
           onConfirm={props.onAddEntityType} />
 
         <DialogTitle className="hidden">
-          Search
+          {t('entityTypeBrowser.dialogTitle')}
         </DialogTitle>
-    
+
         <DialogDescription className="hidden">
-          Search and select an entity class.
+          {t('entityTypeBrowser.dialogDescription')}
         </DialogDescription>
 
         <div className="p-1 pt-1.5 border-t flex justify-between text-muted-foreground">
           <EntityTypeEditor>
             <Button variant="ghost" className="text-xs h-8 px-2 rounded-sm mr-2">
-              <Cuboid className="h-3.5 w-3.5 mr-1.5" /> Create New Entity Class
+              <Cuboid className="h-3.5 w-3.5 mr-1.5" /> {t('entityTypeBrowser.createNewEntityClass')}
             </Button>
           </EntityTypeEditor>
 
@@ -58,14 +61,14 @@ export const EntityTypeBrowserDialog = (props: EntityTypeBrowserDialogProps) => 
             <Button 
               onClick={props.onCancel}
               variant="ghost" className="text-xs h-8 px-2 rounded-sm">
-              Cancel
+              {t('entityTypeBrowser.cancel')}
             </Button>
 
-            <Button 
-              variant="ghost" 
+            <Button
+              variant="ghost"
               className="text-xs h-8 rounded-sm"
               onClick={onOk}>
-              OK
+              {t('entityTypeBrowser.ok')}
             </Button>
           </div>
         </div>

--- a/src/components/EntityTypeBrowser/EntityTypeBrowserInput.tsx
+++ b/src/components/EntityTypeBrowser/EntityTypeBrowserInput.tsx
@@ -1,5 +1,6 @@
 import { Cuboid, ListTree, Search, X } from 'lucide-react';
 import { forwardRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { RenderInputComponentProps } from 'react-autosuggest';
 import { EntityType } from '@/model';
 import { DEFAULT_COLOR, getForegroundColor } from '@/utils/color';
@@ -14,6 +15,8 @@ interface EntityTypeBrowserInputProps extends RenderInputComponentProps {
 }
 
 export const EntityTypeBrowserInput = forwardRef((props: EntityTypeBrowserInputProps, ref: React.Ref<HTMLDivElement>) => {
+
+  const { t } = useTranslation('common');
 
   const { selected, onClearSearch, ...inputProps } = props;
 
@@ -38,7 +41,9 @@ export const EntityTypeBrowserInput = forwardRef((props: EntityTypeBrowserInputP
         <input 
           autoFocus
           {...inputProps}
-          placeholder={selected ? `Search in ${selected.label || selected.id}...` : 'Search...'}
+          placeholder={selected
+            ? t('entityTypeBrowser.searchInPlaceholder', { name: selected.label || selected.id })
+            : t('entityTypeBrowser.searchPlaceholder')}
           className="relative top-[1px] py-1 outline-hidden px-0.5 grow" />
       </div>
 

--- a/src/components/EntityTypeBrowser/EntityTypeBrowserSuggestion.tsx
+++ b/src/components/EntityTypeBrowser/EntityTypeBrowserSuggestion.tsx
@@ -1,4 +1,5 @@
 import { ListTree } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { EntityType } from '@/model';
 import { useDataModel } from '@/store';
 import { DEFAULT_COLOR, getForegroundColor } from '@/utils/color';
@@ -12,6 +13,8 @@ interface EntityTypeBrowserSuggestionProps {
 }
 
 export const EntityTypeBrowserSuggestion = (props: EntityTypeBrowserSuggestionProps) => {
+
+  const { t } = useTranslation('common');
 
   const { type, highlighted } = props;
 
@@ -55,7 +58,7 @@ export const EntityTypeBrowserSuggestion = (props: EntityTypeBrowserSuggestionPr
               <ListTree className="w-3.5 h-3.5" />
 
               <span className="ml-0.5 mt-[0.5px] mr-1">
-                {children.length} child{children.length > 1 && 'ren'}
+                {t('entityTypeBrowser.children', { count: children.length })}
               </span>
             </div>
           )}

--- a/src/components/EntityTypeEditor/Editor/Editor.tsx
+++ b/src/components/EntityTypeEditor/Editor/Editor.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { AlertCircle, CheckCircle2, Cuboid, RefreshCcw } from 'lucide-react';
 import { EntityTypeSearchSimple } from '@/components/EntityTypeSearchSimple';
 import { EntityType } from '@/model';
@@ -31,6 +32,8 @@ interface ValidationErrors {
 }
 
 export const Editor = (props: EditorProps) => {
+
+  const { t } = useTranslation('common');
 
   const model = useDataModel();
 
@@ -111,10 +114,10 @@ export const Editor = (props: EditorProps) => {
             <div>
               <Label 
                 htmlFor="identifier"
-                className="inline-block text-xs mb-1.5 ml-0.5">Entity Class *
+                className="inline-block text-xs mb-1.5 ml-0.5">{t('entityTypeEditor.entityClass')}
               </Label>
-              
-              {errors?.invalidId && (<span className="text-xs text-red-600 ml-1">required</span>)}
+
+              {errors?.invalidId && (<span className="text-xs text-red-600 ml-1">{t('entityTypeEditor.required')}</span>)}
 
               <Input 
                 disabled={Boolean(props.entityType)}
@@ -125,11 +128,11 @@ export const Editor = (props: EditorProps) => {
 
               {entityType.id && (!isIdAvailable ? (
                 <span className="flex items-center text-xs mt-3 text-red-600 whitespace-nowrap">
-                  <AlertCircle className="shrink-0 h-3.5 w-3.5 mb-0.5 ml-0.5 mr-1" /> ID already exists
+                  <AlertCircle className="shrink-0 h-3.5 w-3.5 mb-0.5 ml-0.5 mr-1" /> {t('entityTypeEditor.idExists')}
                 </span>
               ) : (props.entityType && !(props.entityType.id === entityType.id)) || !props.entityType && (
                 <span className="flex items-center text-xs mt-2 text-green-600 whitespace-nowrap">
-                  <CheckCircle2 className="shrink-0 h-3.5 w-3.5 mb-0.5 ml-0.5 mr-1" /> {entityType.id} is available
+                  <CheckCircle2 className="shrink-0 h-3.5 w-3.5 mb-0.5 ml-0.5 mr-1" /> {t('entityTypeEditor.idAvailable', { id: entityType.id })}
                 </span>
               ))}
             </div>
@@ -137,7 +140,7 @@ export const Editor = (props: EditorProps) => {
             <div>
               <Label 
                 htmlFor="color"
-                className="inline-block text-xs mb-1.5 ml-0.5">Color</Label>
+                className="inline-block text-xs mb-1.5 ml-0.5">{t('entityTypeEditor.color')}</Label>
 
               <div className="grid grid-cols-4">
                 <Button 
@@ -163,7 +166,7 @@ export const Editor = (props: EditorProps) => {
           <div className="mt-6">
             <Label 
               htmlFor="label"
-              className="inline-block text-xs mb-1.5 ml-0.5">Display Name
+              className="inline-block text-xs mb-1.5 ml-0.5">{t('entityTypeEditor.displayName')}
             </Label>
 
             <Input
@@ -176,7 +179,7 @@ export const Editor = (props: EditorProps) => {
           <div className="mt-6">
             <Label 
               htmlFor="parent"
-              className="inline-block text-xs mb-1.5 ml-0.5">Parent Class
+              className="inline-block text-xs mb-1.5 ml-0.5">{t('entityTypeEditor.parentClass')}
             </Label>
 
             <EntityTypeSearchSimple
@@ -189,14 +192,14 @@ export const Editor = (props: EditorProps) => {
               <span className="flex items-center text-xs mt-2 text-red-600 whitespace-nowrap">
                 <AlertCircle className="shrink-0 h-3.5 w-3.5 mb-0.5 ml-0.5 mr-1" /> 
                   {entityType.parentId === entityType.id ? (
-                    <>{entityType.id} cannot be its own parent</>
+                    <>{t('entityTypeEditor.cannotBeOwnParent', { id: entityType.id })}</>
                   ) : (
-                    <>No Entity Class called {entityType.parentId}</>
+                    <>{t('entityTypeEditor.noEntityClassCalled', { id: entityType.parentId })}</>
                   )}
               </span>
             ) : entityType.parentId && entityType.parentId !== props.entityType?.parentId && isValidParent && (
               <span className="flex items-center text-xs mt-2 text-green-600 whitespace-nowrap">
-                <CheckCircle2 className="shrink-0 h-3.5 w-3.5 mb-0.5 ml-0.5 mr-1" /> {entityType.parentId} is a valid parent
+                <CheckCircle2 className="shrink-0 h-3.5 w-3.5 mb-0.5 ml-0.5 mr-1" /> {t('entityTypeEditor.validParent', { id: entityType.parentId })}
               </span>
             )}
           </div>
@@ -204,7 +207,7 @@ export const Editor = (props: EditorProps) => {
           <div className="mt-6">
             <Label 
               htmlFor="description"
-              className="inline-block text-xs mb-1.5 ml-0.5">Entity Class Description</Label>
+              className="inline-block text-xs mb-1.5 ml-0.5">{t('entityTypeEditor.description')}</Label>
 
             <Textarea 
               id="description"
@@ -222,7 +225,7 @@ export const Editor = (props: EditorProps) => {
           </div>
 
           <Button className="w-full mt-7 mb-3" onClick={onSave}>
-            <Cuboid className="w-5 h-5 mr-2" /> Save Entity Class
+            <Cuboid className="w-5 h-5 mr-2" /> {t('entityTypeEditor.save')}
           </Button>
         </div>
 

--- a/src/components/EntityTypeEditor/Editor/EntityPreview/EntityPreview.tsx
+++ b/src/components/EntityTypeEditor/Editor/EntityPreview/EntityPreview.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Cuboid } from 'lucide-react';
 import { Separator } from '@/ui/Separator';
 import { getBrightness } from '@/utils/color';
@@ -25,6 +26,8 @@ interface EntityPreviewProps {
 
 export const EntityPreview = (props: EntityPreviewProps) => {
 
+  const { t } = useTranslation('common');
+
   const { entityType } = props;
 
   const { parentId } = entityType;
@@ -50,11 +53,11 @@ export const EntityPreview = (props: EntityPreviewProps) => {
   return (
     <div className="bg-muted px-12 py-6 border-l rounded-r-lg">
       <h2>
-        Entity Preview
+        {t('entityTypeEditor.previewTitle')}
       </h2>
 
       <p className="text-left text-xs leading-relaxed mt-1 mb-6">
-        This is how the data entry form for your Entity will appear in the annotation view.
+        {t('entityTypeEditor.previewHint')}
       </p>
 
       <div className="flex mb-1">
@@ -65,7 +68,7 @@ export const EntityPreview = (props: EntityPreviewProps) => {
             color: brightness > 0.5 ? '#000' : '#fff' 
           }}>
           <Cuboid className="inline h-3.5 w-3.5 mr-1.5" />
-          {entityType.label || entityType.id || 'Entity Preview'}
+          {entityType.label || entityType.id || t('entityTypeEditor.previewTitle')}
         </h3>
       </div>
 

--- a/src/components/EntityTypeEditor/Editor/PropertyDefinitions/PropertyDefinitions.tsx
+++ b/src/components/EntityTypeEditor/Editor/PropertyDefinitions/PropertyDefinitions.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/ui/Button';
 import { EntityType, PropertyDefinition } from '@/model';
 import { useDataModel } from '@/store';
@@ -27,7 +28,9 @@ interface PropertyDefinitionsProps {
 
 export const PropertyDefinitions = (props: PropertyDefinitionsProps) => {
 
-  const { entityType, properties } = props; 
+  const { t } = useTranslation('common');
+
+  const { entityType, properties } = props;
 
   const datamodel = useDataModel();
 
@@ -50,11 +53,9 @@ export const PropertyDefinitions = (props: PropertyDefinitionsProps) => {
   const deleteProperty = (property: PropertyDefinition) => () =>
     props.onChange(properties.filter(p => p !== property));
 
-  const editorHint = 
-    'Use Properties to record specific details in your annotations, such as weight, material, age, etc.';
+  const editorHint = t('propertyDefinitions.editorHint');
 
-  const previewHint =
-    'This is how your property will appear when editing an entity in the annotation interface.';
+  const previewHint = t('propertyDefinitions.previewHint');
 
   return (
     <Accordion
@@ -66,9 +67,9 @@ export const PropertyDefinitions = (props: PropertyDefinitionsProps) => {
           className="rounded-md p-3 m-0 hover:no-underline">
           <div className="flex flex-col items-start">
             <h3 className="text-xs">
-              {properties.length === 0 
-                ? 'No Properties' 
-                : `${properties.length} Propert${properties.length === 1 ? 'y' : 'ies'}`}
+              {properties.length === 0
+                ? t('propertyDefinitions.noProperties')
+                : t('propertyDefinitions.propertyCount', { count: properties.length })}
             </h3>
           </div>
         </AccordionTrigger>
@@ -80,8 +81,7 @@ export const PropertyDefinitions = (props: PropertyDefinitionsProps) => {
                 className="text-center flex text-muted-foreground 
                   px-3 pb-2 justify-center text-xs
                   leading-relaxed">
-                Use Properties to record specific details for an annotated Entity,
-                such as weight, material, age, etc. 
+                {t('propertyDefinitions.emptyHint')}
               </p>
             ) : (
               <ul>
@@ -124,7 +124,7 @@ export const PropertyDefinitions = (props: PropertyDefinitionsProps) => {
                 <Button 
                   variant="outline" 
                   className="text-xs mt-3 h-9 pl-2 px-3 font-medium hover:bg-muted-foreground/5">
-                  Add Property
+                  {t('propertyDefinitions.addProperty')}
                 </Button>
               </PropertyDefinitionEditorDialog>
             </div>

--- a/src/components/EntityTypeEditor/EntityTypeEditor.tsx
+++ b/src/components/EntityTypeEditor/EntityTypeEditor.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { EntityType } from '@/model';
 import { Dialog, DialogContent, DialogDescription, DialogTitle, DialogTrigger } from '@/ui/Dialog';
 import { Editor } from './Editor';
@@ -17,6 +18,8 @@ interface EntityTypeDialogProps {
 }
 
 export const EntityTypeEditor = (props: EntityTypeDialogProps) => {
+
+  const { t } = useTranslation('common');
 
   const { toast } = useToast();
 
@@ -39,9 +42,9 @@ export const EntityTypeEditor = (props: EntityTypeDialogProps) => {
     toast({
       variant: 'destructive',
       // @ts-ignore
-      title: <ToastTitle className="flex"><XCircle size={18} className="mr-2" /> Error</ToastTitle>,
-      description: 'Something went wrong. Could not save entity type.'
-    });   
+      title: <ToastTitle className="flex"><XCircle size={18} className="mr-2" /> {t('entityTypeEditor.errorTitle')}</ToastTitle>,
+      description: t('entityTypeEditor.saveError')
+    });
   }
 
   return (
@@ -57,11 +60,11 @@ export const EntityTypeEditor = (props: EntityTypeDialogProps) => {
 
       <DialogContent className="p-0 max-w-4xl my-8 rounded-lg">
         <DialogTitle className="hidden">
-          Entity Class Editor
+          {t('entityTypeEditor.dialogTitle')}
         </DialogTitle>
-        
+
         <DialogDescription className="hidden">
-          Edit your entity class definition.
+          {t('entityTypeEditor.dialogDescription')}
         </DialogDescription>
 
         <Editor 

--- a/src/components/FixRelocatedManifest/FixRelocatedManifest.tsx
+++ b/src/components/FixRelocatedManifest/FixRelocatedManifest.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { DropdownMenuItem } from '@/ui/DropdownMenu';
 import { IIIFManifestResource } from '@/model';
 import { useFixRelocatedManifest } from './useFixedRelocatedManifest';
@@ -11,6 +12,8 @@ interface FixRelocatedManifestProps {
 }
 
 export const FixRelocatedManifest = (props: FixRelocatedManifestProps) => {
+
+  const { t } = useTranslation('common');
 
   const { fixRelocatedManifest } = useFixRelocatedManifest();
 
@@ -26,7 +29,7 @@ export const FixRelocatedManifest = (props: FixRelocatedManifestProps) => {
         e.preventDefault();
         setIsRepairDialogOpen(true)
       }}>
-        Fix Relocated Manifest
+        {t('fixRelocatedManifest.menuItem')}
       </DropdownMenuItem>
 
       <Dialog
@@ -36,7 +39,7 @@ export const FixRelocatedManifest = (props: FixRelocatedManifestProps) => {
           <input 
             value={newUrl}
             onChange={evt => setNewUrl(evt.target.value) }/>
-          <button onClick={() => onRepair()}>Ok</button>
+          <button onClick={() => onRepair()}>{t('fixRelocatedManifest.ok')}</button>
         </DialogContent>
       </Dialog>
     </>

--- a/src/components/FontSize/FontSizeButton.tsx
+++ b/src/components/FontSize/FontSizeButton.tsx
@@ -1,4 +1,5 @@
 import { ALargeSmall } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/ui/Button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ui/Tooltip';
 import { useState } from 'react';
@@ -13,6 +14,8 @@ interface FontSizeButtonProps {
 }
 
 export const FontSizeButton = (props: FontSizeButtonProps) => {
+
+  const { t } = useTranslation('common');
 
   const [currentSize, setCurrentSize] = useState<FontSize>('base');
 
@@ -40,7 +43,7 @@ export const FontSizeButton = (props: FontSizeButtonProps) => {
       </TooltipTrigger>
 
       <TooltipContent>
-        Change font size
+        {t('fontSize.changeFontSize')}
       </TooltipContent>
     </Tooltip>
   )

--- a/src/components/IIIFMetadataList/IIIFMetadataList.tsx
+++ b/src/components/IIIFMetadataList/IIIFMetadataList.tsx
@@ -1,4 +1,5 @@
 import { Annotation, CozyMetadata } from 'cozy-iiif';
+import { useTranslation } from 'react-i18next';
 import { IIIFCanvasAnnotationCard } from './IIIFCanvasAnnotationCard';
 
 interface IIIFMetadataListProps {
@@ -13,13 +14,15 @@ interface IIIFMetadataListProps {
 
 export const IIIFMetadataList = (props: IIIFMetadataListProps) => {
 
+  const { t } = useTranslation('common');
+
   const { annotations, metadata } = props;
 
   const isEmpty = ((annotations || []).length + props.metadata.length) === 0;
 
   return isEmpty ? (
     <div className="flex items-center justify-center h-full min-h-16 text-muted-foreground text-sm">
-      {props.emptyMessage || 'No IIIF Metadata'}
+      {props.emptyMessage || t('iiifMetadataList.noMetadata')}
     </div>
   ) : (
     <div>

--- a/src/components/MetadataForm/MetadataForm.tsx
+++ b/src/components/MetadataForm/MetadataForm.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { ToyBrick } from 'lucide-react';
 import { Link } from 'react-router-dom';
+import { Trans, useTranslation } from 'react-i18next';
 import { W3CAnnotationBody } from '@annotorious/react';
 import { MetadataSchema, PropertyDefinition } from '@/model';
 import { Separator } from '@/ui/Separator';
@@ -45,6 +46,8 @@ const parseBody = (body?: W3CAnnotationBody, properties?: PropertyDefinition[]) 
 }
 
 export const MetadataForm = (props: MetadataFormProps) => {
+
+  const { t } = useTranslation('common');
 
   const { metadata, schemas } = props;
 
@@ -93,9 +96,13 @@ export const MetadataForm = (props: MetadataFormProps) => {
   return (schemas.length === 0) ? (
     <div className="flex flex-col text-sm items-center px-2 justify-center text-center grow leading-loose text-muted-foreground">
       <span>
-        No schema defined.<br/>
-        Go to <Link to="/model" className="inline-block text-black hover:bg-muted px-1 rounded-sm"><ToyBrick className="inline h-4 w-4 align-text-top" /> Data Model</Link> to 
-        define one.
+        <Trans
+          ns="common"
+          i18nKey="metadataForm.noSchemaDefined"
+          components={{
+            modelLink: <Link to="/model" className="inline-block text-black hover:bg-muted px-1 rounded-sm" />,
+            icon: <ToyBrick className="inline h-4 w-4 align-text-top" />
+          }} />
       </span>
     </div>
   ) : metadata && (
@@ -103,7 +110,7 @@ export const MetadataForm = (props: MetadataFormProps) => {
       {(schemas.length > 1) && (
         <>
           <div className="flex gap-4 items-center">
-            <span className="font-medium">Schema</span>
+            <span className="font-medium">{t('metadataForm.schema')}</span>
     
             <Select value={selectedSchema?.name || ''} onValueChange={onChangeSchema}>
               <SelectTrigger className="grow whitespace-nowrap overflow-hidden">

--- a/src/components/MetadataSchemaEditor/MetadataSchemaEditor.tsx
+++ b/src/components/MetadataSchemaEditor/MetadataSchemaEditor.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { PropertyDefinitionEditorDialog, moveArrayItem } from '@/components/PropertyDefinitionEditor';
 import { MetadataSchema, PropertyDefinition } from '@/model';
 import { Button } from '@/ui/Button';
@@ -25,6 +26,8 @@ interface MetadataSchemaEditorProps {
 }
 
 export const MetadataSchemaEditor = (props: MetadataSchemaEditorProps) => {
+
+  const { t } = useTranslation('common');
 
   const [schema, setSchema] = useState<Partial<MetadataSchema>>(props.schema || {});
 
@@ -84,10 +87,10 @@ export const MetadataSchemaEditor = (props: MetadataSchemaEditorProps) => {
           <div className="mt-6">
             <Label 
               htmlFor="name"
-              className="inline-block text-xs mb-1.5 ml-0.5">Schema Name
+              className="inline-block text-xs mb-1.5 ml-0.5">{t('metadataSchemaEditor.schemaName')}
             </Label>
 
-            {errors.name_missing && (<span className="text-xs text-red-600 ml-1">required</span>)}
+            {errors.name_missing && (<span className="text-xs text-red-600 ml-1">{t('metadataSchemaEditor.required')}</span>)}
 
             <Input
               id="name"
@@ -97,11 +100,11 @@ export const MetadataSchemaEditor = (props: MetadataSchemaEditorProps) => {
 
             {schema.name && (!isNameAvailable ? (
               <span className="flex items-center text-xs mt-3 text-red-600 whitespace-nowrap">
-                <AlertCircle className="shrink-0 h-3.5 w-3.5 mb-0.5 ml-0.5 mr-1" /> Schema already exists
+                <AlertCircle className="shrink-0 h-3.5 w-3.5 mb-0.5 ml-0.5 mr-1" /> {t('metadataSchemaEditor.schemaExists')}
               </span>
             ) : ((props.schema && isNameAvailable) || !props.schema) && (
               <span className="flex items-center text-xs mt-2 text-green-600 whitespace-nowrap">
-                <CheckCircle2 className="shrink-0 h-3.5 w-3.5 mb-0.5 ml-0.5 mr-1" /> {schema.name} is available
+                <CheckCircle2 className="shrink-0 h-3.5 w-3.5 mb-0.5 ml-0.5 mr-1" /> {t('metadataSchemaEditor.nameAvailable', { name: schema.name })}
               </span>
             ))}
           </div>
@@ -109,7 +112,7 @@ export const MetadataSchemaEditor = (props: MetadataSchemaEditorProps) => {
           <div className="mt-6">
             <Label 
               htmlFor="description"
-              className="inline-block text-xs mb-1.5 ml-0.5">Schema Description</Label>
+              className="inline-block text-xs mb-1.5 ml-0.5">{t('metadataSchemaEditor.schemaDescription')}</Label>
 
             <Textarea 
               id="description"
@@ -127,7 +130,7 @@ export const MetadataSchemaEditor = (props: MetadataSchemaEditorProps) => {
                 schema={schema.properties || []}
                 onSave={addProperty}>
                 <Button className="flex items-center" variant="ghost">
-                  <PlusCircle className="h-4 w-4 mr-1.5" /> Add Property
+                  <PlusCircle className="h-4 w-4 mr-1.5" /> {t('metadataSchemaEditor.addProperty')}
                 </Button>
               </PropertyDefinitionEditorDialog>
             </div>
@@ -158,7 +161,7 @@ export const MetadataSchemaEditor = (props: MetadataSchemaEditorProps) => {
                   <Button 
                     variant="outline" 
                     className="text-xs mt-3 h-9 pl-2 px-3 font-medium hover:bg-muted-foreground/5">
-                    Add Property
+                    {t('metadataSchemaEditor.addProperty')}
                   </Button>
                 </PropertyDefinitionEditorDialog>
               </div>
@@ -166,7 +169,7 @@ export const MetadataSchemaEditor = (props: MetadataSchemaEditorProps) => {
           )}
 
           <Button className="w-full mt-7" onClick={onSave}>
-            <Rows3 className="w-4 h-4 mr-2" /> Save Schema
+            <Rows3 className="w-4 h-4 mr-2" /> {t('metadataSchemaEditor.saveSchema')}
           </Button>
         </div>
 

--- a/src/components/MetadataSchemaEditor/MetadataSchemaEditorDialog.tsx
+++ b/src/components/MetadataSchemaEditor/MetadataSchemaEditorDialog.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Dialog, DialogContent, DialogDescription, DialogTitle, DialogTrigger } from '@/ui/Dialog';
 import { MetadataSchemaEditor } from './MetadataSchemaEditor';
 import { MetadataSchema } from '@/model';
@@ -24,6 +25,8 @@ interface MetadataSchemaEditorDialogProps {
 }
 
 export const MetadataSchemaEditorDialog = (props: MetadataSchemaEditorDialogProps) => {
+
+  const { t } = useTranslation('common');
 
   const [open, setOpen] = useState(props.open);
 
@@ -56,7 +59,7 @@ export const MetadataSchemaEditorDialog = (props: MetadataSchemaEditorDialogProp
 
       <DialogContent className="p-0 max-w-3xl my-8 rounded-lg">
         <DialogTitle className="sr-only">
-          Edit Schema
+          {t('metadataSchemaEditor.dialogTitle')}
         </DialogTitle>
 
         <DialogDescription className="sr-only">

--- a/src/components/MetadataSchemaEditor/MetadataSchemaPreview.tsx
+++ b/src/components/MetadataSchemaEditor/MetadataSchemaPreview.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { MetadataSchema } from '@/model';
 import { EnumField, ExternalAuthorityField, GeoCoordinatesField, MeasurementField, NumberField, PropertyValidation, RangeField, TextField, URIField } from '../PropertyFields';
 
@@ -9,15 +10,17 @@ interface MetadataSchemaPreviewProps {
 
 export const MetadataSchemaPreview = (props: MetadataSchemaPreviewProps) => {
 
+  const { t } = useTranslation('common');
+
   return (
     <PropertyValidation>
       <div className="bg-muted px-12 py-6 border-l rounded-r-lg">
         <h2>
-          Preview
+          {t('metadataSchemaEditor.previewTitle')}
         </h2>
 
         <p className="text-left text-xs leading-relaxed mt-1 mb-6">
-          This is how the data entry form for your metadata schema will appear.
+          {t('metadataSchemaEditor.previewHint')}
         </p>
 
         <div>

--- a/src/components/MetadataTable/MetadataTable.tsx
+++ b/src/components/MetadataTable/MetadataTable.tsx
@@ -1,4 +1,5 @@
 import { CaseSensitive, ChevronsLeftRightEllipsis, Database, Hash, Link2, List, MapPin, Ruler } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { PropertyListTooltip } from '@/components/PropertyListTooltip';
 import { MetadataSchema, PropertyDefinition } from '@/model';
 import { MetadataTableActions } from './MetadataTableActions';
@@ -24,14 +25,16 @@ interface MetadataTableProps {
 
 export const MetadataTable = (props: MetadataTableProps) => {
 
+  const { t } = useTranslation('common');
+
   return (
     <div className="rounded-md border mt-6">
       <Table>
         <TableHeader className="text-xs">
           <TableRow>
-            <TableHead className="px-3 whitespace-nowrap">Schema</TableHead>
-            <TableHead className="px-2 whitespace-nowrap w-[280px]">Description</TableHead>
-            <TableHead className="px-2 whitespace-nowrap w-[340px]">Properties</TableHead>
+            <TableHead className="px-3 whitespace-nowrap">{t('metadataTable.schema')}</TableHead>
+            <TableHead className="px-2 whitespace-nowrap w-[280px]">{t('metadataTable.description')}</TableHead>
+            <TableHead className="px-2 whitespace-nowrap w-[340px]">{t('metadataTable.properties')}</TableHead>
             <TableHead></TableHead>
           </TableRow>
         </TableHeader>
@@ -42,7 +45,7 @@ export const MetadataTable = (props: MetadataTableProps) => {
               <TableCell
                 colSpan={6}
                 className="h-24 text-center text-muted-foreground">
-                No schemas defined
+                {t('metadataTable.noSchemas')}
               </TableCell>
             </TableRow>
           ) : props.schemas.map(schema => (

--- a/src/components/MetadataTable/MetadataTableActions.tsx
+++ b/src/components/MetadataTable/MetadataTableActions.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { ConfirmedDelete } from '@/components/ConfirmedDelete';
 import { Button } from '@/ui/Button';
 import { 
@@ -19,6 +20,8 @@ interface MetadataTableActionsProps {
 
 export const MetadataTableActions = (props: MetadataTableActionsProps) => {
 
+  const { t } = useTranslation('common');
+
   const [confirmDelete, setConfirmDelete] = useState(false);
 
   return (
@@ -32,19 +35,19 @@ export const MetadataTableActions = (props: MetadataTableActionsProps) => {
 
         <DropdownMenuContent sideOffset={-10}>
           <DropdownMenuItem className="text-xs" onSelect={props.onEditSchema}>
-            <Pencil size={16} className="inline text-muted-foreground relative -top-px mr-2" />Edit schema
+            <Pencil size={16} className="inline text-muted-foreground relative -top-px mr-2" />{t('metadataTable.editSchema')}
           </DropdownMenuItem>
 
           <DropdownMenuItem className="text-xs" onSelect={() => setConfirmDelete(true)}>
             <Trash2 size={16} className="inline text-red-400 relative -top-px mr-2" />
-            <span className="text-red-500">Delete schema</span>
+            <span className="text-red-500">{t('metadataTable.deleteSchema')}</span>
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
 
       <ConfirmedDelete
         open={confirmDelete}
-        message="This action will delete the schema permanently."
+        message={t('metadataTable.deleteMessage')}
         onConfirm={props.onDeleteSchema}
         onOpenChange={setConfirmDelete} />
     </>

--- a/src/components/ProgressDialog/ProgressDialog.tsx
+++ b/src/components/ProgressDialog/ProgressDialog.tsx
@@ -2,6 +2,7 @@ import { Dialog, DialogTitle, DialogContent } from '@/ui/Dialog';
 import { Progress } from '@/ui/Progress';
 import { DialogDescription } from '@radix-ui/react-dialog';
 import { ReactElement } from 'react';
+import { useTranslation } from 'react-i18next';
 
 interface ProgressDialogProps {
 
@@ -19,11 +20,13 @@ interface ProgressDialogProps {
 
 export const ProgressDialog = (props: ProgressDialogProps) => {
 
+  const { t } = useTranslation('common');
+
   return (
     <Dialog open={props.open}>
       <DialogContent closeIcon={false}>
         <DialogTitle className="flex items-center gap-2">
-          {props.icon} {props.title || 'Processing'}
+          {props.icon} {props.title || t('progressDialog.processing')}
         </DialogTitle>
 
         <div className="pb-4">

--- a/src/components/PropertyDefinitionEditor/EnumOptions/AddOption.tsx
+++ b/src/components/PropertyDefinitionEditor/EnumOptions/AddOption.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/ui/Button';
 import { Input } from '@/ui/Input';
 
@@ -9,6 +10,8 @@ interface AddOptionProps {
 }
 
 export const AddOption = (props: AddOptionProps) => {
+
+  const { t } = useTranslation('common');
 
   const [value, setValue] = useState('');
 
@@ -36,7 +39,7 @@ export const AddOption = (props: AddOptionProps) => {
         variant="outline"
         onClick={onAddOption}
         type="button">
-        Add
+        {t('propertyDefinitionEditor.add')}
       </Button>
     </>
   )

--- a/src/components/PropertyDefinitionEditor/EnumOptions/EnumOptions.tsx
+++ b/src/components/PropertyDefinitionEditor/EnumOptions/EnumOptions.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/ui/Button';
 import { X } from 'lucide-react';
 import { AddOption } from './AddOption';
@@ -12,6 +13,8 @@ interface EnumOptionsProps {
 }
 
 export const EnumOptions = (props: EnumOptionsProps) => {
+
+  const { t } = useTranslation('common');
 
   const { definition } = props;
 
@@ -35,7 +38,7 @@ export const EnumOptions = (props: EnumOptionsProps) => {
       <div className="mt-1 mb-2 col-span-5">
         {!(definition.values?.length > 0) ? (
           <div className="flex py-3 text-muted-foreground text-xs justify-center">
-            Add at least one option.
+            {t('propertyDefinitionEditor.addAtLeastOneOption')}
           </div>
         ) : (
           <ul className="px-2 text-xs text-muted-foreground">

--- a/src/components/PropertyDefinitionEditor/ExternalAuthorityOptions/ExternalAuthorityOptions.tsx
+++ b/src/components/PropertyDefinitionEditor/ExternalAuthorityOptions/ExternalAuthorityOptions.tsx
@@ -1,4 +1,5 @@
 import { AlertCircle, AlertTriangle } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { ExternalAuthority } from '@/model/ExternalAuthority';
 import { useRuntimeConfig } from '@/RuntimeConfig';
 import { Checkbox } from '@/ui/Checkbox';
@@ -13,6 +14,8 @@ interface ExternalAuthorityOptionsProps {
 }
 
 export const ExternalAuthorityOptions = (props: ExternalAuthorityOptionsProps) => {
+
+  const { t } = useTranslation('common');
 
   const { authorities } = useRuntimeConfig();
 
@@ -61,7 +64,7 @@ export const ExternalAuthorityOptions = (props: ExternalAuthorityOptionsProps) =
                   {authority.name}
 
                   {!hasValidConfiguration(authority) && (
-                    <span title="Autority is not configured correctly">
+                    <span title={t('propertyDefinitionEditor.authorityMisconfigured')}>
                       <AlertTriangle 
                         className="ml-1 h-4 w-4 text-orange-500" />
                     </span>
@@ -82,7 +85,7 @@ export const ExternalAuthorityOptions = (props: ExternalAuthorityOptionsProps) =
       {(props.definition.authorities || []).length === 0 && (
         <span className="inline-flex ml-1.5 text-xs text-red-600
           font-medium mt-3 mb-1">
-          <AlertCircle className="h-3.5 w-3.5 mr-2.5" />  Select at least one authority
+          <AlertCircle className="h-3.5 w-3.5 mr-2.5" />  {t('propertyDefinitionEditor.selectAtLeastOneAuthority')}
         </span>
       )}
     </div>

--- a/src/components/PropertyDefinitionEditor/PropertyDefinitionActions.tsx
+++ b/src/components/PropertyDefinitionEditor/PropertyDefinitionActions.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { ArrowUp, ArrowDown, MoreHorizontal, Pencil, X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { PropertyDefinitionEditorDialog } from '@/components/PropertyDefinitionEditor';
 import { PropertyDefinition } from '@/model';
 import { Button } from '@/ui/Button';
@@ -30,7 +31,9 @@ interface PropertyDefinitionActionsProps {
 
 }
 
-export const PropertyDefinitionActions = (props: PropertyDefinitionActionsProps) => {  
+export const PropertyDefinitionActions = (props: PropertyDefinitionActionsProps) => {
+
+  const { t } = useTranslation('common');
 
   const [open, setOpen] = useState(false);
 
@@ -53,11 +56,11 @@ export const PropertyDefinitionActions = (props: PropertyDefinitionActionsProps)
       <DropdownMenuContent
         onEscapeKeyDown={() => setOpen(false)}>
         <DropdownMenuItem className="text-xs" onSelect={andClose(props.onMoveUp)}>
-          <ArrowUp className="h-4 w-4 mr-2 text-muted-foreground" /> Move up
+          <ArrowUp className="h-4 w-4 mr-2 text-muted-foreground" /> {t('propertyDefinitionEditor.moveUp')}
         </DropdownMenuItem>
 
         <DropdownMenuItem className="text-xs" onSelect={andClose(props.onMoveDown)}>
-          <ArrowDown className="h-4 w-4 mr-2 text-muted-foreground" /> Move down
+          <ArrowDown className="h-4 w-4 mr-2 text-muted-foreground" /> {t('propertyDefinitionEditor.moveDown')}
         </DropdownMenuItem>
 
         <PropertyDefinitionEditorDialog
@@ -69,12 +72,12 @@ export const PropertyDefinitionActions = (props: PropertyDefinitionActionsProps)
           onClose={() => setOpen(false)}>
 
           <DropdownMenuItem className="text-xs">
-            <Pencil className="h-4 w-4 mr-2 text-muted-foreground" /> Edit
+            <Pencil className="h-4 w-4 mr-2 text-muted-foreground" /> {t('propertyDefinitionEditor.edit')}
           </DropdownMenuItem>
         </PropertyDefinitionEditorDialog>
 
         <DropdownMenuItem className="text-xs" onSelect={andClose(props.onDeleteProperty)}>
-          <X className="h-4 w-4 mr-2 text-red-500" /> <span className="text-red-500">Delete</span>
+          <X className="h-4 w-4 mr-2 text-red-500" /> <span className="text-red-500">{t('propertyDefinitionEditor.delete')}</span>
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/components/PropertyDefinitionEditor/PropertyDefinitionEditor.tsx
+++ b/src/components/PropertyDefinitionEditor/PropertyDefinitionEditor.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { CaseSensitive, ChevronsLeftRightEllipsis, Database, Hash, Link2, List, MapPin, Palette, Ruler, Spline } from 'lucide-react';
 import { DialogDescription } from '@radix-ui/react-dialog';
 import { PropertyDefinition } from '@/model';
@@ -34,6 +35,8 @@ interface PropertyDefinitionEditorProps {
 }
 
 export const PropertyDefinitionEditor = (props: PropertyDefinitionEditorProps) => {
+
+  const { t } = useTranslation('common');
 
   const [edited, setEdited] = useState<Partial<PropertyDefinition>>(props.property || {});
 
@@ -84,10 +87,10 @@ export const PropertyDefinitionEditor = (props: PropertyDefinitionEditorProps) =
             <Label 
               htmlFor="name"
               className="inline-block text-xs mb-1.5 ml-0.5">
-              Property Name
+              {t('propertyDefinitionEditor.propertyName')}
             </Label>
 
-            {nameError && (<span className="text-xs text-red-600 ml-2">Property name already exists</span>)}
+            {nameError && (<span className="text-xs text-red-600 ml-2">{t('propertyDefinitionEditor.propertyNameExists')}</span>)}
 
             <Input 
               id="name" 
@@ -100,7 +103,7 @@ export const PropertyDefinitionEditor = (props: PropertyDefinitionEditorProps) =
             <Label 
               htmlFor="type"
               className="inline-block text-xs mb-1.5 ml-0.5">
-              Data Type
+              {t('propertyDefinitionEditor.dataType')}
             </Label>
 
             <Select
@@ -112,31 +115,31 @@ export const PropertyDefinitionEditor = (props: PropertyDefinitionEditorProps) =
 
               <SelectContent>
                 <SelectItem value="text">
-                  <CaseSensitive className="inline w-4 h-4 mr-1" /> Text
+                  <CaseSensitive className="inline w-4 h-4 mr-1" /> {t('propertyDefinitionEditor.typeText')}
                 </SelectItem>
                 <SelectItem value="number">
-                  <Hash className="inline w-4 h-4 mr-1.5 mb-0.5" /> Number
+                  <Hash className="inline w-4 h-4 mr-1.5 mb-0.5" /> {t('propertyDefinitionEditor.typeNumber')}
                 </SelectItem>
                 <SelectItem value="enum">
-                  <List className="inline w-4 h-4 mr-1.5 mb-0.5" /> Options
+                  <List className="inline w-4 h-4 mr-1.5 mb-0.5" /> {t('propertyDefinitionEditor.typeOptions')}
                 </SelectItem>
                 <SelectItem value="range">
-                  <ChevronsLeftRightEllipsis className="inline w-4 h-4 mr-1.5 mb-0.5" /> Number Range
+                  <ChevronsLeftRightEllipsis className="inline w-4 h-4 mr-1.5 mb-0.5" /> {t('propertyDefinitionEditor.typeNumberRange')}
                 </SelectItem>
                 <SelectItem value="uri">
-                  <Link2 className="inline w-4 h-4 mr-1.5 mb-0.5" /> URI
+                  <Link2 className="inline w-4 h-4 mr-1.5 mb-0.5" /> {t('propertyDefinitionEditor.typeUri')}
                 </SelectItem>
                 <SelectItem value="geocoordinate">
-                  <MapPin className="inline w-4 h-4 mr-1.5 mb-0.5" /> Geo-coordinates
+                  <MapPin className="inline w-4 h-4 mr-1.5 mb-0.5" /> {t('propertyDefinitionEditor.typeGeoCoordinates')}
                 </SelectItem>
                 <SelectItem value="measurement">
-                  <Ruler className="inline w-4 h-4 mr-1.5 mb-0.5" /> Measurement
+                  <Ruler className="inline w-4 h-4 mr-1.5 mb-0.5" /> {t('propertyDefinitionEditor.typeMeasurement')}
                 </SelectItem>
                 <SelectItem value="color">
-                  <Palette className="inline w-4 h-4 mr-1.5 mb-0.5" /> Color
+                  <Palette className="inline w-4 h-4 mr-1.5 mb-0.5" /> {t('propertyDefinitionEditor.typeColor')}
                 </SelectItem>
                 <SelectItem value="external_authority">
-                  <Database className="inline w-4 h-4 mr-1.5 mb-0.5" /> External Authority
+                  <Database className="inline w-4 h-4 mr-1.5 mb-0.5" /> {t('propertyDefinitionEditor.typeExternalAuthority')}
                 </SelectItem>
               </SelectContent>
             </Select>
@@ -159,13 +162,13 @@ export const PropertyDefinitionEditor = (props: PropertyDefinitionEditorProps) =
           <div className="text-xs flex items-center pt-4 pb-4 px-0.5 gap-3">
             <Switch 
               checked={Boolean(edited.multiple)}
-              onCheckedChange={onCheckMultiple}/> Allow multiple values
+              onCheckedChange={onCheckMultiple}/> {t('propertyDefinitionEditor.allowMultipleValues')}
           </div>
 
           <div className="mt-3">
             <Label 
               htmlFor="description"
-              className="inline-block text-xs mb-1.5 ml-0.5">Property Description</Label>
+              className="inline-block text-xs mb-1.5 ml-0.5">{t('propertyDefinitionEditor.propertyDescription')}</Label>
 
             <Textarea 
               id="description"
@@ -176,7 +179,7 @@ export const PropertyDefinitionEditor = (props: PropertyDefinitionEditorProps) =
           </div>
 
           <div className="mt-5 mb-3 sm:justify-start">
-            <Button type="button" onClick={onSubmit}>Save Property</Button>
+            <Button type="button" onClick={onSubmit}>{t('propertyDefinitionEditor.saveProperty')}</Button>
           </div>
         </form>
       </div>

--- a/src/components/PropertyDefinitionEditor/PropertyDefinitionEditorDialog.tsx
+++ b/src/components/PropertyDefinitionEditor/PropertyDefinitionEditorDialog.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { DialogTitle } from '@radix-ui/react-dialog';
 import { PropertyDefinition } from '@/model';
 import { PropertyDefinitionEditor } from './PropertyDefinitionEditor';
@@ -28,6 +29,8 @@ interface PropertyEditorDialogProps {
 
 export const PropertyDefinitionEditorDialog = (props: PropertyEditorDialogProps) => {
 
+  const { t } = useTranslation('common');
+
   const [open, setOpen] = useState(false);
 
   const onUpdate = (property: PropertyDefinition) => {
@@ -54,7 +57,7 @@ export const PropertyDefinitionEditorDialog = (props: PropertyEditorDialogProps)
 
       <DialogContent className="p-0 max-w-4xl my-8 rounded-lg">
         <DialogTitle className="hidden">
-          Property Definition Editor
+          {t('propertyDefinitionEditor.dialogTitle')}
         </DialogTitle>
 
         <PropertyDefinitionEditor 

--- a/src/components/PropertyDefinitionEditor/PropertyPreview.tsx
+++ b/src/components/PropertyDefinitionEditor/PropertyPreview.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { EnumPropertyDefinition, PropertyDefinition } from '@/model';
 import { Label } from '@/ui/Label';
 import { 
@@ -23,6 +24,8 @@ interface PropertyPreviewProps {
 
 export const PropertyPreview = (props: PropertyPreviewProps) => {
 
+  const { t } = useTranslation('common');
+
   const stub = props.property;
 
   const preview = {
@@ -33,7 +36,7 @@ export const PropertyPreview = (props: PropertyPreviewProps) => {
   return (
     <div className="bg-muted px-8 py-4 border-l col-span-2">
       <h2 className="font-medium">
-        Property Preview
+        {t('propertyDefinitionEditor.previewTitle')}
       </h2>
 
       <p className="text-left text-xs leading-relaxed mt-1 mb-12">

--- a/src/components/PropertyDefinitionEditor/TextOptions/TextOptions.tsx
+++ b/src/components/PropertyDefinitionEditor/TextOptions/TextOptions.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { TextPropertyDefinition } from '@/model';
 import { Switch } from '@/ui/Switch';
 
@@ -11,6 +12,8 @@ interface TextOptionsProps {
 
 export const TextOptions = (props: TextOptionsProps) => {
 
+  const { t } = useTranslation('common');
+
   const { definition, onUpdate } = props;
 
   const onToggleSize = (large: boolean) => large 
@@ -21,9 +24,9 @@ export const TextOptions = (props: TextOptionsProps) => {
     <div className="text-xs flex items-center pt-4 px-0.5 gap-3">
       <Switch 
         checked={props.definition.size === 'L'}
-        onCheckedChange={onToggleSize} /> 
+        onCheckedChange={onToggleSize} />
 
-      Display as multi-line text field
+      {t('propertyDefinitionEditor.multiLine')}
     </div>
   )
 

--- a/src/components/PropertyFields/BasePropertyField.tsx
+++ b/src/components/PropertyFields/BasePropertyField.tsx
@@ -1,5 +1,6 @@
 import { useState, ReactNode, useEffect } from 'react';
 import { CopyPlus } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { PropertyDefinition } from '@/model';
 import { Label } from '@/ui/Label';
 import { InfoTooltip } from './InfoTooltip';
@@ -24,6 +25,8 @@ interface BasePropertyFieldProps <T extends unknown> {
 }
 
 export const BasePropertyField = <T extends unknown>(props: BasePropertyFieldProps<T>) => {
+
+  const { t } = useTranslation('common');
 
   const { definition } = props;
 
@@ -80,7 +83,7 @@ export const BasePropertyField = <T extends unknown>(props: BasePropertyFieldPro
             className="self-end flex gap-1 items-center text-xs text-muted-foreground mt-0.5 mr-0.5"
             onClick={onAppendField}
             type="button">
-            <CopyPlus className="h-3.5 w-3.5 mb-0.5 mr-0.5" /> Add value
+            <CopyPlus className="h-3.5 w-3.5 mb-0.5 mr-0.5" /> {t('propertyFields.addValue')}
           </button>
         )}
       </div>

--- a/src/components/PropertyFields/ColorField/ColorField.tsx
+++ b/src/components/PropertyFields/ColorField/ColorField.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { PropertyDefinition } from '@/model';
 import { isValidColor } from '@/utils/color';
 import { BasePropertyField } from '../BasePropertyField';
@@ -23,6 +24,8 @@ interface ColorFieldProps {
 }
 
 export const ColorField = (props: ColorFieldProps) => {
+
+  const { t } = useTranslation('common');
 
   const { id, definition } = props;
 
@@ -52,7 +55,7 @@ export const ColorField = (props: ColorFieldProps) => {
   const onSample = (isSampling: boolean) =>
     setSamplingCount(prev => isSampling ? prev + 1 : Math.max(0, prev - 1));
 
-  const error = showErrors && !isValid && 'invalid color code';
+  const error = showErrors && !isValid && t('propertyFields.invalidColor');
 
   return (
     <BasePropertyField

--- a/src/components/PropertyFields/ColorField/ColorFieldInput.tsx
+++ b/src/components/PropertyFields/ColorField/ColorFieldInput.tsx
@@ -1,4 +1,5 @@
 import { CSSProperties, useEffect, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import chroma from 'chroma-js';
 import { X } from 'lucide-react';
 import { Button } from '@/ui/Button';
@@ -21,6 +22,8 @@ interface ColorFieldInputProps {
 }
 
 export const ColorFieldInput = (props: ColorFieldInputProps) => {
+
+  const { t } = useTranslation('common');
 
   const value = props.onChange ? props.value || '' : props.value;
 
@@ -63,7 +66,7 @@ export const ColorFieldInput = (props: ColorFieldInputProps) => {
           <div 
             className="h-9 bg-transparent text-muted-foreground rounded-md items-center text-sm flex justify-center border border-input border-dashed"
             style={{ backgroundColor: value }}>
-            Pick a color...
+            {t('propertyFields.pickColor')}
           </div>
         ) : ( 
           <Input 

--- a/src/components/PropertyFields/ExternalAuthorityField/ExternalAuthorityField.tsx
+++ b/src/components/PropertyFields/ExternalAuthorityField/ExternalAuthorityField.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { CopyPlus, Info } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { useRuntimeConfig } from '@/RuntimeConfig';
 import { ExternalAuthorityPropertyDefinition } from '@/model';
 import { Label } from '@/ui/Label';
@@ -29,6 +30,8 @@ interface ExternalAuthorityFieldProps {
 }
 
 export const ExternalAuthorityField = (props: ExternalAuthorityFieldProps) => {
+
+  const { t } = useTranslation('common');
 
   const { id, definition } = props;
 
@@ -143,7 +146,7 @@ export const ExternalAuthorityField = (props: ExternalAuthorityFieldProps) => {
             className="self-end flex gap-1 items-center text-xs text-muted-foreground mt-0.5 mr-0.5"
             type="button"
             onClick={onAppendField}>
-            <CopyPlus className="h-3.5 w-3.5 mb-0.5 mr-0.5" /> Add value
+            <CopyPlus className="h-3.5 w-3.5 mb-0.5 mr-0.5" /> {t('propertyFields.addValue')}
           </button>
         )}
       </div>

--- a/src/components/PropertyFields/ExternalAuthorityField/dialogs/IFrameAuthorityDialog.tsx
+++ b/src/components/PropertyFields/ExternalAuthorityField/dialogs/IFrameAuthorityDialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Database, ExternalLink } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/ui/Dialog';
 import { Input } from '@/ui/Input';
 import { ExternalAuthority, findMatchingPattern } from '@/model/ExternalAuthority';
@@ -15,6 +16,8 @@ interface IFrameAuthorityDialogProps {
 } 
 
 export const IFrameAuthorityDialog = (props: IFrameAuthorityDialogProps) => {
+
+  const { t } = useTranslation('common');
 
   const iframe = useRef<HTMLIFrameElement>(null);
 
@@ -94,7 +97,7 @@ export const IFrameAuthorityDialog = (props: IFrameAuthorityDialogProps) => {
         <div className="relative mt-2">
           <Input
             className="h-9"
-            placeholder={`Search ${authority.name}...`} 
+            placeholder={t('propertyFields.searchAuthorityPlaceholder', { name: authority.name })}
             value={query}
             onChange={evt => setQuery(evt.target.value)} />
 

--- a/src/components/PropertyFields/GeoCoordinatesField/GeoCoordinatesField.tsx
+++ b/src/components/PropertyFields/GeoCoordinatesField/GeoCoordinatesField.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { CopyPlus } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { PropertyDefinition } from '@/model';
 import { Label } from '@/ui/Label';
 import { InfoTooltip } from '../InfoTooltip';
@@ -37,6 +38,8 @@ const stringify = (coords?: [number, number] | [number, number][]): [string, str
 
 
 export const GeoCoordinatesField = (props: GeoCoordinatesFieldProps) => {
+
+  const { t } = useTranslation('common');
 
   const { definition } = props;
 
@@ -76,7 +79,7 @@ export const GeoCoordinatesField = (props: GeoCoordinatesFieldProps) => {
     }
   }, [values, isValid]);
 
-  const error = showErrors && !isValid && 'must be valid coordinates';
+  const error = showErrors && !isValid && t('propertyFields.invalidCoordinates');
 
   const onChange = (idx: number, updated: [string, string]) =>
     setValues(current => current.map((v, i) => i === idx ? updated : v));
@@ -120,7 +123,7 @@ export const GeoCoordinatesField = (props: GeoCoordinatesFieldProps) => {
             className="self-end flex gap-1 items-center text-xs text-muted-foreground mt-0.5 mr-0.5"
             type="button"
             onClick={onAppendField}>
-            <CopyPlus className="h-3.5 w-3.5 mb-0.5 mr-0.5" /> Add value
+            <CopyPlus className="h-3.5 w-3.5 mb-0.5 mr-0.5" /> {t('propertyFields.addValue')}
           </button>
         )}
       </div>

--- a/src/components/PropertyFields/GeoCoordinatesField/GeoCoordinatesFieldInput.tsx
+++ b/src/components/PropertyFields/GeoCoordinatesField/GeoCoordinatesFieldInput.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Input } from '@/ui/Input';
 import { cn } from '@/ui/utils';
 import { PropertyDefinition } from '@/model';
@@ -21,6 +22,8 @@ interface GeoCoordinatesFieldInputProps {
 
 export const GeoCoordinatesFieldInput = (props: GeoCoordinatesFieldInputProps) => {
 
+  const { t } = useTranslation('common');
+
   const [latStr, lngStr] = props.value ? props.value : ['', ''];
 
   const className = cn(props.className, (props.error ? 'mt-0.5 outline-red-500 border-red-500' : 'mt-0.5'));
@@ -29,7 +32,7 @@ export const GeoCoordinatesFieldInput = (props: GeoCoordinatesFieldInputProps) =
     <div className="flex items-center gap-2.5">
       <Input 
         className={className} 
-        placeholder="Lat..."
+        placeholder={t('propertyFields.latPlaceholder')}
         value={latStr} 
         onChange={evt => props.onChange([evt.target.value, lngStr])} />
 
@@ -37,7 +40,7 @@ export const GeoCoordinatesFieldInput = (props: GeoCoordinatesFieldInputProps) =
 
       <Input 
         className={className} 
-        placeholder="Lng..."
+        placeholder={t('propertyFields.lngPlaceholder')}
         value={lngStr} 
         onChange={evt => props.onChange([latStr, evt.target.value])} />
     </div>

--- a/src/components/PropertyFields/InheritedFrom.tsx
+++ b/src/components/PropertyFields/InheritedFrom.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { PropertyDefinition } from '@/model';
 import { Replace } from 'lucide-react';
 import { useDataModel } from '@/store';
@@ -19,6 +20,8 @@ interface InheritedFromProps {
 
 export const InheritedFrom = (props: InheritedFromProps) => {
 
+  const { t } = useTranslation('common');
+
   const model = useDataModel();
 
   const inheritedFrom = model.getEntityType(props.definition.inheritedFrom, false);
@@ -38,7 +41,7 @@ export const InheritedFrom = (props: InheritedFromProps) => {
           align="end" 
           alignOffset={-10}
           sideOffset={-6}>
-          <span className="text-white/70">Inherited from</span> <span>{inheritedFrom.label || inheritedFrom.id}</span>
+          <span className="text-white/70">{t('propertyFields.inheritedFrom')}</span> <span>{inheritedFrom.label || inheritedFrom.id}</span>
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>

--- a/src/components/PropertyFields/MeasurementField/MeasurementField.tsx
+++ b/src/components/PropertyFields/MeasurementField/MeasurementField.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { PropertyDefinition } from '@/model';
 import { Label } from '@/ui/Label';
 import { InfoTooltip } from '../InfoTooltip';
@@ -32,6 +33,8 @@ const stringify = (m?: Measurement | Measurement[]): [string, string][] => {
 }
 
 export const MeasurementField = (props: MeasurementFieldProps) => {
+
+  const { t } = useTranslation('common');
 
   const { definition } = props;
 
@@ -69,7 +72,7 @@ export const MeasurementField = (props: MeasurementFieldProps) => {
     }
   }, [values, isValid]);
 
-  const error = showErrors && !isValid && 'number value and unit required';
+  const error = showErrors && !isValid && t('propertyFields.measurementRequired');
 
   const onChange = (idx: number, updated: [string, string]) =>
     setValues(current => current.map((v, i) => i === idx ? updated : v));
@@ -111,7 +114,7 @@ export const MeasurementField = (props: MeasurementFieldProps) => {
             className="self-end flex gap-1 items-center text-xs text-muted-foreground mt-0.5 mr-0.5"
             type="button"
             onClick={onAppendField}>
-            <CopyPlus className="h-3.5 w-3.5 mb-0.5 mr-0.5" /> Add value
+            <CopyPlus className="h-3.5 w-3.5 mb-0.5 mr-0.5" /> {t('propertyFields.addValue')}
           </button>
         )}
       </div>

--- a/src/components/PropertyFields/MeasurementField/MeasurementFieldInput.tsx
+++ b/src/components/PropertyFields/MeasurementField/MeasurementFieldInput.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Input } from '@/ui/Input';
 import { cn } from '@/ui/utils';
 
@@ -15,6 +16,8 @@ interface MeasurementFieldInputProps {
 
 export const MeasurementFieldInput = (props: MeasurementFieldInputProps) => {
 
+  const { t } = useTranslation('common');
+
   const [valueStr, unit] = props.value ? props.value : ['', ''];
 
   const className = cn(props.className, (props.error ? 'mt-0.5 outline-red-500 border-red-500' : 'mt-0.5'));
@@ -24,7 +27,7 @@ export const MeasurementFieldInput = (props: MeasurementFieldInputProps) => {
       <div className="col-span-3">
         <Input 
           className={className} 
-          placeholder="Value..."
+          placeholder={t('propertyFields.valuePlaceholder')}
           value={valueStr} 
           onChange={evt => props.onChange([evt.target.value, unit])} />
       </div>
@@ -32,7 +35,7 @@ export const MeasurementFieldInput = (props: MeasurementFieldInputProps) => {
       <div>
         <Input 
           className={className} 
-          placeholder="Unit..."
+          placeholder={t('propertyFields.unitPlaceholder')}
           value={unit} 
           onChange={evt => props.onChange([valueStr, evt.target.value])} />
       </div>

--- a/src/components/PropertyFields/NumberField/NumberField.tsx
+++ b/src/components/PropertyFields/NumberField/NumberField.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { PropertyDefinition } from '@/model';
 import { Input } from '@/ui/Input';
 import { BasePropertyField } from '../BasePropertyField';
@@ -31,6 +32,8 @@ const toString = (value?: number | number[]) => {
 
 export const NumberField = (props: NumberFieldProps) => {
 
+  const { t } = useTranslation('common');
+
   const { id, definition } = props;
 
   const [value, setValue] = useState<string | string[]>(toString(props.value));
@@ -61,8 +64,8 @@ export const NumberField = (props: NumberFieldProps) => {
     }
   }, [value]);
 
-  const error = (showErrors && !isValid) 
-    ? value ? 'must be a number' : 'required' : '';
+  const error = (showErrors && !isValid)
+    ? value ? t('propertyFields.mustBeNumber') : t('propertyFields.required') : '';
 
   const className = cn(props.className, (error ? 'mt-0.5 outline-red-500 border-red-500' : 'mt-0.5'));
 

--- a/src/components/PropertyFields/RangeField/RangeField.tsx
+++ b/src/components/PropertyFields/RangeField/RangeField.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { CopyPlus } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { PropertyDefinition } from '@/model';
 import { Label } from '@/ui/Label';
 import { InfoTooltip } from '../InfoTooltip';
@@ -37,6 +38,8 @@ const stringify = (ranges?: [number, number] | [number, number][]): [string, str
 
 
 export const RangeField = (props: RangeFieldProps) => {
+
+  const { t } = useTranslation('common');
 
   const { definition } = props;
 
@@ -86,7 +89,7 @@ export const RangeField = (props: RangeFieldProps) => {
     }
   }, [values, isValid]);
 
-  const error = showErrors && !isValid && 'must be valid range';
+  const error = showErrors && !isValid && t('propertyFields.invalidRange');
 
   const onChange = (idx: number, updated: [string, string]) =>
     setValues(current => current.map((v, i) => i === idx ? updated : v));
@@ -129,7 +132,7 @@ export const RangeField = (props: RangeFieldProps) => {
             className="self-end flex gap-1 items-center text-xs text-muted-foreground mt-0.5 mr-0.5"
             type="button"
             onClick={onAppendField}>
-            <CopyPlus className="h-3.5 w-3.5 mb-0.5 mr-0.5" /> Add value
+            <CopyPlus className="h-3.5 w-3.5 mb-0.5 mr-0.5" /> {t('propertyFields.addValue')}
           </button>
         )}
       </div>

--- a/src/components/PropertyFields/RangeField/RangeFieldInput.tsx
+++ b/src/components/PropertyFields/RangeField/RangeFieldInput.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Input } from '@/ui/Input';
 import { cn } from '@/ui/utils';
 import { PropertyDefinition } from '@/model';
@@ -19,6 +20,8 @@ interface RangeFieldInputProps {
 
 export const RangeFieldInput = (props: RangeFieldInputProps) => {
 
+  const { t } = useTranslation('common');
+
   const [startStr, endStr] = props.value ? props.value : ['', ''];
 
   const className = cn(props.className, (props.error ? 'mt-0.5 outline-red-500 border-red-500' : 'mt-0.5'));
@@ -27,7 +30,7 @@ export const RangeFieldInput = (props: RangeFieldInputProps) => {
     <div className="flex items-center gap-2.5">
       <Input 
         className={className} 
-        placeholder="Start..."
+        placeholder={t('propertyFields.startPlaceholder')}
         value={startStr} 
         onChange={evt => props.onChange([evt.target.value, endStr])} />
 
@@ -35,7 +38,7 @@ export const RangeFieldInput = (props: RangeFieldInputProps) => {
 
       <Input 
         className={className} 
-        placeholder="End..."
+        placeholder={t('propertyFields.endPlaceholder')}
         value={endStr} 
         onChange={evt => props.onChange([startStr, evt.target.value])} />
     </div>

--- a/src/components/PropertyFields/TextField/TextField.tsx
+++ b/src/components/PropertyFields/TextField/TextField.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { CopyPlus } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { TextPropertyDefinition } from '@/model';
 import { Label } from '@/ui/Label';
 import { InfoTooltip } from '../InfoTooltip';
@@ -22,6 +23,8 @@ interface TextFieldProps {
 }
 
 export const TextField = (props: TextFieldProps) => {
+
+  const { t } = useTranslation('common');
 
   const { definition } = props;
 
@@ -77,7 +80,7 @@ export const TextField = (props: TextFieldProps) => {
             className="self-end flex gap-1 items-center text-xs text-muted-foreground mt-0.5 mr-0.5"
             onClick={onAppendField}
             type="button">
-            <CopyPlus className="h-3.5 w-3.5 mb-0.5 mr-0.5" /> Add value
+            <CopyPlus className="h-3.5 w-3.5 mb-0.5 mr-0.5" /> {t('propertyFields.addValue')}
           </button>
         )}
       </div>

--- a/src/components/PropertyFields/TextField/TextFieldInput.tsx
+++ b/src/components/PropertyFields/TextField/TextFieldInput.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import TextareaAutosize from 'react-textarea-autosize';
 import { FontSize, FontSizeButton } from '@/components/FontSize';
 import { TranslateButton, Translation, TranslationArgs, TranslationSettings } from '@/components/Translation';
@@ -24,6 +25,8 @@ interface TextFieldInputProps {
 }
 
 export const TextFieldInput = (props: TextFieldInputProps) => {
+
+  const { t } = useTranslation('common');
 
   const { definition } = props;
 
@@ -81,7 +84,7 @@ export const TextFieldInput = (props: TextFieldInputProps) => {
             className="flex gap-1 items-center text-xs text-muted-foreground ml-1"
             onClick={props.onAppendField}
             type="button">
-            <CopyPlus className="h-3.5 w-3.5 mb-0.5 mr-0.5" /> Add value
+            <CopyPlus className="h-3.5 w-3.5 mb-0.5 mr-0.5" /> {t('propertyFields.addValue')}
           </button>
         )}
       </div>

--- a/src/components/PropertyFields/URIField/URIField.tsx
+++ b/src/components/PropertyFields/URIField/URIField.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Pen } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { PropertyDefinition } from '@/model';
 import { Input } from '@/ui/Input';
 import { BasePropertyField } from '../BasePropertyField';
@@ -22,6 +23,8 @@ interface URIFieldProps {
 }
 
 export const URIField = (props: URIFieldProps) => {
+
+  const { t } = useTranslation('common');
 
   const { id, definition } = props;
 
@@ -50,7 +53,7 @@ export const URIField = (props: URIFieldProps) => {
     }
   }, [props.value]);
 
-  const error = showErrors && props.value && !isValid && 'must be a URI';
+  const error = showErrors && props.value && !isValid && t('propertyFields.mustBeURI');
 
   const className = cn(props.className, (error ? 'mt-0.5 outline-red-500 border-red-500' : 'mt-0.5'));
 

--- a/src/components/RelationshipTypeEditor/RelationshipTypeEditor.tsx
+++ b/src/components/RelationshipTypeEditor/RelationshipTypeEditor.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { RelationshipType } from '@/model';
 import { useDataModel } from '@/store';
 import { Button } from '@/ui/Button';
@@ -23,6 +24,8 @@ interface RelationshipTypeEditorProps {
 }
 
 export const RelationshipTypeEditor = (props: RelationshipTypeEditorProps) => {
+
+  const { t } = useTranslation('common');
 
   const { relationshipType } = props;
 
@@ -62,9 +65,9 @@ export const RelationshipTypeEditor = (props: RelationshipTypeEditorProps) => {
           toast({
             variant: 'destructive',
             // @ts-ignore
-            title: <ToastTitle className="flex"><XCircle size={18} className="mr-2" /> Error</ToastTitle>,
-            description: 'Something went wrong. Could not save entity type.'
-          });  
+            title: <ToastTitle className="flex"><XCircle size={18} className="mr-2" /> {t('relationshipTypeEditor.errorTitle')}</ToastTitle>,
+            description: t('relationshipTypeEditor.saveError')
+          });
         });
     }
 
@@ -111,17 +114,17 @@ export const RelationshipTypeEditor = (props: RelationshipTypeEditorProps) => {
 
       <DialogContent className="px-8 py-3 max-md my-8 rounded-lg">
         <DialogTitle className="hidden">
-          New Relationship Type
+          {t('relationshipTypeEditor.dialogTitle')}
         </DialogTitle>
-        
+
         <DialogDescription className="hidden">
-          Create a new relationship type below.
+          {t('relationshipTypeEditor.dialogDescription')}
         </DialogDescription>
 
         <fieldset className="mt-6">
           <Label 
             htmlFor="relationship-name"
-            className="inline-block mb-1.5 ml-0.5">Relationship Name
+            className="inline-block mb-1.5 ml-0.5">{t('relationshipTypeEditor.relationshipName')}
           </Label>
 
           <Input
@@ -141,12 +144,11 @@ export const RelationshipTypeEditor = (props: RelationshipTypeEditorProps) => {
 
             <div>
               <Label htmlFor="directionality">
-                Directed Relation
+                {t('relationshipTypeEditor.directedRelation')}
               </Label>
 
               <p className="text-muted-foreground text-xs mt-1">
-                Enable this option if the relationship is meant to be directional, 
-                in the sense that source and target roles are relevant.
+                {t('relationshipTypeEditor.directedHint')}
               </p>
             </div>
           </div>
@@ -155,7 +157,7 @@ export const RelationshipTypeEditor = (props: RelationshipTypeEditorProps) => {
         <fieldset className="mt-4">
           <Label 
             htmlFor="relationship-description"
-            className="inline-block text-xs mb-1.5 ml-0.5">Relationship Type Description</Label>
+            className="inline-block text-xs mb-1.5 ml-0.5">{t('relationshipTypeEditor.typeDescription')}</Label>
 
           <Textarea 
             id="relationship-description"
@@ -175,12 +177,11 @@ export const RelationshipTypeEditor = (props: RelationshipTypeEditorProps) => {
 
             <div>
               <Label htmlFor="restrict-source">
-                Restrict source entity class
+                {t('relationshipTypeEditor.restrictSource')}
               </Label>
 
               <p className="text-muted-foreground text-xs mt-1">
-                The relationship can only start on annotations 
-                with this entity class.
+                {t('relationshipTypeEditor.restrictSourceHint')}
               </p>
 
               <EntityTypeSelector 
@@ -200,12 +201,11 @@ export const RelationshipTypeEditor = (props: RelationshipTypeEditorProps) => {
 
             <div>
               <Label htmlFor="restrict-source">
-                Restrict target entity class
+                {t('relationshipTypeEditor.restrictTarget')}
               </Label>
 
               <p className="text-muted-foreground text-xs mt-1">
-                The relationship can only end on annotations 
-                with this entity class.
+                {t('relationshipTypeEditor.restrictTargetHint')}
               </p>
 
               <EntityTypeSelector 
@@ -219,7 +219,7 @@ export const RelationshipTypeEditor = (props: RelationshipTypeEditorProps) => {
           className="w-full mt-2 mb-3"
           disabled={!relationship.name}
           onClick={onSave}>
-          Save
+          {t('relationshipTypeEditor.save')}
         </Button>
       </DialogContent>
     </Dialog>

--- a/src/components/Translation/TranslateButton/TranslateButton.tsx
+++ b/src/components/Translation/TranslateButton/TranslateButton.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Languages } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ui/Tooltip';
 import { ServiceConnectorConfig, ServiceRegistry } from '@/services';
 import { cn } from '@/ui/utils';
@@ -53,6 +54,8 @@ const setPersistedService = (connectorId: string, index: number) =>
   localStorage.setItem(KEY_SERVICE, `${connectorId}::${index}`);
 
 export const TranslateButton = (props: TranslateButtonProps) => {
+
+  const { t } = useTranslation('common');
 
   const availableConnectors = useMemo(() => connectors.filter(connector => {
     if (!connector.requiresKey) return true;
@@ -117,7 +120,7 @@ export const TranslateButton = (props: TranslateButtonProps) => {
       </TooltipTrigger>
 
       <TooltipContent>
-        Show translation
+        {t('translation.showTranslation')}
       </TooltipContent>
     </Tooltip>
   ) : null;

--- a/src/components/Translation/TranslateButton/TranslateSettingsPopover.tsx
+++ b/src/components/Translation/TranslateButton/TranslateSettingsPopover.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { ChevronDown, CloudCog, Globe } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { ServiceConnectorConfig } from '@/services';
 import { Popover, PopoverContent, PopoverTrigger } from '@/ui/Popover';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/ui/Tabs';
@@ -25,6 +26,8 @@ interface TranslateSettingsPopoverProps {
 }
 
 export const TranslateSettingsPopover = (props: TranslateSettingsPopoverProps) => {
+
+  const { t } = useTranslation('common');
 
   const [open, setOpen] = useState(false);
 
@@ -61,14 +64,14 @@ export const TranslateSettingsPopover = (props: TranslateSettingsPopoverProps) =
               value="service"
               className="flex border-b-2 border-r border-r-input border-transparent shadow-none rounded-none rounded-tl-md text-xs p-2 font-normal items-center gap-2 opacity-50 data-[state=active]:bg-white data-[state=active]:opacity-100 data-[state=active]:border-b-black">
               <CloudCog className="size-4" />
-              Services
+              {t('translation.services')}
             </TabsTrigger>
 
             <TabsTrigger 
               value="language" 
               className="flex border-b-2 border-transparent shadow-none rounded-none rounded-tr-md text-xs p-2 font-normal items-center gap-2 opacity-50 data-[state=active]:bg-white data-[state=active]:opacity-100 data-[state=active]:border-black">
               <Globe className="size-3.5" />
-              Language
+              {t('translation.language')}
             </TabsTrigger>
           </TabsList>
 

--- a/src/components/Translation/TranslateButton/languages/LanguagesTab.tsx
+++ b/src/components/Translation/TranslateButton/languages/LanguagesTab.tsx
@@ -1,4 +1,5 @@
 import { Check } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { BASE_LANGUAGES } from './Languages';
 import { 
   Command, 
@@ -20,19 +21,21 @@ interface LanguagesTabProps {
 
 export const LanguagesTab = (props: LanguagesTabProps) => {
 
+  const { t } = useTranslation('common');
+
   return (
     <Command>
       <div className="p-1.5 border-b">
         <div className="language-filter bg-muted/70 rounded">
-          <CommandInput 
-            placeholder="Search language..." 
+          <CommandInput
+            placeholder={t('translation.searchLanguagePlaceholder')}
             className="text-xs" />
         </div>
       </div>
 
       <CommandList 
         className="p-1.5">
-        <CommandEmpty>No supported language found.</CommandEmpty>
+        <CommandEmpty>{t('translation.noLanguageFound')}</CommandEmpty>
         {BASE_LANGUAGES.map(({ iso, label}) => (
           <CommandItem
             key={iso}

--- a/src/components/Translation/Translation.tsx
+++ b/src/components/Translation/Translation.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Ban, Check, Copy, X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { TranslationServiceResponse, useService } from '@/services';
 import { Separator } from '@/ui/Separator';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ui/Tooltip';
@@ -16,6 +17,8 @@ interface TranslationProps {
 }
 
 export const Translation = (props: TranslationProps) => {
+
+  const { t } = useTranslation('common');
 
   const { connector, connectorConfig, serviceConfig } = useService(props.args.connector.id, props.args.service);
 
@@ -52,7 +55,7 @@ export const Translation = (props: TranslationProps) => {
         console.error(error);
 
         setBusy(false);
-        setError('Translation service error');
+        setError(t('translation.serviceError'));
       });
   }, [connectorConfig, serviceConfig, connector, props.args]);
 
@@ -91,7 +94,7 @@ export const Translation = (props: TranslationProps) => {
               </TooltipTrigger>
 
               <TooltipContent>
-                Copy to clipboard
+                {t('translation.copyToClipboard')}
               </TooltipContent>
             </Tooltip>
 
@@ -106,7 +109,7 @@ export const Translation = (props: TranslationProps) => {
               </TooltipTrigger>
 
               <TooltipContent>
-                Hide translation
+                {t('translation.hideTranslation')}
               </TooltipContent>
             </Tooltip>
           </div>

--- a/src/components/VisualSearchDebugAction/VisualSearchDebugAction.tsx
+++ b/src/components/VisualSearchDebugAction/VisualSearchDebugAction.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Bug } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import type { IndexedImageSegment } from 'browser-visual-search';
 import { Annotorious, OpenSeadragonAnnotator, OpenSeadragonViewer, useAnnotator } from '@annotorious/react';
 import type { AnnotationState, DrawingStyleExpression, ImageAnnotation } from '@annotorious/react';
@@ -111,6 +112,8 @@ const VisualSearchDebugViewer = (props: VisualSearchDebugViewerProps) => {
 }
 
 export const VisualSearchDebugAction = (props: VisualSearchDebugActionProps) => {
+  const { t } = useTranslation('common');
+
   const hasVisualSearch = useVisualSearchAvailable();
   const [showVisualSearchDebug, setShowVisualSearchDebug] = useState(false);
 
@@ -129,7 +132,7 @@ export const VisualSearchDebugAction = (props: VisualSearchDebugActionProps) => 
 
       <DropdownMenuItem onSelect={onOpenVSDebug}>
         <Bug className="size-4 mr-2 text-amber-500" />
-        Inspect indexed patches
+        {t('visualSearchDebug.inspectIndexedPatches')}
       </DropdownMenuItem>
 
 

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -2,8 +2,13 @@ import i18n from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
 
+import enCommon from '../locales/en/common.json';
 import enStart from '../locales/en/start.json';
+import enUi from '../locales/en/ui.json';
+
+import jaCommon from '../locales/ja/common.json';
 import jaStart from '../locales/ja/start.json';
+import jaUi from '../locales/ja/ui.json';
 
 export const SUPPORTED_LANGUAGES = [
   { code: 'en', label: 'English' },
@@ -15,8 +20,16 @@ i18n
   .use(initReactI18next)
   .init({
     resources: {
-      en: { start: enStart },
-      ja: { start: jaStart }
+      en: {
+        common: enCommon,
+        start: enStart,
+        ui: enUi
+      },
+      ja: {
+        common: jaCommon,
+        start: jaStart,
+        ui: jaUi
+      }
     },
     fallbackLng: 'en',
     interpolation: {

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1,0 +1,223 @@
+{
+  "appNavigationSidebar": {
+    "images": "Images",
+    "workspace": "Workspace",
+    "knowledgeGraph": "Knowledge Graph",
+    "dataModel": "Data Model",
+    "export": "Export",
+    "settings": "Settings",
+    "about": "About",
+    "immarkus": "IMMARKUS",
+    "xmarkus": "X-MARKUS",
+    "help": "Help",
+    "exit": "Exit"
+  },
+  "combobox": {
+    "searchPlaceholder": "Search...",
+    "noMatches": "No matches"
+  },
+  "confirmedDelete": {
+    "title": "Are you sure?",
+    "cancel": "Cancel",
+    "delete": "Delete"
+  },
+  "copyManifestURL": {
+    "label": "Copy Manifest URL"
+  },
+  "dataModelImport": {
+    "title": {
+      "entityTypes": "Import Entity Classes",
+      "relationshipTypes": "Import Relationship Types",
+      "folderSchemas": "Import Folder Schemas",
+      "imageSchemas": "Import Image Schemas"
+    },
+    "itemsClasses": "classes",
+    "itemsSchemas": "schemas",
+    "success": "Success",
+    "error": "Error",
+    "warning": "Warning",
+    "entityClassesImported_one": "{{count}} entity class imported successfully.",
+    "entityClassesImported_other": "{{count}} entity classes imported successfully.",
+    "schemasImported_one": "{{count}} schema imported successfully.",
+    "schemasImported_other": "{{count}} schemas imported successfully.",
+    "importError": "Error importing to data model",
+    "replaceCurrentModel": "Replace Current Model",
+    "replaceHint": "You can either delete and replace your existing model, or add the imported {{items}} to your current model.",
+    "replaceWarning": {
+      "entityTypes": "All current Entity Classes will be deleted from your model.",
+      "schemas": "All current schemas will be deleted from your model."
+    },
+    "duplicatesTitle": {
+      "entityTypes": "How to Handle Duplicate Classes",
+      "schemas": "How to Handle Duplicate Schemas"
+    },
+    "duplicatesHint": "Select how the import should merge {{items}} that already exist in your model.",
+    "keepExisting": "Keep Existing",
+    "keepExistingHint": "If the import contains {{items}} that already exist in your model, keep the existing ones and discard the imported {{items}}.",
+    "keepImported": "Keep Imported",
+    "keepImportedHint": "If the import contains {{items}} that already exist in your model, discard the existing ones and keep the imported {{items}}.",
+    "importFromPreset": "Import from Preset",
+    "orSeparator": "— or —",
+    "uploadButton": "Upload Datamodel File",
+    "invalidFormat": "Invalid data model format",
+    "couldNotOpenFile": "Could not open the data file",
+    "useExportedFiles": "Use files downloaded from <exportLink>Export / Data Model</exportLink>."
+  },
+  "entityBadge": {
+    "error": "error"
+  },
+  "entityTypeBrowser": {
+    "noResults": "No results",
+    "searchPlaceholder": "Search...",
+    "searchInPlaceholder": "Search in {{name}}...",
+    "children_one": "{{count}} child",
+    "children_other": "{{count}} children",
+    "dialogTitle": "Search",
+    "dialogDescription": "Search and select an entity class.",
+    "createNewEntityClass": "Create New Entity Class",
+    "cancel": "Cancel",
+    "ok": "OK"
+  },
+  "entityTypeEditor": {
+    "dialogTitle": "Entity Class Editor",
+    "dialogDescription": "Edit your entity class definition.",
+    "errorTitle": "Error",
+    "saveError": "Something went wrong. Could not save entity type.",
+    "entityClass": "Entity Class *",
+    "required": "required",
+    "idExists": "ID already exists",
+    "idAvailable": "{{id}} is available",
+    "color": "Color",
+    "displayName": "Display Name",
+    "parentClass": "Parent Class",
+    "cannotBeOwnParent": "{{id}} cannot be its own parent",
+    "noEntityClassCalled": "No Entity Class called {{id}}",
+    "validParent": "{{id}} is a valid parent",
+    "description": "Entity Class Description",
+    "save": "Save Entity Class",
+    "previewTitle": "Entity Preview",
+    "previewHint": "This is how the data entry form for your Entity will appear in the annotation view."
+  },
+  "propertyDefinitions": {
+    "editorHint": "Use Properties to record specific details in your annotations, such as weight, material, age, etc.",
+    "previewHint": "This is how your property will appear when editing an entity in the annotation interface.",
+    "noProperties": "No Properties",
+    "propertyCount_one": "{{count}} Property",
+    "propertyCount_other": "{{count}} Properties",
+    "emptyHint": "Use Properties to record specific details for an annotated Entity, such as weight, material, age, etc.",
+    "addProperty": "Add Property"
+  },
+  "fixRelocatedManifest": {
+    "menuItem": "Fix Relocated Manifest",
+    "ok": "OK"
+  },
+  "fontSize": {
+    "changeFontSize": "Change font size"
+  },
+  "iiifMetadataList": {
+    "noMetadata": "No IIIF Metadata"
+  },
+  "metadataForm": {
+    "noSchemaDefined": "No schema defined.<br/>Go to <modelLink><icon></icon> Data Model</modelLink> to define one.",
+    "schema": "Schema"
+  },
+  "metadataSchemaEditor": {
+    "dialogTitle": "Edit Schema",
+    "schemaName": "Schema Name",
+    "required": "required",
+    "schemaExists": "Schema already exists",
+    "nameAvailable": "{{name}} is available",
+    "schemaDescription": "Schema Description",
+    "addProperty": "Add Property",
+    "saveSchema": "Save Schema",
+    "previewTitle": "Preview",
+    "previewHint": "This is how the data entry form for your metadata schema will appear."
+  },
+  "metadataTable": {
+    "schema": "Schema",
+    "description": "Description",
+    "properties": "Properties",
+    "noSchemas": "No schemas defined",
+    "editSchema": "Edit schema",
+    "deleteSchema": "Delete schema",
+    "deleteMessage": "This action will delete the schema permanently."
+  },
+  "progressDialog": {
+    "processing": "Processing"
+  },
+  "propertyDefinitionEditor": {
+    "dialogTitle": "Property Definition Editor",
+    "add": "Add",
+    "addAtLeastOneOption": "Add at least one option.",
+    "authorityMisconfigured": "Authority is not configured correctly",
+    "selectAtLeastOneAuthority": "Select at least one authority",
+    "moveUp": "Move up",
+    "moveDown": "Move down",
+    "edit": "Edit",
+    "delete": "Delete",
+    "propertyName": "Property Name",
+    "propertyNameExists": "Property name already exists",
+    "dataType": "Data Type",
+    "typeText": "Text",
+    "typeNumber": "Number",
+    "typeOptions": "Options",
+    "typeNumberRange": "Number Range",
+    "typeUri": "URI",
+    "typeGeoCoordinates": "Geo-coordinates",
+    "typeMeasurement": "Measurement",
+    "typeColor": "Color",
+    "typeExternalAuthority": "External Authority",
+    "allowMultipleValues": "Allow multiple values",
+    "propertyDescription": "Property Description",
+    "saveProperty": "Save Property",
+    "previewTitle": "Property Preview",
+    "multiLine": "Display as multi-line text field"
+  },
+  "propertyFields": {
+    "addValue": "Add value",
+    "invalidColor": "invalid color code",
+    "pickColor": "Pick a color...",
+    "invalidCoordinates": "must be valid coordinates",
+    "latPlaceholder": "Lat...",
+    "lngPlaceholder": "Lng...",
+    "searchAuthorityPlaceholder": "Search {{name}}...",
+    "inheritedFrom": "Inherited from",
+    "measurementRequired": "number value and unit required",
+    "valuePlaceholder": "Value...",
+    "unitPlaceholder": "Unit...",
+    "mustBeNumber": "must be a number",
+    "required": "required",
+    "invalidRange": "must be valid range",
+    "startPlaceholder": "Start...",
+    "endPlaceholder": "End...",
+    "mustBeURI": "must be a URI"
+  },
+  "relationshipTypeEditor": {
+    "dialogTitle": "New Relationship Type",
+    "dialogDescription": "Create a new relationship type below.",
+    "errorTitle": "Error",
+    "saveError": "Something went wrong. Could not save entity type.",
+    "relationshipName": "Relationship Name",
+    "directedRelation": "Directed Relation",
+    "directedHint": "Enable this option if the relationship is meant to be directional, in the sense that source and target roles are relevant.",
+    "typeDescription": "Relationship Type Description",
+    "restrictSource": "Restrict source entity class",
+    "restrictSourceHint": "The relationship can only start on annotations with this entity class.",
+    "restrictTarget": "Restrict target entity class",
+    "restrictTargetHint": "The relationship can only end on annotations with this entity class.",
+    "save": "Save"
+  },
+  "translation": {
+    "serviceError": "Translation service error",
+    "copyToClipboard": "Copy to clipboard",
+    "hideTranslation": "Hide translation",
+    "showTranslation": "Show translation",
+    "services": "Services",
+    "language": "Language",
+    "searchLanguagePlaceholder": "Search language...",
+    "noLanguageFound": "No supported language found."
+  },
+  "visualSearchDebug": {
+    "inspectIndexedPatches": "Inspect indexed patches"
+  }
+}

--- a/src/locales/en/ui.json
+++ b/src/locales/en/ui.json
@@ -1,0 +1,13 @@
+{
+  "dialog": {
+    "close": "Close"
+  },
+  "sheet": {
+    "close": "Close"
+  },
+  "sidebar": {
+    "title": "Sidebar",
+    "description": "Displays the mobile sidebar.",
+    "toggle": "Toggle Sidebar"
+  }
+}

--- a/src/locales/ja/common.json
+++ b/src/locales/ja/common.json
@@ -1,0 +1,219 @@
+{
+  "appNavigationSidebar": {
+    "images": "画像",
+    "workspace": "ワークスペース",
+    "knowledgeGraph": "ナレッジグラフ",
+    "dataModel": "データモデル",
+    "export": "エクスポート",
+    "settings": "設定",
+    "about": "情報",
+    "immarkus": "IMMARKUS",
+    "xmarkus": "X-MARKUS",
+    "help": "ヘルプ",
+    "exit": "終了"
+  },
+  "combobox": {
+    "searchPlaceholder": "検索...",
+    "noMatches": "該当なし"
+  },
+  "confirmedDelete": {
+    "title": "本当に削除しますか?",
+    "cancel": "キャンセル",
+    "delete": "削除"
+  },
+  "copyManifestURL": {
+    "label": "マニフェスト URL をコピー"
+  },
+  "dataModelImport": {
+    "title": {
+      "entityTypes": "エンティティクラスをインポート",
+      "relationshipTypes": "リレーションタイプをインポート",
+      "folderSchemas": "フォルダスキーマをインポート",
+      "imageSchemas": "画像スキーマをインポート"
+    },
+    "itemsClasses": "エンティティクラス",
+    "itemsSchemas": "スキーマ",
+    "success": "成功",
+    "error": "エラー",
+    "warning": "警告",
+    "entityClassesImported_other": "{{count}} 件のエンティティクラスをインポートしました。",
+    "schemasImported_other": "{{count}} 件のスキーマをインポートしました。",
+    "importError": "データモデルへのインポート中にエラーが発生しました",
+    "replaceCurrentModel": "現在のモデルを置き換える",
+    "replaceHint": "既存のモデルを削除して置き換えるか、インポートした{{items}}を現在のモデルに追加するかを選択できます。",
+    "replaceWarning": {
+      "entityTypes": "現在のエンティティクラスはすべてモデルから削除されます。",
+      "schemas": "現在のスキーマはすべてモデルから削除されます。"
+    },
+    "duplicatesTitle": {
+      "entityTypes": "重複するクラスの扱い",
+      "schemas": "重複するスキーマの扱い"
+    },
+    "duplicatesHint": "モデル内に既に存在する{{items}}をインポート時にどのようにマージするかを選択してください。",
+    "keepExisting": "既存を残す",
+    "keepExistingHint": "モデル内に既に存在する{{items}}がインポートに含まれる場合、既存のものを残し、インポートされた{{items}}を破棄します。",
+    "keepImported": "インポートを優先",
+    "keepImportedHint": "モデル内に既に存在する{{items}}がインポートに含まれる場合、既存のものを破棄し、インポートされた{{items}}を残します。",
+    "importFromPreset": "プリセットからインポート",
+    "orSeparator": "— または —",
+    "uploadButton": "データモデルファイルをアップロード",
+    "invalidFormat": "データモデルの形式が不正です",
+    "couldNotOpenFile": "データファイルを開けませんでした",
+    "useExportedFiles": "<exportLink>エクスポート / データモデル</exportLink>からダウンロードしたファイルを使用してください。"
+  },
+  "entityBadge": {
+    "error": "エラー"
+  },
+  "entityTypeBrowser": {
+    "noResults": "該当する結果がありません",
+    "searchPlaceholder": "検索...",
+    "searchInPlaceholder": "{{name}}内を検索...",
+    "children_other": "子クラス {{count}} 件",
+    "dialogTitle": "検索",
+    "dialogDescription": "エンティティクラスを検索して選択します。",
+    "createNewEntityClass": "新しいエンティティクラスを作成",
+    "cancel": "キャンセル",
+    "ok": "OK"
+  },
+  "entityTypeEditor": {
+    "dialogTitle": "エンティティクラスエディター",
+    "dialogDescription": "エンティティクラスの定義を編集します。",
+    "errorTitle": "エラー",
+    "saveError": "問題が発生しました。エンティティタイプを保存できませんでした。",
+    "entityClass": "エンティティクラス *",
+    "required": "必須",
+    "idExists": "この ID は既に存在します",
+    "idAvailable": "{{id}} は使用可能です",
+    "color": "カラー",
+    "displayName": "表示名",
+    "parentClass": "親クラス",
+    "cannotBeOwnParent": "{{id}} を自身の親にすることはできません",
+    "noEntityClassCalled": "{{id}} というエンティティクラスはありません",
+    "validParent": "{{id}} は有効な親クラスです",
+    "description": "エンティティクラスの説明",
+    "save": "エンティティクラスを保存",
+    "previewTitle": "エンティティプレビュー",
+    "previewHint": "アノテーションビューでこのエンティティの入力フォームがどのように表示されるかのプレビューです。"
+  },
+  "propertyDefinitions": {
+    "editorHint": "プロパティを使うと、重さ・素材・年代など、アノテーションに具体的な詳細を記録できます。",
+    "previewHint": "アノテーション画面でエンティティを編集する際に、このプロパティがどのように表示されるかのプレビューです。",
+    "noProperties": "プロパティなし",
+    "propertyCount_other": "プロパティ {{count}} 件",
+    "emptyHint": "プロパティを使うと、アノテーション対象のエンティティについて、重さ・素材・年代などの具体的な詳細を記録できます。",
+    "addProperty": "プロパティを追加"
+  },
+  "fixRelocatedManifest": {
+    "menuItem": "移動したマニフェストを修復",
+    "ok": "OK"
+  },
+  "fontSize": {
+    "changeFontSize": "文字サイズを変更"
+  },
+  "iiifMetadataList": {
+    "noMetadata": "IIIF メタデータがありません"
+  },
+  "metadataForm": {
+    "noSchemaDefined": "スキーマが定義されていません。<br/><modelLink><icon></icon> データモデル</modelLink>で定義してください。",
+    "schema": "スキーマ"
+  },
+  "metadataSchemaEditor": {
+    "dialogTitle": "スキーマを編集",
+    "schemaName": "スキーマ名",
+    "required": "必須",
+    "schemaExists": "このスキーマ名は既に存在します",
+    "nameAvailable": "{{name}} は使用可能です",
+    "schemaDescription": "スキーマの説明",
+    "addProperty": "プロパティを追加",
+    "saveSchema": "スキーマを保存",
+    "previewTitle": "プレビュー",
+    "previewHint": "このメタデータスキーマの入力フォームがどのように表示されるかのプレビューです。"
+  },
+  "metadataTable": {
+    "schema": "スキーマ",
+    "description": "説明",
+    "properties": "プロパティ",
+    "noSchemas": "スキーマが定義されていません",
+    "editSchema": "スキーマを編集",
+    "deleteSchema": "スキーマを削除",
+    "deleteMessage": "この操作はスキーマを完全に削除します。"
+  },
+  "progressDialog": {
+    "processing": "処理中"
+  },
+  "propertyDefinitionEditor": {
+    "dialogTitle": "プロパティ定義エディター",
+    "add": "追加",
+    "addAtLeastOneOption": "少なくとも 1 つの選択肢を追加してください。",
+    "authorityMisconfigured": "典拠が正しく設定されていません",
+    "selectAtLeastOneAuthority": "少なくとも 1 つの典拠を選択してください",
+    "moveUp": "上へ移動",
+    "moveDown": "下へ移動",
+    "edit": "編集",
+    "delete": "削除",
+    "propertyName": "プロパティ名",
+    "propertyNameExists": "このプロパティ名は既に存在します",
+    "dataType": "データ型",
+    "typeText": "テキスト",
+    "typeNumber": "数値",
+    "typeOptions": "選択肢",
+    "typeNumberRange": "数値範囲",
+    "typeUri": "URI",
+    "typeGeoCoordinates": "地理座標",
+    "typeMeasurement": "計測値",
+    "typeColor": "カラー",
+    "typeExternalAuthority": "外部典拠",
+    "allowMultipleValues": "複数の値を許可",
+    "propertyDescription": "プロパティの説明",
+    "saveProperty": "プロパティを保存",
+    "previewTitle": "プロパティプレビュー",
+    "multiLine": "複数行のテキストフィールドとして表示"
+  },
+  "propertyFields": {
+    "addValue": "値を追加",
+    "invalidColor": "無効なカラーコードです",
+    "pickColor": "色を選択...",
+    "invalidCoordinates": "有効な座標を入力してください",
+    "latPlaceholder": "緯度...",
+    "lngPlaceholder": "経度...",
+    "searchAuthorityPlaceholder": "{{name}}を検索...",
+    "inheritedFrom": "継承元",
+    "measurementRequired": "数値と単位は必須です",
+    "valuePlaceholder": "値...",
+    "unitPlaceholder": "単位...",
+    "mustBeNumber": "数値を入力してください",
+    "required": "必須",
+    "invalidRange": "有効な範囲を入力してください",
+    "startPlaceholder": "開始...",
+    "endPlaceholder": "終了...",
+    "mustBeURI": "URI を入力してください"
+  },
+  "relationshipTypeEditor": {
+    "dialogTitle": "新しいリレーションタイプ",
+    "dialogDescription": "新しいリレーションタイプを作成します。",
+    "errorTitle": "エラー",
+    "saveError": "問題が発生しました。リレーションタイプを保存できませんでした。",
+    "relationshipName": "リレーション名",
+    "directedRelation": "有向リレーション",
+    "directedHint": "ソースとターゲットの役割が意味を持つ、方向性のあるリレーションの場合に有効にしてください。",
+    "typeDescription": "リレーションタイプの説明",
+    "restrictSource": "ソースのエンティティクラスを制限",
+    "restrictSourceHint": "このエンティティクラスを持つアノテーションからのみリレーションを開始できます。",
+    "restrictTarget": "ターゲットのエンティティクラスを制限",
+    "restrictTargetHint": "このエンティティクラスを持つアノテーションでのみリレーションを終了できます。",
+    "save": "保存"
+  },
+  "translation": {
+    "serviceError": "翻訳サービスでエラーが発生しました",
+    "copyToClipboard": "クリップボードにコピー",
+    "hideTranslation": "翻訳を隠す",
+    "showTranslation": "翻訳を表示",
+    "services": "サービス",
+    "language": "言語",
+    "searchLanguagePlaceholder": "言語を検索...",
+    "noLanguageFound": "対応する言語が見つかりません。"
+  },
+  "visualSearchDebug": {
+    "inspectIndexedPatches": "インデックス済みパッチを確認"
+  }
+}

--- a/src/locales/ja/ui.json
+++ b/src/locales/ja/ui.json
@@ -1,0 +1,13 @@
+{
+  "dialog": {
+    "close": "閉じる"
+  },
+  "sheet": {
+    "close": "閉じる"
+  },
+  "sidebar": {
+    "title": "サイドバー",
+    "description": "モバイル用サイドバーを表示します。",
+    "toggle": "サイドバーを切り替え"
+  }
+}

--- a/src/locales/locales.test.ts
+++ b/src/locales/locales.test.ts
@@ -1,0 +1,132 @@
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Regression tests for the i18n locale resources.
+ *
+ * 1. en/ja key parity — every key present in one locale must exist in the
+ *    other (Japanese legitimately omits `_one` plural variants).
+ * 2. Every literal translation key referenced in the source code
+ *    (t('...') and <Trans i18nKey="...">) must resolve in the English
+ *    resources. Dynamic keys (template literals, variables) cannot be
+ *    checked statically and are skipped.
+ */
+
+const LOCALES_DIR = dirname(fileURLToPath(import.meta.url));
+const SRC_DIR = join(LOCALES_DIR, '..');
+
+const flatten = (obj: object, prefix = ''): string[] =>
+  Object.entries(obj).flatMap(([key, value]) =>
+    value !== null && typeof value === 'object'
+      ? flatten(value, `${prefix}${key}.`)
+      : [`${prefix}${key}`]);
+
+const loadNamespace = (lang: string, file: string): Set<string> =>
+  new Set(flatten(JSON.parse(readFileSync(join(LOCALES_DIR, lang, file), 'utf8'))));
+
+const namespaceFiles = readdirSync(join(LOCALES_DIR, 'en')).filter(f => f.endsWith('.json'));
+
+/** A key resolves if it exists verbatim or via its plural variants. */
+const resolves = (keys: Set<string>, key: string) =>
+  keys.has(key) || keys.has(`${key}_other`) || keys.has(`${key}_one`);
+
+describe('locale key parity (en vs ja)', () => {
+
+  it('has the same namespace files in both locales', () => {
+    const ja = readdirSync(join(LOCALES_DIR, 'ja')).filter(f => f.endsWith('.json'));
+    expect(ja.sort()).toEqual([...namespaceFiles].sort());
+  });
+
+  it.each(namespaceFiles)('%s: every en key has a ja translation', file => {
+    const en = loadNamespace('en', file);
+    const ja = loadNamespace('ja', file);
+
+    const missing = [...en].filter(key =>
+      // ja only needs the _other variant of a plural pair
+      !ja.has(key) && !(key.endsWith('_one') && ja.has(key.replace(/_one$/, '_other'))));
+
+    expect(missing).toEqual([]);
+  });
+
+  it.each(namespaceFiles)('%s: ja has no keys missing from en', file => {
+    const en = loadNamespace('en', file);
+    const ja = loadNamespace('ja', file);
+
+    const orphaned = [...ja].filter(key => !en.has(key));
+    expect(orphaned).toEqual([]);
+  });
+
+  it.each(namespaceFiles)('%s: no empty ja translations', file => {
+    const values: string[] = [];
+    const collect = (obj: object) => Object.values(obj).forEach(v =>
+      v !== null && typeof v === 'object' ? collect(v) : values.push(v));
+    collect(JSON.parse(readFileSync(join(LOCALES_DIR, 'ja', file), 'utf8')));
+
+    expect(values.filter(v => typeof v !== 'string' || v.trim() === '')).toEqual([]);
+  });
+
+});
+
+describe('translation keys referenced in source', () => {
+
+  const enByNamespace = new Map(namespaceFiles.map(file =>
+    [file.replace(/\.json$/, ''), loadNamespace('en', file)]));
+
+  const allEnKeys = new Set([...enByNamespace.entries()]
+    .flatMap(([ns, keys]) => [...keys].map(key => `${ns}:${key}`)));
+
+  const sourceFiles: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir)) {
+      const path = join(dir, entry);
+      if (statSync(path).isDirectory()) walk(path);
+      else if (/\.tsx?$/.test(entry) && !/\.test\.tsx?$/.test(entry)) sourceFiles.push(path);
+    }
+  };
+  walk(SRC_DIR);
+
+  const resolvesAnywhere = (key: string) =>
+    [...enByNamespace.values()].some(keys => resolves(keys, key));
+
+  it('every literal t()/Trans key resolves in the en resources', () => {
+    const unresolved: string[] = [];
+
+    for (const path of sourceFiles) {
+      const content = readFileSync(path, 'utf8');
+      if (!content.includes('react-i18next')) continue;
+
+      const namespaces = [...content.matchAll(/useTranslation\(\s*['"]([\w-]+)['"]/g)]
+        .map(m => m[1]);
+
+      // t('key') / t("key") — \b keeps e.g. format( from matching
+      for (const [, key] of content.matchAll(/\bt\(\s*['"]([^'"]+)['"]/g)) {
+        const [ns, bareKey] = key.includes(':') ? key.split(':', 2) : [null, key];
+
+        const ok = ns
+          ? resolves(enByNamespace.get(ns) ?? new Set(), bareKey)
+          : namespaces.some(n => resolves(enByNamespace.get(n) ?? new Set(), bareKey))
+            || (namespaces.length === 0 && resolvesAnywhere(bareKey));
+
+        if (!ok) unresolved.push(`${path}: t('${key}') [ns: ${ns ?? (namespaces.join(',') || '?')}]`);
+      }
+
+      // <Trans ns="..." i18nKey="..."> (attribute order varies)
+      for (const [tag] of content.matchAll(/<Trans\b[\s\S]*?>/g)) {
+        const i18nKey = tag.match(/i18nKey=["']([^"']+)["']/)?.[1];
+        if (!i18nKey) continue;
+
+        const ns = tag.match(/\bns=["']([\w-]+)["']/)?.[1];
+        const candidates = ns ? [ns] : namespaces;
+
+        const ok = candidates.some(n => resolves(enByNamespace.get(n) ?? new Set(), i18nKey));
+        if (!ok) unresolved.push(`${path}: <Trans i18nKey="${i18nKey}"> [ns: ${ns ?? (namespaces.join(',') || '?')}]`);
+      }
+    }
+
+    expect(unresolved).toEqual([]);
+    expect(allEnKeys.size).toBeGreaterThan(0);
+  });
+
+});

--- a/src/ui/Command/dialog.tsx
+++ b/src/ui/Command/dialog.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
 import { X } from "lucide-react"
+import { useTranslation } from "react-i18next"
 
 import { cn } from "@/ui/utils"
 
@@ -30,7 +31,10 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+>(({ className, children, ...props }, ref) => {
+  const { t } = useTranslation('ui');
+
+  return (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
@@ -44,11 +48,12 @@ const DialogContent = React.forwardRef<
       {children}
       <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
         <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
+        <span className="sr-only">{t('dialog.close')}</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>
-))
+  )
+})
 DialogContent.displayName = DialogPrimitive.Content.displayName
 
 const DialogHeader = ({

--- a/src/ui/Dialog/dialog.tsx
+++ b/src/ui/Dialog/dialog.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
 import { X } from "lucide-react"
+import { useTranslation } from "react-i18next"
 
 import { cn } from "@/ui/utils"
 
@@ -36,7 +37,10 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & { closeIcon?: boolean }
->(({ className, children, closeIcon, ...props }, ref) => (
+>(({ className, children, closeIcon, ...props }, ref) => {
+  const { t } = useTranslation('ui');
+
+  return (
   <DialogPortal>
     <DialogOverlay>
     <DialogPrimitive.Content
@@ -52,13 +56,14 @@ const DialogContent = React.forwardRef<
       {(closeIcon === undefined || closeIcon === true) && (
         <DialogPrimitive.Close type="button" className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
           <X className="h-5 w-5 p-0.5" />
-          <span className="sr-only">Close</span>
+          <span className="sr-only">{t('dialog.close')}</span>
         </DialogPrimitive.Close>
       )}
     </DialogPrimitive.Content>
     </DialogOverlay>
   </DialogPortal>
-))
+  )
+})
 DialogContent.displayName = DialogPrimitive.Content.displayName
 
 const DialogHeader = ({

--- a/src/ui/Sheet/sheet.tsx
+++ b/src/ui/Sheet/sheet.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 import * as SheetPrimitive from "@radix-ui/react-dialog"
 import { cva, type VariantProps } from "class-variance-authority"
 import { X } from "lucide-react"
+import { useTranslation } from "react-i18next"
 
 import { cn } from "../utils"
 
@@ -56,7 +57,10 @@ interface SheetContentProps
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = "right", className, children, ...props }, ref) => (
+>(({ side = "right", className, children, ...props }, ref) => {
+  const { t } = useTranslation('ui');
+
+  return (
   <SheetPortal>
     <SheetOverlay />
     <SheetPrimitive.Content
@@ -67,11 +71,12 @@ const SheetContent = React.forwardRef<
       {children}
       <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
         <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
+        <span className="sr-only">{t('sheet.close')}</span>
       </SheetPrimitive.Close>
     </SheetPrimitive.Content>
   </SheetPortal>
-))
+  )
+})
 SheetContent.displayName = SheetPrimitive.Content.displayName
 
 const SheetHeader = ({

--- a/src/ui/Sidebar/sidebar.tsx
+++ b/src/ui/Sidebar/sidebar.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
 import { PanelLeft } from "lucide-react"
+import { useTranslation } from "react-i18next"
 
 import { useIsMobile } from "./use-mobile"
 import { cn } from "../utils"
@@ -180,6 +181,7 @@ const Sidebar = React.forwardRef<
     ref
   ) => {
     const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
+    const { t } = useTranslation('ui')
 
     if (collapsible === "none") {
       return (
@@ -211,8 +213,8 @@ const Sidebar = React.forwardRef<
             side={side}
           >
             <SheetHeader className="sr-only">
-              <SheetTitle>Sidebar</SheetTitle>
-              <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+              <SheetTitle>{t('sidebar.title')}</SheetTitle>
+              <SheetDescription>{t('sidebar.description')}</SheetDescription>
             </SheetHeader>
             <div className="flex h-full w-full flex-col">{children}</div>
           </SheetContent>
@@ -272,6 +274,7 @@ const SidebarTrigger = React.forwardRef<
   React.ComponentProps<typeof Button>
 >(({ className, onClick, ...props }, ref) => {
   const { toggleSidebar } = useSidebar()
+  const { t } = useTranslation('ui')
 
   return (
     <Button
@@ -287,7 +290,7 @@ const SidebarTrigger = React.forwardRef<
       {...props}
     >
       <PanelLeft />
-      <span className="sr-only">Toggle Sidebar</span>
+      <span className="sr-only">{t('sidebar.toggle')}</span>
     </Button>
   )
 })
@@ -298,15 +301,16 @@ const SidebarRail = React.forwardRef<
   React.ComponentProps<"button">
 >(({ className, ...props }, ref) => {
   const { toggleSidebar } = useSidebar()
+  const { t } = useTranslation('ui')
 
   return (
     <button
       ref={ref}
       data-sidebar="rail"
-      aria-label="Toggle Sidebar"
+      aria-label={t('sidebar.toggle')}
       tabIndex={-1}
       onClick={toggleSidebar}
-      title="Toggle Sidebar"
+      title={t('sidebar.toggle')}
       className={cn(
         "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-0.5 hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
         "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // Playwright owns e2e/; vitest only runs unit tests under src/
+    include: ['src/**/*.test.ts']
+  }
+});


### PR DESCRIPTION
First of the page-by-page translation PRs, following up on #322 (now merged). Per the plan in #305, the translation lands as a series of focused, self-contained PRs grouped by area.

## What's in this one

- **`common` namespace** — shared components (`src/components`) and the navigation sidebar
- **`ui` namespace** — the handful of user-visible strings baked into the UI primitives (`src/ui`), e.g. sr-only "Close" / "Toggle Sidebar"
- Wires both namespaces into `src/i18n/index.ts` (subsequent PRs add their own)
- **Test foundation** (this repo had no tests yet — all opt-in, no impact on `npm run build`):
  - `npm test` — vitest: en/ja key parity per namespace, no empty ja values, and every literal `t()` / `<Trans>` key referenced in the code resolves in the English resources
  - `npm run test:e2e` — Playwright: the start page in both languages, the language switcher, and folder-open flow. `e2e/helpers.ts` mocks `window.showDirectoryPicker` via OPFS so tests get past the native folder picker.

## Notes

- i18next plurals (`_one`/`_other`) replace hand-rolled `+ 's'` suffixes where shared components had them; Japanese uses `_other` only.
- `<Trans>` is used for the two shared strings with inline links/icons.
- Fixed a couple of pre-existing EN typos encountered while extracting (e.g. "Autority" → "Authority").

## Coming next (one at a time)

2. Annotate (incl. smart tools) · 3. Images · 4. Knowledge graph · 5. Smaller pages (data model, export, settings, about, X-MARKUS)

Each later PR depends on this one (pages reference the `common` namespace), so this is the base of the series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)