### PR TITLE
i18n (2/5): annotate page (incl. smart tools)

### DIFF
--- a/e2e/annotate.spec.ts
+++ b/e2e/annotate.spec.ts
@@ -1,0 +1,262 @@
+import { expect, test, Page } from '@playwright/test';
+import { findRawTranslationKeys, mockWorkFolder, openWorkFolder, setLanguage } from './helpers';
+
+// The annotate toolbar collapses GDocs-style when it overflows (at the
+// default 1280px viewport the "Add image" button etc. move into a "more
+// tools" popover). Use a wide viewport so the full toolbar is rendered.
+test.use({ viewport: { width: 1920, height: 1080 } });
+
+// The annotation canvas (OpenSeadragon + Annotorious + plugins) is heavy;
+// with several workers booting it in parallel the default 30s can be tight.
+test.describe.configure({ timeout: 60000 });
+
+/**
+ * Hovers a tooltip trigger, asserts the translated tooltip text, then
+ * dismisses it with Escape and waits until it is gone. The dismissal is
+ * required: while a Radix tooltip is still open, hovering the next trigger
+ * does not open its tooltip (hoverable-content grace handling), which makes
+ * back-to-back hover assertions silently fail.
+ */
+const expectTooltip = async (page: Page, trigger: ReturnType<Page['locator']>, text: string) => {
+  await trigger.hover();
+  await expect(page.getByText(text).first()).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(page.getByText(text)).toHaveCount(0);
+};
+
+/**
+ * Collects uncaught page errors. The annotation canvas stack
+ * (OpenSeadragon / Annotorious / SAM plugin) probes GPU + WebGPU features
+ * that headless Chromium may not provide. Errors originating from that
+ * stack are reported but excluded from the assertion — they are caused by
+ * the headless environment, not by the i18n changes under test.
+ */
+const collectPageErrors = (page: Page): Error[] => {
+  const errors: Error[] = [];
+  page.on('pageerror', error => errors.push(error));
+  return errors;
+};
+
+const isHeadlessGpuError = (error: Error): boolean =>
+  /webgpu|gpu|adapter|webgl|annotorious|openseadragon|segment.?anything|\bsam\b|onnx|wasm/i
+    .test(`${error.message}\n${error.stack ?? ''}`);
+
+const assertNoOwnPageErrors = (errors: Error[]) => {
+  const excluded = errors.filter(isHeadlessGpuError);
+  if (excluded.length > 0)
+    console.log(
+      `[annotate.spec] Excluded ${excluded.length} headless-GPU/plugin error(s):`,
+      excluded.map(e => e.message));
+  expect(errors.filter(e => !isHeadlessGpuError(e))).toEqual([]);
+};
+
+/** Boots the app with the mocked work folder and lands on /#/images. */
+const bootApp = async (page: Page, lang: 'en' | 'ja') => {
+  await setLanguage(page, lang);
+  await mockWorkFolder(page);
+  await page.goto('/');
+  await openWorkFolder(page);
+};
+
+/**
+ * Opens sample.png in the annotation view by clicking its thumbnail in the
+ * images overview (client-side navigation — keeps the store alive).
+ */
+const openSampleImage = async (page: Page) => {
+  const thumbnail = page.getByRole('img', { name: 'sample.png' });
+  await thumbnail.waitFor({ timeout: 15000 });
+  await thumbnail.click();
+  await page.waitForURL(/#\/annotate\/.+/, { timeout: 15000 });
+};
+
+test.describe('annotate – empty workspace', () => {
+
+  test('renders translated empty-workspace instructions (ja)', async ({ page }) => {
+    const errors = collectPageErrors(page);
+    await bootApp(page, 'ja');
+
+    // Navigate to the empty workspace via the app sidebar (no image id in URL)
+    await page.getByRole('link', { name: 'ワークスペース' }).click();
+    await page.waitForURL(/#\/annotate$/);
+
+    await expect(page.getByText('ワークスペースは空です')).toBeVisible();
+
+    // <Trans>-interpolated paragraphs (text is split around inline icons)
+    const annotatePage = page.locator('.page.annotate');
+    await expect(annotatePage).toContainText('ギャラリーから画像を開いてください');
+    await expect(annotatePage).toContainText('画像を追加');
+    await expect(annotatePage).toContainText('ツールで保存・復元できます');
+
+    expect(await findRawTranslationKeys(page)).toEqual([]);
+    assertNoOwnPageErrors(errors);
+  });
+
+  test('renders translated empty-workspace instructions (en)', async ({ page }) => {
+    const errors = collectPageErrors(page);
+    await bootApp(page, 'en');
+
+    await page.getByRole('link', { name: 'Workspace' }).click();
+    await page.waitForURL(/#\/annotate$/);
+
+    await expect(page.getByText('Your workspace is empty')).toBeVisible();
+
+    const annotatePage = page.locator('.page.annotate');
+    await expect(annotatePage).toContainText('Start by opening an image from the');
+    await expect(annotatePage).toContainText('Add image');
+    await expect(annotatePage).toContainText('Save and restore workspace layouts');
+
+    expect(await findRawTranslationKeys(page)).toEqual([]);
+    assertNoOwnPageErrors(errors);
+  });
+
+});
+
+test.describe('annotate – image open', () => {
+
+  test('shows translated toolbar, tooltips and sidebar (ja)', async ({ page }) => {
+    const errors = collectPageErrors(page);
+    await bootApp(page, 'ja');
+    await openSampleImage(page);
+
+    // --- Header chrome -----------------------------------------------------
+    // "Add image" toolbar button (visible label)
+    await expect(page.getByRole('button', { name: '画像を追加' })).toBeVisible();
+
+    // Move-mode button label
+    await expect(page.getByRole('button', { name: '移動' })).toBeVisible();
+
+    // Hover tooltips. The zoom buttons are disabled (no tooltip) until the
+    // image is registered, so wait for enablement first. We wait on DOM
+    // elements only — never on canvas rendering.
+    const zoomIn = page.locator('button:has(svg.lucide-zoom-in)');
+    await expect(zoomIn).toBeEnabled({ timeout: 30000 });
+    await expectTooltip(page, zoomIn, 'ズームイン');
+
+    // "Add image" tooltip
+    await expectTooltip(page, page.getByRole('button', { name: '画像を追加' }), '画像をワークスペースに追加');
+
+    // Smart tools button tooltip
+    const smartToolsButton = page.locator('button:has(svg.lucide-wand-sparkles)');
+    await expectTooltip(page, smartToolsButton, 'スマートアノテーションツール');
+
+    // Tool selector dropdown options
+    await page.locator('.tool-dropdown-trigger').click();
+    await expect(page.getByRole('option', { name: '矩形' })).toBeVisible();
+    await expect(page.getByRole('option', { name: 'ポリゴン' })).toBeVisible();
+    await expect(page.getByRole('option', { name: '楕円' })).toBeVisible();
+    await expect(page.getByRole('option', { name: 'パス' })).toBeVisible();
+    await page.keyboard.press('Escape');
+
+    // --- Sidebar -----------------------------------------------------------
+    await expect(page.getByRole('tab', { name: '選択' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'リスト' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'メタデータ' })).toBeVisible();
+
+    // Selection tab empty state
+    await expect(page.getByText('アノテーションが選択されていません')).toBeVisible();
+
+    // Annotation list tab: filter / select-all controls
+    await page.getByRole('tab', { name: 'リスト' }).click();
+    await expect(page.getByText('表示:')).toBeVisible();
+    await expect(page.getByText('すべて選択')).toBeVisible();
+
+    expect(await findRawTranslationKeys(page)).toEqual([]);
+    assertNoOwnPageErrors(errors);
+  });
+
+  test('shows translated toolbar, tooltips and sidebar (en)', async ({ page }) => {
+    const errors = collectPageErrors(page);
+    await bootApp(page, 'en');
+    await openSampleImage(page);
+
+    await expect(page.getByRole('button', { name: 'Add image' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Move' })).toBeVisible();
+
+    const zoomIn = page.locator('button:has(svg.lucide-zoom-in)');
+    await expect(zoomIn).toBeEnabled({ timeout: 30000 });
+    await expectTooltip(page, zoomIn, 'Zoom in');
+    await expectTooltip(page, page.getByRole('button', { name: 'Add image' }), 'Add image to workspace');
+    await expectTooltip(page, page.locator('button:has(svg.lucide-wand-sparkles)'), 'Smart annotation tools');
+
+    await page.locator('.tool-dropdown-trigger').click();
+    await expect(page.getByRole('option', { name: 'Box' })).toBeVisible();
+    await expect(page.getByRole('option', { name: 'Polygon' })).toBeVisible();
+    await expect(page.getByRole('option', { name: 'Ellipse' })).toBeVisible();
+    await expect(page.getByRole('option', { name: 'Path' })).toBeVisible();
+    await page.keyboard.press('Escape');
+
+    await expect(page.getByRole('tab', { name: 'Selection' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'List' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Metadata' })).toBeVisible();
+    await expect(page.getByText('No annotation selected')).toBeVisible();
+
+    await page.getByRole('tab', { name: 'List' }).click();
+    await expect(page.getByText('Select All')).toBeVisible();
+
+    expect(await findRawTranslationKeys(page)).toEqual([]);
+    assertNoOwnPageErrors(errors);
+  });
+
+});
+
+test.describe('annotate – smart tools panel', () => {
+
+  /**
+   * The panel branches on `'gpu' in navigator`: with WebGPU it renders the
+   * tool accordion, without it the "not supported" fallback. Headless
+   * Chromium may expose either state — both are translated, so assert
+   * whichever one renders.
+   */
+  const assertSmartToolsPanel = async (page: Page, lang: 'en' | 'ja') => {
+    const smartToolsButton = page.locator('button:has(svg.lucide-wand-sparkles)');
+    await smartToolsButton.click();
+
+    const strings = lang === 'ja'
+      ? {
+          title: 'スマートツール',
+          tools: ['スマートシザーズ', 'エッジスナップ', '自動選択', 'ビジュアル検索'],
+          notSupported: '非対応',
+          notSupportedDetail: 'WebGPU'
+        }
+      : {
+          title: 'Smart Tools',
+          tools: ['Smart Scissors', 'Edge Snap', 'Auto Select', 'Visual Search'],
+          notSupported: 'Not Supported',
+          notSupportedDetail: 'WebGPU'
+        };
+
+    await expect(page.getByText(strings.title, { exact: true })).toBeVisible();
+
+    const webGpuAvailable = await page.evaluate(() => 'gpu' in navigator);
+    console.log(`[annotate.spec] WebGPU available in headless Chromium: ${webGpuAvailable}`);
+
+    if (webGpuAvailable) {
+      for (const tool of strings.tools)
+        await expect(page.getByText(tool, { exact: true })).toBeVisible();
+    } else {
+      await expect(page.getByText(strings.notSupported, { exact: true })).toBeVisible();
+      await expect(page.getByText(new RegExp(strings.notSupportedDetail))).toBeVisible();
+    }
+  };
+
+  test('renders translated smart tools panel or WebGPU fallback (ja)', async ({ page }) => {
+    const errors = collectPageErrors(page);
+    await bootApp(page, 'ja');
+    await openSampleImage(page);
+    await assertSmartToolsPanel(page, 'ja');
+
+    expect(await findRawTranslationKeys(page)).toEqual([]);
+    assertNoOwnPageErrors(errors);
+  });
+
+  test('renders translated smart tools panel or WebGPU fallback (en)', async ({ page }) => {
+    const errors = collectPageErrors(page);
+    await bootApp(page, 'en');
+    await openSampleImage(page);
+    await assertSmartToolsPanel(page, 'en');
+
+    expect(await findRawTranslationKeys(page)).toEqual([]);
+    assertNoOwnPageErrors(errors);
+  });
+
+});

--- a/src/i18n/dateLocale.ts
+++ b/src/i18n/dateLocale.ts
@@ -1,0 +1,9 @@
+import { Locale } from 'date-fns';
+import { ja } from 'date-fns/locale';
+import i18n from './index';
+
+const DATE_LOCALES: Record<string, Locale> = { ja };
+
+/** date-fns locale matching the current UI language (undefined = date-fns default, English) */
+export const getDateLocale = (): Locale | undefined =>
+  DATE_LOCALES[i18n.language?.split('-')[0]];

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -2,11 +2,15 @@ import i18n from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
 
+import enAnnotate from '../locales/en/annotate.json';
 import enCommon from '../locales/en/common.json';
+import enSmartTools from '../locales/en/smartTools.json';
 import enStart from '../locales/en/start.json';
 import enUi from '../locales/en/ui.json';
 
+import jaAnnotate from '../locales/ja/annotate.json';
 import jaCommon from '../locales/ja/common.json';
+import jaSmartTools from '../locales/ja/smartTools.json';
 import jaStart from '../locales/ja/start.json';
 import jaUi from '../locales/ja/ui.json';
 
@@ -21,12 +25,16 @@ i18n
   .init({
     resources: {
       en: {
+        annotate: enAnnotate,
         common: enCommon,
+        smartTools: enSmartTools,
         start: enStart,
         ui: enUi
       },
       ja: {
+        annotate: jaAnnotate,
         common: jaCommon,
+        smartTools: jaSmartTools,
         start: jaStart,
         ui: jaUi
       }

--- a/src/locales/en/annotate.json
+++ b/src/locales/en/annotate.json
@@ -1,0 +1,165 @@
+{
+  "common": {
+    "save": "Save",
+    "cancel": "Cancel",
+    "searchPlaceholder": "Search..."
+  },
+  "emptyWorkspace": {
+    "title": "Your workspace is empty",
+    "description1": "Start by opening an image from the <strong><imageIcon /> Images</strong> gallery. You can also send images here from the <strong><graphIcon /> Knowledge Graph</strong>, or use the <strong><addIcon /> Add image</strong> button in the toolbar.",
+    "description2": "Save and restore workspace layouts using the <strong><bookmarkIcon /> bookmark</strong> tool in the toolbar."
+  },
+  "connectorPopup": {
+    "addToVocabulary": "Add to vocabulary:"
+  },
+  "gpuError": {
+    "title": "Error",
+    "intro": "IMMARKUS could not launch the annotation interface. The most likely reason is that <strong>hardware acceleration is disabled on your browser</strong>.",
+    "chromeIntro": "To enable hardware acceleration on <strong>Chrome</strong>:",
+    "stepOpenMenu": "Open the browser menu (three dots in the upper right corner)",
+    "chromeStep2": "Go to <strong>Settings → System</strong>",
+    "chromeStep3": "Enable the switch <strong>Use hardware acceleration when available</strong>",
+    "chromeStep4": "Click <strong>Relaunch</strong> to restart Chrome",
+    "edgeIntro": "To enable hardware acceleration on <strong>Edge</strong>:",
+    "edgeStep2": "Go to <strong>Settings → System and performance</strong>",
+    "edgeStep3": "Click <strong>System</strong>",
+    "edgeStep4": "Enable the switch <strong>Use graphics acceleration when available</strong>",
+    "edgeStep5": "You may have to restart Edge for the setting to take effect",
+    "goBack": "Go Back"
+  },
+  "headerSection": {
+    "addImage": "Add image",
+    "addImageTooltip": "Add image to workspace",
+    "hideUnannotated": "Hide unannotated",
+    "back": "Back",
+    "workspaceBookmarks": "Workspace bookmarks",
+    "deleteCurrentBookmark": "Delete current bookmark",
+    "saveBookmark": "Save bookmark...",
+    "noSavedBookmarks": "No saved bookmarks",
+    "saveCurrentWorkspace": "Save current workspace",
+    "newBookmarkName": "New bookmark name",
+    "orOverwriteExisting": "– or overwrite an existing bookmark –",
+    "copySnippetTooltip": "Copy image snippet to clipboard",
+    "copyExactShape": "Copy exact shape",
+    "copyBoundingBox": "Copy bounding box",
+    "rotateCounterclockwise": "Rotate image counterclockwise",
+    "rotateClockwise": "Rotate image clockwise",
+    "zoomIn": "Zoom in",
+    "zoomOut": "Zoom out",
+    "undo": "Undo",
+    "redo": "Redo",
+    "move": "Move",
+    "showAnnotations": "Show annotations",
+    "hideAnnotations": "Hide annotations",
+    "smartToolsTooltip": "Smart annotation tools"
+  },
+  "toolSelector": {
+    "box": "Box",
+    "polygon": "Polygon",
+    "ellipse": "Ellipse",
+    "path": "Path"
+  },
+  "pagination": {
+    "previousImage": "Previous image in this folder",
+    "nextImage": "Next image in this folder",
+    "changeImage": "Change image",
+    "selectThisImage": "Select this image",
+    "addImageToWorkspace": "Add image to workspace"
+  },
+  "savingState": {
+    "allSaved": "All annotations saved",
+    "saved": "Saved",
+    "saving": "Saving",
+    "failed": "Failed",
+    "errorSaving": "Error saving data",
+    "couldNotSaveAnnotation": "Could not save the last annotation. Error: {{message}}"
+  },
+  "relationEditor": {
+    "createRelationTooltip": "Create relation",
+    "createRelation": "Create Relation",
+    "selectTargetAnnotation": "Select a target annotation.",
+    "chooseRelationType": "Choose a relation type.",
+    "noTypesFound": "No types found.",
+    "noApplicableTypesFound": "No applicable types found.",
+    "notApplicableTypes_one": "{{count}} not applicable type",
+    "notApplicableTypes_other": "{{count}} not applicable types",
+    "hideNotApplicableTypes": "Hide not applicable types.",
+    "create": "Create",
+    "createNewType": "Create New Type"
+  },
+  "annotationList": {
+    "dragToChangeOrder": "Drag cards to change order",
+    "selectAll": "Select All",
+    "show": "Show",
+    "filter": {
+      "all": "All",
+      "withEntity": "With Entity",
+      "withoutEntity": "Without Entity",
+      "withRelation": "With Relation",
+      "entityClasses": "Entity Classes",
+      "relationshipTypes": "Relationship Types",
+      "nClasses_one": "{{count}} class",
+      "nClasses_other": "{{count}} classes",
+      "nRelations_one": "{{count}} relation",
+      "nRelations_other": "{{count}} relations"
+    },
+    "order": {
+      "recent": "recent",
+      "oldest": "oldest",
+      "entity": "entity",
+      "custom": "custom"
+    },
+    "emptyAnnotation": "Empty annotation",
+    "editTooltip": "Edit",
+    "duplicateTooltip": "Duplicate this annotation",
+    "deleteTooltip": "Delete",
+    "deleteAnnotation": "Delete Annotation",
+    "confirmDeleteAnnotation": "Are you sure you want to delete this annotation?"
+  },
+  "currentSelection": {
+    "noAnnotationSelected": "No annotation selected",
+    "addTag": "Add Tag",
+    "addNote": "Add Note",
+    "deleteAnnotation": "Delete Annotation",
+    "confirmDeleteAnnotation": "Are you sure you want to delete this annotation?"
+  },
+  "multiSelection": {
+    "annotations_one": "{{count}} Annotation",
+    "annotations_other": "{{count}} Annotations",
+    "compareDialogTitle_one": "Compare {{count}} Annotation",
+    "compareDialogTitle_other": "Compare {{count}} Annotations",
+    "compare": "Compare",
+    "compareHint": "View selected annotations side by side.",
+    "addTag": "Add Tag",
+    "addTagHint": "Apply the same tag to all selected annotations.",
+    "merge": "Merge",
+    "mergeHint": "Combine selected annotations. Preserves all tags and concatenates notes in the order of selection.",
+    "subtract": "Subtract",
+    "subtractHint": "Keep first annotation, delete all others. Overlapping areas are removed from the first annotation.",
+    "deleteSelected": "Delete Selected"
+  },
+  "propertiesForm": {
+    "addTag": "Add Tag",
+    "addNote": "Add Note",
+    "clearNote": "Clear Note",
+    "clearNoteTooltip": "Clear note",
+    "editEntitySchema": "Edit entity schema",
+    "deleteTag": "Delete this tag",
+    "relatedAnnotations": "Related Annotations",
+    "deleteRelationMessage": "This action will delete the relation permanently.",
+    "deleteRelationTooltip": "Delete this relationship"
+  },
+  "imageMetadata": {
+    "manifest": "Manifest",
+    "canvas": "Canvas",
+    "my": "My",
+    "noManifestMetadata": "No Manifest Metadata",
+    "noCanvasMetadata": "No Canvas Metadata",
+    "saveMetadata": "Save Metadata"
+  },
+  "sidebar": {
+    "selection": "Selection",
+    "list": "List",
+    "metadata": "Metadata"
+  }
+}

--- a/src/locales/en/smartTools.json
+++ b/src/locales/en/smartTools.json
@@ -1,0 +1,136 @@
+{
+  "panel": {
+    "title": "Smart Tools",
+    "smartScissors": "Smart Scissors",
+    "edgeSnap": "Edge Snap",
+    "autoSelect": "Auto Select",
+    "autoTranscribe": "Auto Transcribe",
+    "visualSearch": "Visual Search",
+    "notSupported": {
+      "title": "Not Supported",
+      "description": "Smart Tools use experimental WebGPU technology not available in your browser. Please switch to a recent version of Chrome or Edge to use this feature. <compatLink>View browser compatibility</compatLink>."
+    }
+  },
+  "sam": {
+    "downloadingModel": "Downloading AI model",
+    "downloadHint": "This may take a while. The model will remain stored in your browser for future uses."
+  },
+  "autoSelect": {
+    "instructions": "Hover to preview a selection. Click to confirm. Add or remove points to refine.",
+    "selectObject": "Select object",
+    "removeArea": "Remove area",
+    "done": "Done",
+    "reset": "Reset"
+  },
+  "edgeSnap": {
+    "instructions": "Snaps your cursor to nearby edges.",
+    "hint": "Ideal for tracing objects with clear, straight outlines—especially in high-contrast images."
+  },
+  "smartScissors": {
+    "instructions": "Click to start, move to follow edges. Click again to place points.",
+    "hint": "Ideal for quickly tracing complex shapes and curved edges."
+  },
+  "transcribe": {
+    "transcribeThisImage": "Automatically transcribe this image, or parts of it.",
+    "selectImageToTranscribe": "Select an image to transcribe automatically.",
+    "enableExternalAI": "Enable external AI tools.",
+    "disclaimer": "I understand that images I send are processed by 3rd-party services and that I’m responsible for what I upload.",
+    "selectService": "Select Service",
+    "dialogTitle": "Auto Transcribe",
+    "dialogDescription": "Submit this image for automatic transcription.",
+    "consent": {
+      "title": "Before You Use Auto Transcribe",
+      "intro": "The IMMARKUS Auto Transcribe tool allows you to connect to external AI platforms (e.g. Google, Microsoft Azure, OpenAI). Please read and confirm the following before continuing:",
+      "externalProcessing": "<strong>External Processing</strong>: When you use the Auto Transcribe tool, any images or image portions you submit will be sent to the selected third-party service for processing.",
+      "ownKeys": "<strong>Your Own Keys</strong>: For services that require an API key, you must provide your own key. The key is stored locally in your browser and used only to connect directly to the intended AI service. IMMARKUS does not transmit or store your key elsewhere.",
+      "imageRights": "<strong>Image Rights & Responsibility</strong>: Ensure that you have the right to upload and process any materials you use. Do not send copyrighted, personal, or sensitive data to external service unless you understand and accept their terms of use.",
+      "noHiddenTransfers": "<strong>No Hidden Transfers</strong>: IMMARKUS itself does not send your data anywhere. Only the AI services you choose to connect to will receive the data you submit.",
+      "confirmation": "By continuing, you confirm that you have read and understood this information and accept responsibility for your use of external AI services.",
+      "agree": "I Understand and Agree",
+      "close": "Close"
+    },
+    "controls": {
+      "service": "Service",
+      "apiKeyRequired": "API Key Required",
+      "areaSelected": "Area Selected",
+      "selectAreaToTranscribe": "Select Area to Transcribe",
+      "regionHint": "This service returns transcriptions without bounding box information. Select the area you want to transcribe. The result will be inserted as a single annotation.",
+      "runTranscription": "Run Transcription",
+      "cancel": "Cancel"
+    },
+    "status": {
+      "compressionFailed": "Image compression failed",
+      "ocrError": "OCR Service Error",
+      "ocrResponded": "OCR service responded:",
+      "noResults": "No Results",
+      "success": "Success",
+      "cropping": "Cropping Image",
+      "fetchingIIIF": "Fetching IIIF Image",
+      "compressing": "Compressing Image",
+      "processing": "Processing"
+    },
+    "nav": {
+      "rotateCounterClockwise": "Rotate counter-clockwise",
+      "rotateClockwise": "Rotate clockwise",
+      "zoomIn": "Zoom in",
+      "zoomOut": "Zoom out"
+    },
+    "resultBadge": {
+      "annotationCount_one": "{{count}} Annotation",
+      "annotationCount_other": "{{count}} Annotations",
+      "importToImmarkus": "Import to IMMARKUS",
+      "noResults": "No Results"
+    },
+    "selectRegion": {
+      "clearSelection": "Clear Selection",
+      "selectRegionOptional": "Select a region (optional)"
+    }
+  },
+  "visualSearch": {
+    "description": "Search your collection for visually similar elements.",
+    "notIndexed": "Your collection is not indexed. Go to <nowrap><icon/> <searchLink>Visual Search</searchLink></nowrap> to learn more.",
+    "indexOutdated": "Your search index is outdated. Go to <searchLink>Visual Search</searchLink> to learn more.",
+    "searchInsideImages": "Search Inside Images",
+    "discoverSimilar": "Discover similar patterns across all images.",
+    "selectAnnotation": "Select an annotation to start.",
+    "dialog": {
+      "downloadingModel": "Downloading embedding model",
+      "discardTitle": "Discard selected results?",
+      "discardDescription_one": "You have selected {{count}} result for import. If you continue, your selection will be lost.",
+      "discardDescription_other": "You have selected {{count}} results for import. If you continue, your selection will be lost.",
+      "cancel": "Cancel",
+      "discardSelection": "Discard Selection"
+    },
+    "toolbar": {
+      "showingMatches_one": "Showing {{count}} match",
+      "showingMatches_other": "Showing {{count}} matches",
+      "searching": "Searching...",
+      "dialogDescription": "Visual similarity search results for the selected image region",
+      "searchInside": "Search inside",
+      "sourceImage": "Source Image",
+      "currentlyOpenImages": "Currently Open Images",
+      "allImages": "All Images",
+      "smallThumbnails": "Small Thumbnails",
+      "mediumThumbnails": "Medium Thumbnails",
+      "largeThumbnails": "Large Thumbnails"
+    },
+    "sidebar": {
+      "selectAll": "Select All",
+      "sortByMatches": "Number of matches",
+      "sortByScore": "Best match",
+      "hitsAndScore_one": "<strong>{{count}} hit</strong> · {{score}} best score",
+      "hitsAndScore_other": "<strong>{{count}} hits</strong> · {{score}} best score",
+      "sourceBadge": "Source",
+      "openBadge": "Open",
+      "sourceTooltip": "This image contains the query annotation",
+      "openTooltip": "This image is currently open in your workspace"
+    },
+    "preview": {
+      "back": "Back",
+      "selectAll": "Select All",
+      "importSelectedAnnotations": "Import Selected Annotations",
+      "importAnnotations_one": "Import {{count}} Annotation",
+      "importAnnotations_other": "Import {{count}} Annotations"
+    }
+  }
+}

--- a/src/locales/ja/annotate.json
+++ b/src/locales/ja/annotate.json
@@ -1,0 +1,160 @@
+{
+  "common": {
+    "save": "保存",
+    "cancel": "キャンセル",
+    "searchPlaceholder": "検索..."
+  },
+  "emptyWorkspace": {
+    "title": "ワークスペースは空です",
+    "description1": "まずは <strong><imageIcon /> 画像</strong>ギャラリーから画像を開いてください。<strong><graphIcon /> ナレッジグラフ</strong>から画像を送ることも、ツールバーの <strong><addIcon /> 画像を追加</strong>ボタンを使うこともできます。",
+    "description2": "ワークスペースのレイアウトは、ツールバーの <strong><bookmarkIcon /> ブックマーク</strong>ツールで保存・復元できます。"
+  },
+  "connectorPopup": {
+    "addToVocabulary": "語彙に追加:"
+  },
+  "gpuError": {
+    "title": "エラー",
+    "intro": "IMMARKUS はアノテーションインターフェースを起動できませんでした。最も可能性が高い原因は、<strong>ブラウザのハードウェアアクセラレーションが無効になっている</strong>ことです。",
+    "chromeIntro": "<strong>Chrome</strong> でハードウェアアクセラレーションを有効にするには:",
+    "stepOpenMenu": "ブラウザのメニュー(右上の 3 点アイコン)を開きます",
+    "chromeStep2": "<strong>設定 → システム</strong>に移動します",
+    "chromeStep3": "<strong>ハードウェア アクセラレーションが使用可能な場合は使用する</strong>のスイッチを有効にします",
+    "chromeStep4": "<strong>再起動</strong>をクリックして Chrome を再起動します",
+    "edgeIntro": "<strong>Edge</strong> でハードウェアアクセラレーションを有効にするには:",
+    "edgeStep2": "<strong>設定 → システムとパフォーマンス</strong>に移動します",
+    "edgeStep3": "<strong>システム</strong>をクリックします",
+    "edgeStep4": "<strong>使用可能な場合はグラフィックス アクセラレーションを使用する</strong>のスイッチを有効にします",
+    "edgeStep5": "設定を反映するには Edge の再起動が必要な場合があります",
+    "goBack": "戻る"
+  },
+  "headerSection": {
+    "addImage": "画像を追加",
+    "addImageTooltip": "画像をワークスペースに追加",
+    "hideUnannotated": "未アノテーションを非表示",
+    "back": "戻る",
+    "workspaceBookmarks": "ワークスペースのブックマーク",
+    "deleteCurrentBookmark": "現在のブックマークを削除",
+    "saveBookmark": "ブックマークを保存...",
+    "noSavedBookmarks": "保存済みのブックマークはありません",
+    "saveCurrentWorkspace": "現在のワークスペースを保存",
+    "newBookmarkName": "新しいブックマーク名",
+    "orOverwriteExisting": "– または既存のブックマークを上書き –",
+    "copySnippetTooltip": "画像スニペットをクリップボードにコピー",
+    "copyExactShape": "正確な形状をコピー",
+    "copyBoundingBox": "バウンディングボックスをコピー",
+    "rotateCounterclockwise": "画像を反時計回りに回転",
+    "rotateClockwise": "画像を時計回りに回転",
+    "zoomIn": "ズームイン",
+    "zoomOut": "ズームアウト",
+    "undo": "元に戻す",
+    "redo": "やり直す",
+    "move": "移動",
+    "showAnnotations": "アノテーションを表示",
+    "hideAnnotations": "アノテーションを非表示",
+    "smartToolsTooltip": "スマートアノテーションツール"
+  },
+  "toolSelector": {
+    "box": "矩形",
+    "polygon": "ポリゴン",
+    "ellipse": "楕円",
+    "path": "パス"
+  },
+  "pagination": {
+    "previousImage": "このフォルダ内の前の画像",
+    "nextImage": "このフォルダ内の次の画像",
+    "changeImage": "画像を変更",
+    "selectThisImage": "この画像を選択",
+    "addImageToWorkspace": "画像をワークスペースに追加"
+  },
+  "savingState": {
+    "allSaved": "すべてのアノテーションを保存済み",
+    "saved": "保存済み",
+    "saving": "保存中",
+    "failed": "失敗",
+    "errorSaving": "データを保存できませんでした",
+    "couldNotSaveAnnotation": "直前のアノテーションを保存できませんでした。エラー: {{message}}"
+  },
+  "relationEditor": {
+    "createRelationTooltip": "リレーションを作成",
+    "createRelation": "リレーションを作成",
+    "selectTargetAnnotation": "ターゲットのアノテーションを選択します。",
+    "chooseRelationType": "リレーションタイプを選択します。",
+    "noTypesFound": "タイプが見つかりません。",
+    "noApplicableTypesFound": "適用可能なタイプが見つかりません。",
+    "notApplicableTypes_other": "適用不可のタイプ {{count}} 件",
+    "hideNotApplicableTypes": "適用不可のタイプを非表示",
+    "create": "作成:",
+    "createNewType": "新しいタイプを作成"
+  },
+  "annotationList": {
+    "dragToChangeOrder": "カードをドラッグして順序を変更",
+    "selectAll": "すべて選択",
+    "show": "表示:",
+    "filter": {
+      "all": "すべて",
+      "withEntity": "エンティティあり",
+      "withoutEntity": "エンティティなし",
+      "withRelation": "リレーションあり",
+      "entityClasses": "エンティティクラス",
+      "relationshipTypes": "リレーションタイプ",
+      "nClasses_other": "{{count}} クラス",
+      "nRelations_other": "{{count}} リレーション"
+    },
+    "order": {
+      "recent": "新しい順",
+      "oldest": "古い順",
+      "entity": "エンティティ順",
+      "custom": "カスタム"
+    },
+    "emptyAnnotation": "空のアノテーション",
+    "editTooltip": "編集",
+    "duplicateTooltip": "このアノテーションを複製",
+    "deleteTooltip": "削除",
+    "deleteAnnotation": "アノテーションを削除",
+    "confirmDeleteAnnotation": "このアノテーションを削除してもよろしいですか?"
+  },
+  "currentSelection": {
+    "noAnnotationSelected": "アノテーションが選択されていません",
+    "addTag": "タグを追加",
+    "addNote": "ノートを追加",
+    "deleteAnnotation": "アノテーションを削除",
+    "confirmDeleteAnnotation": "このアノテーションを削除してもよろしいですか?"
+  },
+  "multiSelection": {
+    "annotations_other": "{{count}} 件のアノテーション",
+    "compareDialogTitle_other": "{{count}} 件のアノテーションを比較",
+    "compare": "比較",
+    "compareHint": "選択したアノテーションを並べて表示します。",
+    "addTag": "タグを追加",
+    "addTagHint": "選択したすべてのアノテーションに同じタグを適用します。",
+    "merge": "結合",
+    "mergeHint": "選択したアノテーションを結合します。すべてのタグを保持し、ノートは選択順に連結します。",
+    "subtract": "減算",
+    "subtractHint": "最初のアノテーションを残し、それ以外をすべて削除します。重なっている領域は最初のアノテーションから取り除かれます。",
+    "deleteSelected": "選択項目を削除"
+  },
+  "propertiesForm": {
+    "addTag": "タグを追加",
+    "addNote": "ノートを追加",
+    "clearNote": "ノートをクリア",
+    "clearNoteTooltip": "ノートをクリア",
+    "editEntitySchema": "エンティティスキーマを編集",
+    "deleteTag": "このタグを削除",
+    "relatedAnnotations": "関連アノテーション",
+    "deleteRelationMessage": "この操作はリレーションを完全に削除します。",
+    "deleteRelationTooltip": "このリレーションを削除"
+  },
+  "imageMetadata": {
+    "manifest": "マニフェスト",
+    "canvas": "キャンバス",
+    "my": "マイ",
+    "noManifestMetadata": "マニフェストのメタデータはありません",
+    "noCanvasMetadata": "キャンバスのメタデータはありません",
+    "saveMetadata": "メタデータを保存"
+  },
+  "sidebar": {
+    "selection": "選択",
+    "list": "リスト",
+    "metadata": "メタデータ"
+  }
+}

--- a/src/locales/ja/smartTools.json
+++ b/src/locales/ja/smartTools.json
@@ -1,0 +1,131 @@
+{
+  "panel": {
+    "title": "スマートツール",
+    "smartScissors": "スマートシザーズ",
+    "edgeSnap": "エッジスナップ",
+    "autoSelect": "自動選択",
+    "autoTranscribe": "自動文字起こし",
+    "visualSearch": "ビジュアル検索",
+    "notSupported": {
+      "title": "非対応",
+      "description": "スマートツールは、お使いのブラウザでは利用できない実験的な WebGPU 技術を使用しています。この機能を使用するには、最新版の Chrome または Edge に切り替えてください。<compatLink>ブラウザの対応状況を見る</compatLink>。"
+    }
+  },
+  "sam": {
+    "downloadingModel": "AI モデルをダウンロード中",
+    "downloadHint": "しばらく時間がかかる場合があります。モデルは今後の使用に備えてブラウザに保存されます。"
+  },
+  "autoSelect": {
+    "instructions": "ホバーで選択をプレビューし、クリックで確定します。ポイントを追加・削除して調整できます。",
+    "selectObject": "オブジェクトを選択",
+    "removeArea": "領域を削除",
+    "done": "完了",
+    "reset": "リセット"
+  },
+  "edgeSnap": {
+    "instructions": "カーソルを近くのエッジにスナップします。",
+    "hint": "輪郭がはっきりした直線的なオブジェクトのトレースに最適です。特にコントラストの高い画像で効果的です。"
+  },
+  "smartScissors": {
+    "instructions": "クリックで開始し、カーソルを動かすとエッジに沿って線を描きます。再度クリックでポイントを配置します。",
+    "hint": "複雑な形状や曲線のエッジをすばやくトレースするのに最適です。"
+  },
+  "transcribe": {
+    "transcribeThisImage": "この画像の全体または一部を自動で文字起こしします。",
+    "selectImageToTranscribe": "自動文字起こしする画像を選択してください。",
+    "enableExternalAI": "外部 AI ツールを有効にする。",
+    "disclaimer": "送信した画像が第三者のサービスで処理されること、およびアップロードする内容について自分が責任を負うことを理解しています。",
+    "selectService": "サービスを選択",
+    "dialogTitle": "自動文字起こし",
+    "dialogDescription": "この画像を自動文字起こしのために送信します。",
+    "consent": {
+      "title": "自動文字起こしを使用する前に",
+      "intro": "IMMARKUS の自動文字起こしツールでは、外部の AI プラットフォーム(例: Google、Microsoft Azure、OpenAI)に接続できます。続行する前に、以下をお読みのうえご確認ください:",
+      "externalProcessing": "<strong>外部処理</strong>: 自動文字起こしツールを使用すると、送信した画像または画像の一部が、選択した第三者サービスに送られて処理されます。",
+      "ownKeys": "<strong>ご自身の API キー</strong>: API キーが必要なサービスでは、ご自身のキーを用意する必要があります。キーはブラウザ内にローカル保存され、対象の AI サービスへの直接接続のみに使用されます。IMMARKUS がキーを他の場所へ送信・保存することはありません。",
+      "imageRights": "<strong>画像の権利と責任</strong>: 使用する素材をアップロード・処理する権利があることを確認してください。利用規約を理解し同意していない限り、著作権で保護されたデータ、個人情報、機密データを外部サービスに送信しないでください。",
+      "noHiddenTransfers": "<strong>隠れたデータ送信はありません</strong>: IMMARKUS 自体がデータをどこかへ送信することはありません。送信したデータを受け取るのは、接続先として選択した AI サービスのみです。",
+      "confirmation": "続行することで、この情報を読み理解したこと、および外部 AI サービスの使用について責任を負うことに同意したものとみなされます。",
+      "agree": "理解して同意します",
+      "close": "閉じる"
+    },
+    "controls": {
+      "service": "サービス",
+      "apiKeyRequired": "API キーが必要",
+      "areaSelected": "領域を選択済み",
+      "selectAreaToTranscribe": "文字起こしする領域を選択",
+      "regionHint": "このサービスはバウンディングボックス情報なしで文字起こしを返します。文字起こししたい領域を選択してください。結果は単一のアノテーションとして挿入されます。",
+      "runTranscription": "文字起こしを実行",
+      "cancel": "キャンセル"
+    },
+    "status": {
+      "compressionFailed": "画像の圧縮に失敗しました",
+      "ocrError": "OCR サービスエラー",
+      "ocrResponded": "OCR サービスの応答:",
+      "noResults": "結果なし",
+      "success": "成功",
+      "cropping": "画像を切り抜き中",
+      "fetchingIIIF": "IIIF 画像を取得中",
+      "compressing": "画像を圧縮中",
+      "processing": "処理中"
+    },
+    "nav": {
+      "rotateCounterClockwise": "反時計回りに回転",
+      "rotateClockwise": "時計回りに回転",
+      "zoomIn": "ズームイン",
+      "zoomOut": "ズームアウト"
+    },
+    "resultBadge": {
+      "annotationCount_other": "{{count}} 件のアノテーション",
+      "importToImmarkus": "IMMARKUS にインポート",
+      "noResults": "結果なし"
+    },
+    "selectRegion": {
+      "clearSelection": "選択を解除",
+      "selectRegionOptional": "領域を選択(任意)"
+    }
+  },
+  "visualSearch": {
+    "description": "コレクション内から視覚的に類似した要素を検索します。",
+    "notIndexed": "コレクションがインデックス化されていません。詳しくは <nowrap><icon/> <searchLink>ビジュアル検索</searchLink></nowrap> をご覧ください。",
+    "indexOutdated": "検索インデックスが最新ではありません。詳しくは <searchLink>ビジュアル検索</searchLink> をご覧ください。",
+    "searchInsideImages": "画像内を検索",
+    "discoverSimilar": "すべての画像から類似のパターンを見つけます。",
+    "selectAnnotation": "アノテーションを選択して開始してください。",
+    "dialog": {
+      "downloadingModel": "埋め込みモデルをダウンロード中",
+      "discardTitle": "選択した結果を破棄しますか?",
+      "discardDescription_other": "インポート対象として {{count}} 件の結果を選択しています。続行すると選択内容は失われます。",
+      "cancel": "キャンセル",
+      "discardSelection": "選択を破棄"
+    },
+    "toolbar": {
+      "showingMatches_other": "{{count}} 件の一致を表示中",
+      "searching": "検索中...",
+      "dialogDescription": "選択した画像領域に対するビジュアル類似検索の結果",
+      "searchInside": "検索対象",
+      "sourceImage": "ソース画像",
+      "currentlyOpenImages": "現在開いている画像",
+      "allImages": "すべての画像",
+      "smallThumbnails": "小さいサムネイル",
+      "mediumThumbnails": "中サイズのサムネイル",
+      "largeThumbnails": "大きいサムネイル"
+    },
+    "sidebar": {
+      "selectAll": "すべて選択",
+      "sortByMatches": "一致数",
+      "sortByScore": "ベストマッチ",
+      "hitsAndScore_other": "<strong>{{count}} 件ヒット</strong> · ベストスコア {{score}}",
+      "sourceBadge": "ソース",
+      "openBadge": "表示中",
+      "sourceTooltip": "この画像にはクエリのアノテーションが含まれています",
+      "openTooltip": "この画像は現在ワークスペースで開いています"
+    },
+    "preview": {
+      "back": "戻る",
+      "selectAll": "すべて選択",
+      "importSelectedAnnotations": "選択したアノテーションをインポート",
+      "importAnnotations_other": "{{count}} 件のアノテーションをインポート"
+    }
+  }
+}

--- a/src/pages/annotate/Annotate.tsx
+++ b/src/pages/annotate/Annotate.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Bookmark, Image, ImagePlus, Loader2, Waypoints } from 'lucide-react';
+import { Trans, useTranslation } from 'react-i18next';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { AnnotoriousManifold, OSDViewerManifold, PluginProvider, Plugin } from '@annotorious/react-manifold';
 import { mountPlugin as BooleanPlugin } from '@annotorious/plugin-boolean-operations';
@@ -24,6 +25,8 @@ import './Annotate.css';
 import '@annotorious/plugin-segment-anything/annotorious-plugin-smart-tools.css';
 
 export const Annotate = () => {
+
+  const { t } = useTranslation('annotate');
 
   const params = useParams();
 
@@ -119,21 +122,29 @@ export const Annotate = () => {
                     ) : imageIds.length === 0 ? (
                       <div className="flex items-center justify-center h-full text-muted-foreground bg-muted">
                         <Alert className="bg-transparent border-none max-w-lg p-6 text-primary/60">
-                          <AlertTitle className="text-lg">Your workspace is empty</AlertTitle>
+                          <AlertTitle className="text-lg">{t('emptyWorkspace.title')}</AlertTitle>
 
                           <div className="text-sm leading-relaxed mt-4 space-y-4">
                             <p>
-                              Start by opening an image from 
-                              the <span className="font-semibold"><Image className="size-4 inline-block mb-0.5" strokeWidth={2.25} /> Images</span> gallery.
-                              You can also send images here from 
-                              the <span className="font-semibold"><Waypoints className="size-4 inline-block mb-0.5" strokeWidth={2.25} /> Knowledge Graph</span>, or
-                              use the <span className="font-semibold"><ImagePlus className="size-4 inline-block mb-0.5" strokeWidth={2.25} /> Add image</span> button 
-                              in the toolbar.
+                              <Trans
+                                ns="annotate"
+                                i18nKey="emptyWorkspace.description1"
+                                components={{
+                                  strong: <span className="font-semibold" />,
+                                  imageIcon: <Image className="size-4 inline-block mb-0.5" strokeWidth={2.25} />,
+                                  graphIcon: <Waypoints className="size-4 inline-block mb-0.5" strokeWidth={2.25} />,
+                                  addIcon: <ImagePlus className="size-4 inline-block mb-0.5" strokeWidth={2.25} />
+                                }} />
                             </p>
-                            <p> 
-                              Save and restore workspace layouts using 
-                              the <span className="font-semibold"><Bookmark className="size-4 inline-block mb-0.5" strokeWidth={2.25} /> bookmark</span> tool in the toolbar.
-                            </p> 
+                            <p>
+                              <Trans
+                                ns="annotate"
+                                i18nKey="emptyWorkspace.description2"
+                                components={{
+                                  strong: <span className="font-semibold" />,
+                                  bookmarkIcon: <Bookmark className="size-4 inline-block mb-0.5" strokeWidth={2.25} />
+                                }} />
+                            </p>
                           </div>
                         </Alert>
                       </div>

--- a/src/pages/annotate/ConnectorPopup/ConnectorPopup.tsx
+++ b/src/pages/annotate/ConnectorPopup/ConnectorPopup.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { CirclePlus, Plus } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { ConnectionPopupProps } from '@annotorious/plugin-wires-react';
 import { Combobox, ComboboxState } from '@/components/Combobox';
 import { useDataModel } from '@/store';
@@ -8,6 +9,8 @@ import { Button } from '@/ui/Button';
 import './ConnectorPopup.css';
 
 export const ConnectorPopup = (props: ConnectionPopupProps) => {
+
+  const { t } = useTranslation('annotate');
 
   const model = useDataModel();
 
@@ -55,7 +58,7 @@ export const ConnectorPopup = (props: ConnectionPopupProps) => {
         {addTerm && (
           <div className="p-2 border-t bg-muted">
             <p className="p-1 pb-2 text-center text-xs text-muted-foreground">
-              Add to vocabulary:
+              {t('connectorPopup.addToVocabulary')}
             </p>
             <Button 
               size="sm"

--- a/src/pages/annotate/GPUDisabledError/GPUDisabledError.tsx
+++ b/src/pages/annotate/GPUDisabledError/GPUDisabledError.tsx
@@ -1,5 +1,6 @@
+import { Trans, useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import { 
+import {
   AlertDialog, 
   AlertDialogAction, 
   AlertDialogContent, 
@@ -12,6 +13,8 @@ import { ShieldAlert } from 'lucide-react';
 
 export const GPUDisabledError = () => {
 
+  const { t } = useTranslation('annotate');
+
   const navigate = useNavigate();
 
   return (
@@ -19,46 +22,45 @@ export const GPUDisabledError = () => {
       <AlertDialogContent className="max-w-2xl">
         <AlertDialogHeader>
           <AlertDialogTitle className="flex gap-1.5 items-center text-destructive">
-            <ShieldAlert className="size-5.5" /> Error
+            <ShieldAlert className="size-5.5" /> {t('gpuError.title')}
           </AlertDialogTitle>
 
           <AlertDialogDescription className="py-2 leading-relaxed space-y-4">
             <p>
-              IMMARKUS could not launch the annotation interface. The most likely reason is 
-              that <strong>hardware acceleration is disabled on your browser</strong>.
+              <Trans ns="annotate" i18nKey="gpuError.intro" components={{ strong: <strong /> }} />
             </p>
 
             <div>
               <p>
-                To enable hardware acceleration on <strong>Chrome</strong>:
+                <Trans ns="annotate" i18nKey="gpuError.chromeIntro" components={{ strong: <strong /> }} />
               </p>
               <ul className="list-disc pl-4 pt-1">
-                <li>Open the browser menu (three dots in the upper right corner)</li>
-                <li>Go to <strong>Settings → System</strong></li>
-                <li>Enable the switch <strong>Use hardware acceleration when available</strong></li>
-                <li>Click <strong>Relaunch</strong> to restart Chrome</li>
+                <li>{t('gpuError.stepOpenMenu')}</li>
+                <li><Trans ns="annotate" i18nKey="gpuError.chromeStep2" components={{ strong: <strong /> }} /></li>
+                <li><Trans ns="annotate" i18nKey="gpuError.chromeStep3" components={{ strong: <strong /> }} /></li>
+                <li><Trans ns="annotate" i18nKey="gpuError.chromeStep4" components={{ strong: <strong /> }} /></li>
               </ul>
             </div>
 
             <div>
               <p>
-                To enable hardware acceleration on <strong>Edge</strong>:
+                <Trans ns="annotate" i18nKey="gpuError.edgeIntro" components={{ strong: <strong /> }} />
               </p>
-              <ul className="list-disc pl-4 pt-1">         
-                <li>Open the browser menu (three dots in the upper right corner)</li>
-                <li>Go to <strong>Settings → System and performance</strong></li>
-                <li>Click <strong>System</strong></li>
-                <li>Enable the switch <strong>Use graphics acceleration when available</strong></li>
-                <li>You may have to restart Edge for the setting to take effect</li>
+              <ul className="list-disc pl-4 pt-1">
+                <li>{t('gpuError.stepOpenMenu')}</li>
+                <li><Trans ns="annotate" i18nKey="gpuError.edgeStep2" components={{ strong: <strong /> }} /></li>
+                <li><Trans ns="annotate" i18nKey="gpuError.edgeStep3" components={{ strong: <strong /> }} /></li>
+                <li><Trans ns="annotate" i18nKey="gpuError.edgeStep4" components={{ strong: <strong /> }} /></li>
+                <li>{t('gpuError.edgeStep5')}</li>
               </ul>
             </div>
           </AlertDialogDescription>
         </AlertDialogHeader>
 
         <AlertDialogFooter>
-          <AlertDialogAction 
+          <AlertDialogAction
             onClick={() => navigate(-1)}>
-            Go Back
+            {t('gpuError.goBack')}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/src/pages/annotate/HeaderSection/AddImage/AddImage.tsx
+++ b/src/pages/annotate/HeaderSection/AddImage/AddImage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ArrowLeft, ImagePlus, MessageSquareOff, Search } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { useStore } from '@/store';
 import { Popover, PopoverContent, PopoverTrigger } from '@/ui/Popover';
 import { Toggle } from '@/ui/Toggle';
@@ -27,6 +28,8 @@ interface AddImageProps {
 }
 
 export const AddImage = (props: AddImageProps) => {
+
+  const { t } = useTranslation('annotate');
 
   const store = useStore();
 
@@ -140,12 +143,12 @@ export const AddImage = (props: AddImageProps) => {
           <PopoverTrigger
             className="p-2 flex items-center text-xs rounded-md hover:bg-muted focus-visible:outline-hidden 
               focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 whitespace-nowrap">
-            <ImagePlus className="h-4 w-4 mr-1" /> Add image
+            <ImagePlus className="h-4 w-4 mr-1" /> {t('headerSection.addImage')}
           </PopoverTrigger>
         </TooltipTrigger>
 
         <TooltipContent>
-          Add image to workspace
+          {t('headerSection.addImageTooltip')}
         </TooltipContent>
       </Tooltip>
       
@@ -157,7 +160,7 @@ export const AddImage = (props: AddImageProps) => {
           
           <input 
             autoFocus
-            placeholder="Search..."
+            placeholder={t('common.searchPlaceholder')}
             className="relative top-px py-1 outline-hidden px-0.5 grow text-sm" 
             value={query} 
             onChange={evt => setQuery(evt.target.value)} />
@@ -175,7 +178,7 @@ export const AddImage = (props: AddImageProps) => {
             </TooltipTrigger>
 
             <TooltipContent>
-              Hide unannotated
+              {t('headerSection.hideUnannotated')}
             </TooltipContent>
           </Tooltip>
         </div>

--- a/src/pages/annotate/HeaderSection/BookmarkWorkspace/BookmarkWorkspace.tsx
+++ b/src/pages/annotate/HeaderSection/BookmarkWorkspace/BookmarkWorkspace.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Bookmark, BookmarkCheck, Check, Trash2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { LoadedImage } from '@/model';
 import { WorkspaceBookmark } from '@/store';
 import { Button } from '@/ui/Button';
@@ -25,6 +26,8 @@ interface BookmarkWorkspaceProps {
 }
 
 export const BookmarkWorkspace = (props: BookmarkWorkspaceProps) => {
+
+  const { t } = useTranslation('annotate');
 
   const { openInAnnotationView } = useOpenInAnnotationView();
 
@@ -75,7 +78,7 @@ export const BookmarkWorkspace = (props: BookmarkWorkspaceProps) => {
         onOpenChange={open => setPopoverOpen(open)}>
         <PopoverTrigger asChild>
           <ToolbarButton
-            tooltip="Workspace bookmarks">
+            tooltip={t('headerSection.workspaceBookmarks')}>
             {isCurrentBookmarked ? (
               <BookmarkCheck className="size-8.5 p-2" />
             ) : (
@@ -92,7 +95,7 @@ export const BookmarkWorkspace = (props: BookmarkWorkspaceProps) => {
                 variant="ghost"
                 onClick={() => onDeleteBookmark()}
                 className="text-xs font-normal items-center justify-start disabled:hover:bg-transparent h-auto px-2 py-1.5 flex gap-1.5 w-full">
-                <Trash2 className="size-3.5 mb-px" /> Delete current bookmark
+                <Trash2 className="size-3.5 mb-px" /> {t('headerSection.deleteCurrentBookmark')}
               </Button>
             ) : (
               <Button
@@ -100,7 +103,7 @@ export const BookmarkWorkspace = (props: BookmarkWorkspaceProps) => {
                 disabled={props.images.length === 0}
                 onClick={() => setDialogOpen(true)}
                 className="text-xs font-normal items-center justify-start disabled:hover:bg-transparent h-auto px-2 py-1.5 flex gap-1.5 w-full">
-                <Bookmark className="size-3.5 mb-px" /> Save bookmark...
+                <Bookmark className="size-3.5 mb-px" /> {t('headerSection.saveBookmark')}
               </Button>
             )}
           </div>
@@ -110,7 +113,7 @@ export const BookmarkWorkspace = (props: BookmarkWorkspaceProps) => {
           <div className="p-1">
             {bookmarks.length === 0 ? (
               <div className="text-muted-foreground text-xs px-2 py-1.25 font-light text-center">
-                No saved bookmarks
+                {t('headerSection.noSavedBookmarks')}
               </div>
             ) : (
               <Command className="rounded-none">
@@ -142,18 +145,18 @@ export const BookmarkWorkspace = (props: BookmarkWorkspaceProps) => {
         onOpenChange={setDialogOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Save current workspace</DialogTitle>
+            <DialogTitle>{t('headerSection.saveCurrentWorkspace')}</DialogTitle>
           </DialogHeader>
 
           <Input
-            placeholder="New bookmark name"
+            placeholder={t('headerSection.newBookmarkName')}
             value={workspaceName}
             onChange={e => setWorkspaceName(e.target.value)}
             onKeyDown={e => e.key === 'Enter' && onSaveBookmark()} />
 
           {bookmarks.length > 0 && (
             <div className="space-y-4">
-              <div className="text-muted-foreground text-xs font-light">– or overwrite an existing bookmark –</div>
+              <div className="text-muted-foreground text-xs font-light">{t('headerSection.orOverwriteExisting')}</div>
 
               <Command className="h-auto rounded-none">
                 <div className="[&>div]:border [&>div]:rounded-t">
@@ -175,13 +178,13 @@ export const BookmarkWorkspace = (props: BookmarkWorkspaceProps) => {
 
           <DialogFooter>
             <Button variant="ghost" onClick={() => setDialogOpen(false)}>
-              Cancel
+              {t('common.cancel')}
             </Button>
 
-            <Button 
-              disabled={!workspaceName.trim()} 
+            <Button
+              disabled={!workspaceName.trim()}
               onClick={onSaveBookmark}>
-              Save
+              {t('common.save')}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/pages/annotate/HeaderSection/CopyToClipboard/CopyToClipboard.tsx
+++ b/src/pages/annotate/HeaderSection/CopyToClipboard/CopyToClipboard.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Clipboard, ClipboardCheck, ClipboardPen, ClipboardX } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { Spinner } from '@/components/Spinner';
 import { LoadedImage } from '@/model';
 import { ToolbarButton } from '../../ToolbarButton';
@@ -21,6 +22,8 @@ type CopyMode = 'masked' | 'unmasked';
 
 export const CopyToClipboard = (props: CopyToClipboardProps) => {
 
+  const { t } = useTranslation('annotate');
+
   const [mode, setMode] = useState<CopyMode>('masked');
 
   const { status, canCopy, copyToClipboard } = useCopyToClipboard(props.images, mode === 'masked');
@@ -29,7 +32,7 @@ export const CopyToClipboard = (props: CopyToClipboardProps) => {
     <div className="flex items-center">
       <ToolbarButton
         disabled={!canCopy}
-        tooltip="Copy image snippet to clipboard"
+        tooltip={t('headerSection.copySnippetTooltip')}
         onClick={copyToClipboard}>
         {status === 'busy' ? (
           <Spinner className="size-6 p-2" />
@@ -58,13 +61,13 @@ export const CopyToClipboard = (props: CopyToClipboardProps) => {
           <SelectItem 
             value="masked"
             className="text-xs">
-            Copy exact shape
+            {t('headerSection.copyExactShape')}
           </SelectItem>
 
           <SelectItem 
             value="unmasked"
             className="text-xs">
-            Copy bounding box
+            {t('headerSection.copyBoundingBox')}
           </SelectItem>
         </SelectContent>
       </Select>

--- a/src/pages/annotate/HeaderSection/HeaderSection.tsx
+++ b/src/pages/annotate/HeaderSection/HeaderSection.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useAnnotoriousManifold, useViewers } from '@annotorious/react-manifold';
 import { LoadedImage } from '@/model';
 import { TruncatedLabel } from '@/components/TruncatedLabel';
@@ -54,6 +55,8 @@ interface HeaderSectionProps {
 }
 
 export const HeaderSection = (props: HeaderSectionProps) => {
+
+  const { t } = useTranslation('annotate');
 
   const viewers = useViewers();
 
@@ -125,7 +128,7 @@ export const HeaderSection = (props: HeaderSectionProps) => {
           <BackButton images={props.images} />
 
           <TruncatedLabel
-            value={props.images.length === 1 ? props.images[0].name : 'Back'} />
+            value={props.images.length === 1 ? props.images[0].name : t('headerSection.back')} />
         </div>
 
         <SavingState.Indicator />
@@ -179,7 +182,7 @@ export const HeaderSection = (props: HeaderSectionProps) => {
             <ToolbarButton
               disabled={osdToolsDisabled}
               onClick={() => onRotate(false)}
-              tooltip="Rotate image counterclockwise">
+              tooltip={t('headerSection.rotateCounterclockwise')}>
               <RotateCcwSquare
                 className="size-8 p-2" />
             </ToolbarButton>
@@ -187,7 +190,7 @@ export const HeaderSection = (props: HeaderSectionProps) => {
             <ToolbarButton
               disabled={osdToolsDisabled}
               onClick={() => onRotate(true)}
-              tooltip="Rotate image clockwise">
+              tooltip={t('headerSection.rotateClockwise')}>
               <RotateCwSquare 
                 className="size-8 p-2" />
             </ToolbarButton>
@@ -197,7 +200,7 @@ export const HeaderSection = (props: HeaderSectionProps) => {
         <ToolbarButton 
           disabled={osdToolsDisabled}
           onClick={onZoom(2)}
-          tooltip="Zoom in">
+          tooltip={t('headerSection.zoomIn')}>
           <ZoomIn 
             className="size-8 p-2" />
         </ToolbarButton>
@@ -205,7 +208,7 @@ export const HeaderSection = (props: HeaderSectionProps) => {
         <ToolbarButton 
           disabled={osdToolsDisabled}
           onClick={onZoom(0.5)}
-          tooltip="Zoom out">
+          tooltip={t('headerSection.zoomOut')}>
           <ZoomOut 
             className="size-8 p-2" />
         </ToolbarButton>
@@ -217,7 +220,7 @@ export const HeaderSection = (props: HeaderSectionProps) => {
             <ToolbarButton
               disabled={osdToolsDisabled}
               onClick={onUndo}
-              tooltip="Undo">
+              tooltip={t('headerSection.undo')}>
               <Undo2 
                 className="size-8 p-2" />
             </ToolbarButton>
@@ -225,7 +228,7 @@ export const HeaderSection = (props: HeaderSectionProps) => {
             <ToolbarButton
               disabled={osdToolsDisabled}
               onClick={onRedo}
-              tooltip="Redo">
+              tooltip={t('headerSection.redo')}>
               <Redo2
                 className="size-8 p-2" />
             </ToolbarButton>
@@ -240,7 +243,7 @@ export const HeaderSection = (props: HeaderSectionProps) => {
           data-state={props.mode === 'move' ? 'active' : undefined}
           onClick={() => props.onChangeMode('move')}>
           <MousePointer2 className="size-4" />
-          {collapseLevel < 2 && (<span className="ml-1 pr-1">Move</span>)}
+          {collapseLevel < 2 && (<span className="ml-1 pr-1">{t('headerSection.move')}</span>)}
         </button>
 
         <ToolSelector 
@@ -258,7 +261,7 @@ export const HeaderSection = (props: HeaderSectionProps) => {
 
             <ToolbarButton
               data-state={props.hideAnnotations ? 'active' : undefined}
-              tooltip={`${props.hideAnnotations ? 'Show' : 'Hide'} annotations`}
+              tooltip={props.hideAnnotations ? t('headerSection.showAnnotations') : t('headerSection.hideAnnotations')}
               className="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground"
               onClick={() => props.onHideAnnotations(!props.hideAnnotations)}>
               <MessageCircleOff className="size-8 p-2" />

--- a/src/pages/annotate/HeaderSection/MoreToolsPanel.tsx
+++ b/src/pages/annotate/HeaderSection/MoreToolsPanel.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { LoadedImage } from '@/model';
 import { Popover, PopoverContent, PopoverTrigger } from '@/ui/Popover';
 import { Separator } from '@/ui/Separator';
@@ -49,6 +50,8 @@ interface MoreToolsPanelProps {
 }
 
 export const MoreToolsPanel = (props: MoreToolsPanelProps) => {
+
+  const { t } = useTranslation('annotate');
 
   const [open, setOpen] = useState(false);
 
@@ -126,7 +129,7 @@ export const MoreToolsPanel = (props: MoreToolsPanelProps) => {
 
           <ToolbarButton
             data-state={props.hideAnnotations ? 'active' : undefined}
-            tooltip={`${props.hideAnnotations ? 'Show' : 'Hide'} annotations`}
+            tooltip={props.hideAnnotations ? t('headerSection.showAnnotations') : t('headerSection.hideAnnotations')}
             className="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground"
             onClick={() => props.onHideAnnotations(!props.hideAnnotations)}>
             <MessageCircleOff className="size-8 p-2" />

--- a/src/pages/annotate/HeaderSection/SmartToolsButton.tsx
+++ b/src/pages/annotate/HeaderSection/SmartToolsButton.tsx
@@ -1,4 +1,5 @@
 import { WandSparkles } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { BorderBeam } from '@/ui/BorderBeam';
 import { ToolbarButton } from '../ToolbarButton';
 
@@ -12,11 +13,13 @@ interface SmartToolsButtonProps {
 
 export const SmartToolsButton = (props: SmartToolsButtonProps) => {
 
-  return (     
+  const { t } = useTranslation('annotate');
+
+  return (
     <ToolbarButton
       onClick={props.onClick}
       data-state={props.isSmartPanelOpen ? 'active' : undefined}
-      tooltip="Smart annotation tools"
+      tooltip={t('headerSection.smartToolsTooltip')}
       className="group overflow-hidden relative text-orange-600/70 flex items-center rounded-md hover:bg-orange-50 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-[state=active]:bg-orange-50">
       <WandSparkles className="size-4 h-8 w-8 p-2" />
       <BorderBeam className="opacity-0 group-data-[state=active]:opacity-50 group-hover:opacity-50 transition-opacity duration-300" />

--- a/src/pages/annotate/HeaderSection/ToolSelector.tsx
+++ b/src/pages/annotate/HeaderSection/ToolSelector.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { Circle, Square, Tangent, TriangleRight } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { AnnotationMode, Tool } from '../AnnotationMode';
 import {
   Select,
@@ -24,6 +25,8 @@ interface ToolSelectorProps {
 const TOOLS = new Set(['rectangle', 'polygon', 'ellipse', 'path']);
 
 export const ToolSelector = (props: ToolSelectorProps) => {
+
+  const { t } = useTranslation('annotate');
 
   const tool = useMemo(() => {
     return (TOOLS.has(props.tool)) ? props.tool : 'rectangle';
@@ -70,28 +73,28 @@ export const ToolSelector = (props: ToolSelectorProps) => {
         <SelectItem value="rectangle">
           <div className="flex items-center text-xs gap-1.5">
             <Square className="w-3.5 h-3.5 mb-px" /> 
-            {!props.compact && (<>Box</>)}
+            {!props.compact && (<>{t('toolSelector.box')}</>)}
           </div>
         </SelectItem>
 
         <SelectItem value="polygon">
           <div className="flex items-center text-xs gap-1.5">
             <TriangleRight className="w-3.5 h-3.5 rotate-[-10deg]" /> 
-            {!props.compact && (<>Polygon</>)}
+            {!props.compact && (<>{t('toolSelector.polygon')}</>)}
           </div>
         </SelectItem>
 
         <SelectItem value="ellipse" >
           <div className="flex items-center text-xs gap-1.5">
             <Circle className="w-3.5 h-3.5 scale-y-90 mb-px" />
-            {!props.compact && (<>Ellipse</>)}
+            {!props.compact && (<>{t('toolSelector.ellipse')}</>)}
           </div>
         </SelectItem>
 
         <SelectItem value="path">
           <div className="flex items-center text-xs gap-1.5">
             <Tangent className="w-3.5 h-3.5 scale-y-90 mb-px" />
-            {!props.compact && (<>Path</>)}
+            {!props.compact && (<>{t('toolSelector.path')}</>)}
           </div>
         </SelectItem>
       </SelectContent>

--- a/src/pages/annotate/Pagination/PaginationWidget.tsx
+++ b/src/pages/annotate/Pagination/PaginationWidget.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useRef, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { CanvasInformation, FileImage, IIIFManifestResource, LoadedImage } from '@/model';
 import { useStore } from '@/store';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
@@ -23,6 +24,8 @@ interface PaginationWidgetProps {
 }
 
 export const PaginationWidget = (props: PaginationWidgetProps) => {
+
+  const { t } = useTranslation('annotate');
 
   const store = useStore();
 
@@ -101,7 +104,7 @@ export const PaginationWidget = (props: PaginationWidgetProps) => {
           disabled={props.disabled || currentIndex === 0}
           className="mr-1"
           onClick={() => onSkipImage(-1)}
-          tooltip="Previous image in this folder">
+          tooltip={t('pagination.previousImage')}>
           <ChevronLeft className="w-5 h-8 py-2 px-0 mr-0.5" />
         </ToolbarButton>
       )}
@@ -120,7 +123,7 @@ export const PaginationWidget = (props: PaginationWidgetProps) => {
           disabled={props.disabled || images.length < 2}
           className="py-1 bg-muted disabled:bg-transparent hover:bg-slate-200"
           onClick={() => setShowThumbnails(show => !show)}
-          tooltip="Change image">
+          tooltip={t('pagination.changeImage')}>
           <span className="min-w-12 inline-block px-1.5 whitespace-nowrap">
             {currentIndex + 1} / {images.length}
           </span>
@@ -139,7 +142,7 @@ export const PaginationWidget = (props: PaginationWidgetProps) => {
           className="ml-1"
           disabled={props.disabled || currentIndex === images.length - 1}
           onClick={() => onSkipImage(1)}
-          tooltip="Next image in this folder">
+          tooltip={t('pagination.nextImage')}>
           <ChevronRight className="w-5 h-8 py-2 px-0" />
         </ToolbarButton>
       )}

--- a/src/pages/annotate/Pagination/ThumbnailStrip.tsx
+++ b/src/pages/annotate/Pagination/ThumbnailStrip.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { ChevronLeft, ChevronRight, ImageIcon, ImagePlus } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { useTransition, animated, easings } from '@react-spring/web';
 import { Thumbnail } from '@/components/Thumbnail';
 import { CanvasInformation, FileImage, LoadedImage } from '@/model';
@@ -29,6 +30,8 @@ interface ThumbnailStripProps {
 import './ThumbnailStrip.css';
 
 export const ThumbnailStrip = (props: ThumbnailStripProps) => {
+
+  const { t } = useTranslation('annotate');
 
   const el = useRef<HTMLOListElement>(null);
 
@@ -145,13 +148,13 @@ export const ThumbnailStrip = (props: ThumbnailStripProps) => {
                 <ContextMenuItem 
                   className="flex gap-2 items-center text-xs"
                   onClick={() => onSelect(image)}>
-                  <ImageIcon className="h-3.5 w-3.5" /> Select this image
+                  <ImageIcon className="h-3.5 w-3.5" /> {t('pagination.selectThisImage')}
                 </ContextMenuItem>
 
                 <ContextMenuItem 
                   className="flex gap-2 items-center text-xs"
                   onClick={() => props.onAdd(image.id)}>
-                  <ImagePlus className="h-3.5 w-3.5" /> Add image to workspace
+                  <ImagePlus className="h-3.5 w-3.5" /> {t('pagination.addImageToWorkspace')}
                 </ContextMenuItem>
               </ContextMenuContent>
             </ContextMenu>

--- a/src/pages/annotate/RelationEditor/RelationEditor.tsx
+++ b/src/pages/annotate/RelationEditor/RelationEditor.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { Spline } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { v4 as uuidv4 } from 'uuid';
 import { ImageAnnotation } from '@annotorious/react';
 import { useSelection } from '@annotorious/react-manifold';
@@ -20,6 +21,8 @@ interface RelationEditorProps {
 }
 
 export const RelationEditor = (props: RelationEditorProps) => {
+
+  const { t } = useTranslation('annotate');
 
   const store = useStore();
 
@@ -95,7 +98,7 @@ export const RelationEditor = (props: RelationEditorProps) => {
           <ToolbarButton
             className="flex items-center"
             disabled={disabled}
-            tooltip="Create relation"
+            tooltip={t('relationEditor.createRelationTooltip')}
             onClick={() => props.onOpenChange(!props.open)}>
             <Spline
               className="h-8 w-8 p-2" />

--- a/src/pages/annotate/RelationEditor/RelationEditorContent.tsx
+++ b/src/pages/annotate/RelationEditor/RelationEditorContent.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Spline } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { ImageAnnotation } from '@annotorious/react';
 import { AnnotationThumbnail } from '@/components/AnnotationThumbnail';
 import { Button } from '@/ui/Button';
@@ -21,6 +22,8 @@ interface RelationEditorContentProps {
 
 export const RelationEditorContent = (props: RelationEditorContentProps) => {
 
+  const { t } = useTranslation('annotate');
+
   const { source, target } = props;
   
   const [relation, setRelation] = useState<RelationshipType | undefined>();
@@ -38,12 +41,12 @@ export const RelationEditorContent = (props: RelationEditorContentProps) => {
   return (
     <div>
       <h3 className="flex text-xs text-muted-foreground items-center gap-1 font-medium">
-        <Spline className="h-4 w-4" /> Create Relation
+        <Spline className="h-4 w-4" /> {t('relationEditor.createRelation')}
       </h3>
 
       <ol className="list-decimal list-inside">
         <li className="text-xs mt-5 shrink-0">
-          Select a target annotation.
+          {t('relationEditor.selectTargetAnnotation')}
 
           <div className="mt-3 mb-1 ml-4 w-56 flex gap-1 justify-between items-center relative">
             <AnnotationThumbnail 
@@ -68,7 +71,7 @@ export const RelationEditorContent = (props: RelationEditorContentProps) => {
         </li>
 
         <li className="text-xs mt-6 mb-1 shrink-0">
-          Choose a relation type.
+          {t('relationEditor.chooseRelationType')}
 
           <div className="ml-4 mt-2">
             <RelationshipBrowserPopover 
@@ -83,13 +86,13 @@ export const RelationEditorContent = (props: RelationEditorContentProps) => {
       <Button 
         className="mt-6 w-full"
         disabled={!relation || !props.target}
-        onClick={onSave}>Save</Button>
+        onClick={onSave}>{t('common.save')}</Button>
 
       <Button
         variant="outline"
         className="mt-2 w-full"
         onClick={props.onCancel}>
-        Cancel
+        {t('common.cancel')}
       </Button>
     </div>
   )

--- a/src/pages/annotate/RelationEditor/RelationshipBrowser/RelationshipBrowser.tsx
+++ b/src/pages/annotate/RelationEditor/RelationshipBrowser/RelationshipBrowser.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 import ReactAutosuggest from 'react-autosuggest';
+import { useTranslation } from 'react-i18next';
 import { ImageAnnotation } from '@annotorious/react';
 import { RelationshipSearchResult, useRelationshipSearch } from '@/store';
 import { RelationshipType } from '@/model';
@@ -22,6 +23,8 @@ interface RelationshipBrowserProps {
 }
 
 export const RelationshipBrowser = (props: RelationshipBrowserProps) => {
+
+  const { t } = useTranslation('annotate');
 
   const [showNotApplicable, setShowNotApplicable] = useState(false);
 
@@ -83,17 +86,17 @@ export const RelationshipBrowser = (props: RelationshipBrowserProps) => {
           ) : (
             results.length === 0 ? (
               <div className="flex flex-col border-b justify-center items-center p-6 text-xs text-muted-foreground font-light bg-muted">
-                <span>No types found.</span>
+                <span>{t('relationEditor.noTypesFound')}</span>
               </div>
             ) : !showNotApplicable && (
               <div className="flex flex-col justify-center items-center border-b px-2 pt-6 pb-4 text-xs bg-muted">
-                <span>No applicable types found.</span>
+                <span>{t('relationEditor.noApplicableTypesFound')}</span>
 
                 <Button 
                   variant="outline"
                   className="py-0.5 px-1.5 mt-3 gap-1.5 text-[11.5px] font-normal text-muted-foreground/60 h-auto hover:bg-white"
                   onClick={() => setShowNotApplicable(true)}>
-                  <Eye className="h-3.5 w-3.5" strokeWidth={1.8} /> {results.length} not applicable type{results.length === 1 ? '' : 's'}
+                  <Eye className="h-3.5 w-3.5" strokeWidth={1.8} /> {t('relationEditor.notApplicableTypes', { count: results.length })}
                 </Button>
               </div>
             )
@@ -126,7 +129,7 @@ export const RelationshipBrowser = (props: RelationshipBrowserProps) => {
                 variant="outline"
                 className="py-0.5 px-1.5 gap-1.5 text-[11.5px] font-normal text-muted-foreground/60 h-auto hover:bg-white"
                 onClick={() => setShowNotApplicable(false)}>
-                <EyeOff className="h-3.5 w-3.5" strokeWidth={1.8} /> Hide not applicable types.
+                <EyeOff className="h-3.5 w-3.5" strokeWidth={1.8} /> {t('relationEditor.hideNotApplicableTypes')}
               </Button>
             </div>
           </div>
@@ -136,7 +139,7 @@ export const RelationshipBrowser = (props: RelationshipBrowserProps) => {
               variant="outline"
               className="py-0.5 px-1.5 gap-1.5 text-[11.5px] font-normal text-muted-foreground/60 h-auto hover:bg-white"
               onClick={() => setShowNotApplicable(true)}>
-              <Eye className="h-3.5 w-3.5" strokeWidth={1.8} /> {notApplicable} not applicable type{notApplicable === 1 ? '' : 's'}
+              <Eye className="h-3.5 w-3.5" strokeWidth={1.8} /> {t('relationEditor.notApplicableTypes', { count: notApplicable })}
             </Button>
           </div>
         )}
@@ -145,7 +148,7 @@ export const RelationshipBrowser = (props: RelationshipBrowserProps) => {
       <div className="flex px-1 pt-2 pb-1.5 overflow-hidden">
         {(query && !results.some(t => t.name === query)) ? (
           <div className="px-1.5 py-1 flex gap-1 items-center text-[11px] text-muted-foreground overflow-hidden">
-            <Spline className="h-4 w-4" /> Create
+            <Spline className="h-4 w-4" /> {t('relationEditor.create')}
             <Button
               size="sm"
               className="block font-light border h-auto text-[11px] rounded px-1.5 py-1 whitespace-nowrap overflow-hidden text-ellipsis"
@@ -160,8 +163,8 @@ export const RelationshipBrowser = (props: RelationshipBrowserProps) => {
             className="px-1.5 pr-2 pt-2 pb-1.5 text-[11px] text-muted-foreground flex gap-1 h-auto overflow-hidden"
             variant="ghost"
             onClick={onCreateNew}>
-            <Spline className="h-4 w-4" /> 
-            Create New Type
+            <Spline className="h-4 w-4" />
+            {t('relationEditor.createNewType')}
           </Button>
         )}
       </div>

--- a/src/pages/annotate/RelationEditor/RelationshipBrowser/RelationshipBrowserInput.tsx
+++ b/src/pages/annotate/RelationEditor/RelationshipBrowser/RelationshipBrowserInput.tsx
@@ -1,5 +1,6 @@
 import { forwardRef } from 'react';
 import { Search } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { RenderInputComponentProps } from 'react-autosuggest';
 
 interface RelationshipBrowserInputProps extends RenderInputComponentProps  {
@@ -10,6 +11,8 @@ interface RelationshipBrowserInputProps extends RenderInputComponentProps  {
 
 export const RelationshipBrowserInput = forwardRef((props: RelationshipBrowserInputProps, ref: React.Ref<HTMLDivElement>) => {
 
+  const { t } = useTranslation('annotate');
+
   return (
     <div className="flex border-b items-center py-1.5 px-1 text-xs">
       <Search className="w-8 h-4 px-2 text-muted-foreground" />
@@ -17,7 +20,7 @@ export const RelationshipBrowserInput = forwardRef((props: RelationshipBrowserIn
       <input 
         autoFocus
         {...props}
-        placeholder="Search..."
+        placeholder={t('common.searchPlaceholder')}
         className="relative top-[1px] py-1 outline-hidden px-0.5 grow" />
     </div>
   )

--- a/src/pages/annotate/SavingState/SavingStateIndicator.tsx
+++ b/src/pages/annotate/SavingState/SavingStateIndicator.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react'; 
+import { useEffect, useState } from 'react';
 import { FolderCheck, FolderSync, FolderX } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { useSavingState } from './useSavingState';
 import {
   Popover,
@@ -14,6 +15,8 @@ interface SavingStateIndicatorProps {
 }
 
 export const SavingStateIndicator = (props: SavingStateIndicatorProps) => {
+
+  const { t } = useTranslation('annotate');
 
   const { savingState } = useSavingState();
 
@@ -50,7 +53,7 @@ export const SavingStateIndicator = (props: SavingStateIndicatorProps) => {
             align="center"
             className="text-xs flex gap-2 font-medium w-auto items-center px-3.5 py-2.5
             justify-center text-green-600">
-            <FolderCheck className="h-4 w-4" />All annotations saved
+            <FolderCheck className="h-4 w-4" />{t('savingState.allSaved')}
           </PopoverContent>
         </Popover>
       ) : savingState.value === 'success' ? (
@@ -60,7 +63,7 @@ export const SavingStateIndicator = (props: SavingStateIndicatorProps) => {
               focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 items-center">
             <FolderCheck className="h-4 w-4" />
             <span style={{ opacity, width: opacity === 0 ? 0 : undefined}}>
-              <span className="ml-1">Saved</span>
+              <span className="ml-1">{t('savingState.saved')}</span>
             </span>
           </PopoverTrigger>
 
@@ -68,7 +71,7 @@ export const SavingStateIndicator = (props: SavingStateIndicatorProps) => {
             align="center"
             className="text-xs flex gap-2 font-medium w-[200px] items-center 
             justify-center text-green-600">
-            <FolderCheck className="h-4 w-4" />All annotations saved
+            <FolderCheck className="h-4 w-4" />{t('savingState.allSaved')}
           </PopoverContent>
         </Popover>
       ) : savingState.value === 'failed' ? (
@@ -77,7 +80,7 @@ export const SavingStateIndicator = (props: SavingStateIndicatorProps) => {
             className="p-2 flex gap-1 text-xs font-medium rounded-md hover:bg-muted focus-visible:outline-hidden 
               focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 items-center text-red-600">
             <FolderX size={16} />
-            <span>Failed</span>
+            <span>{t('savingState.failed')}</span>
           </PopoverTrigger> 
 
           <PopoverContent 
@@ -85,7 +88,7 @@ export const SavingStateIndicator = (props: SavingStateIndicatorProps) => {
             alignOffset={-18}
             className="text-xs flex gap-2 font-medium w-[200px] items-center 
             justify-center text-red-600">
-            <FolderX className="h-4 w-4" />{savingState.message || 'Error saving data'}
+            <FolderX className="h-4 w-4" />{savingState.message || t('savingState.errorSaving')}
           </PopoverContent>
         </Popover>
       ) : savingState.value === 'saving' ? (
@@ -93,7 +96,7 @@ export const SavingStateIndicator = (props: SavingStateIndicatorProps) => {
           className="p-2 flex text-xs rounded-md hover:bg-muted focus-visible:outline-hidden 
             focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 items-center">
           <FolderSync size={16} />
-          <span className="ml-1">Saving</span>
+          <span className="ml-1">{t('savingState.saving')}</span>
         </button>
       ) : null}
     </div>

--- a/src/pages/annotate/SidebarSection/AnnotationList/AnnotationList.tsx
+++ b/src/pages/annotate/SidebarSection/AnnotationList/AnnotationList.tsx
@@ -1,5 +1,6 @@
 import { type MouseEvent, useCallback, useMemo, useState } from 'react';
 import { Move } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { v4 as uuidv4 } from 'uuid';
 import { ImageAnnotation, parseW3CImageAnnotation } from '@annotorious/react';
 import type { AnnotoriousOpenSeadragonAnnotator, W3CImageAnnotation } from '@annotorious/react';
@@ -48,6 +49,8 @@ const cloneAnnotation = (annotation: ImageAnnotation): ImageAnnotation => {
 }
 
 export const AnnotationList = (props: AnnotationListProps) => {
+
+  const { t } = useTranslation('annotate');
 
   const manifold = useAnnotoriousManifold<ImageAnnotation, W3CImageAnnotation>();
 
@@ -180,7 +183,7 @@ export const AnnotationList = (props: AnnotationListProps) => {
       {!sorting && (
         <div className="px-1.5 py-3 border border-dashed border-slate-300/50 rounded mt-2.5 mb-1 text-muted-foreground/80 text-xs flex justify-center">
           <span className="flex gap-1.5">
-            <Move className="size-3.5 mt-px" /> Drag cards to change order
+            <Move className="size-3.5 mt-px" /> {t('annotationList.dragToChangeOrder')}
           </span>
         </div>
       )}

--- a/src/pages/annotate/SidebarSection/AnnotationList/AnnotationListItem.tsx
+++ b/src/pages/annotate/SidebarSection/AnnotationList/AnnotationListItem.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState, type MouseEvent } from 'react';
 import { CopyPlus, SquarePen, Trash2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { format } from 'date-fns';
+import { getDateLocale } from '@/i18n/dateLocale';
 import { useInView } from 'react-intersection-observer';
 import { DraggableAttributes } from '@dnd-kit/core';
 import type { SyntheticListenerMap } from '@dnd-kit/core/dist/hooks/utilities';
@@ -33,6 +35,8 @@ interface AnnotationListItemProps {
 }
 
 export const AnnotationListItem = (props: AnnotationListItemProps) => {
+
+  const { t } = useTranslation('annotate');
 
   const store = useStore();
 
@@ -120,7 +124,7 @@ export const AnnotationListItem = (props: AnnotationListItemProps) => {
 
           {isEmpty && (
             <div className="py-6 flex justify-center text-muted-foreground">
-              Empty annotation
+              {t('annotationList.emptyAnnotation')}
             </div>
           )}
         </button>
@@ -143,7 +147,7 @@ export const AnnotationListItem = (props: AnnotationListItemProps) => {
         <div className="bg-slate-50 border-t py-0.5 pl-2.5 pr-1 flex justify-between items-center text-[11px]">
           {lastEdit ? (
             <div className="text-gray-400">
-              {format(lastEdit, 'H:mm MMM dd')}
+              {format(lastEdit, 'H:mm MMM dd', { locale: getDateLocale() })}
             </div>
           ) : (
             <div />
@@ -154,7 +158,7 @@ export const AnnotationListItem = (props: AnnotationListItemProps) => {
               variant="ghost" 
               size="icon" 
               className="h-8 w-8 text-gray-400 hover:text-black"
-              tooltip="Edit"
+              tooltip={t('annotationList.editTooltip')}
               onClick={props.onEdit}>
               <SquarePen className="size-4" />
             </TooltippedButton>
@@ -163,7 +167,7 @@ export const AnnotationListItem = (props: AnnotationListItemProps) => {
               variant="ghost" 
               size="icon" 
               className="h-8 w-8 text-gray-400 hover:text-black"
-              tooltip="Duplicate this annotation"
+              tooltip={t('annotationList.duplicateTooltip')}
               onClick={props.onDuplicate}>
               <CopyPlus className="size-4" />
             </TooltippedButton>
@@ -172,7 +176,7 @@ export const AnnotationListItem = (props: AnnotationListItemProps) => {
               variant="ghost" 
               size="icon" 
               className="h-8 w-8 text-gray-400 hover:text-red-600"
-              tooltip="Delete"
+              tooltip={t('annotationList.deleteTooltip')}
               onClick={() => setConfirmDelete(true)}>
               <Trash2 className="size-4" />
             </TooltippedButton>
@@ -182,8 +186,8 @@ export const AnnotationListItem = (props: AnnotationListItemProps) => {
 
       <ConfirmedDelete
         open={confirmDelete}
-        title="Delete Annotation"
-        message="Are you sure you want to delete this annotation?"
+        title={t('annotationList.deleteAnnotation')}
+        message={t('annotationList.confirmDeleteAnnotation')}
         onConfirm={props.onDelete}
         onOpenChange={setConfirmDelete} />
     </>

--- a/src/pages/annotate/SidebarSection/AnnotationList/SelectAll.tsx
+++ b/src/pages/annotate/SidebarSection/AnnotationList/SelectAll.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/ui/Button';
 
 interface SelectAllProps {
@@ -10,12 +11,14 @@ interface SelectAllProps {
 
 export const SelectAll = (props: SelectAllProps) => {
 
+  const { t } = useTranslation('annotate');
+
   return (
     <Button
       disabled={props.disabled}
       className="p-0 font-normal text-xs hover:underline text-muted-foreground bg-transparent h-auto ml-1.5"
       onClick={props.onSelectAll}>
-      Select All
+      {t('annotationList.selectAll')}
     </Button>
   )
 

--- a/src/pages/annotate/SidebarSection/AnnotationList/SelectFilter.tsx
+++ b/src/pages/annotate/SidebarSection/AnnotationList/SelectFilter.tsx
@@ -1,4 +1,5 @@
 import { ChevronDown } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import type { ImageAnnotation, W3CImageAnnotation } from '@annotorious/react';
 import { EntityType } from '@/model';
 import { useStore } from '@/store';
@@ -24,14 +25,16 @@ interface SelectFilterOpts {
 
 }
 
-const LABELS = {
-  all: 'All',
-  with_entity: 'With Entity',
-  without_entity: 'Without Entity',
-  with_relationship: 'With Relation'
+const LABEL_KEYS = {
+  all: 'annotationList.filter.all',
+  with_entity: 'annotationList.filter.withEntity',
+  without_entity: 'annotationList.filter.withoutEntity',
+  with_relationship: 'annotationList.filter.withRelation'
 }
 
 export const SelectFilter = (props: SelectFilterOpts) => {
+
+  const { t } = useTranslation('annotate');
 
   const store = useStore();
 
@@ -156,16 +159,18 @@ export const SelectFilter = (props: SelectFilterOpts) => {
       if (filterValue.length === 1) {
         return first.substring(first.indexOf('-') + 1);
       } else {
-        return `${filterValue.length} ${first.startsWith('entity-') ? 'classes' : 'relations'}`; 
+        return first.startsWith('entity-')
+          ? t('annotationList.filter.nClasses', { count: filterValue.length })
+          : t('annotationList.filter.nRelations', { count: filterValue.length });
       }
     } else {
-      return LABELS[filterValue];
+      return t(LABEL_KEYS[filterValue]);
     }
   }
 
   return (
     <div className="flex text-xs">
-      Show <DropdownMenu>
+      {t('annotationList.show')} <DropdownMenu>
         <DropdownMenuTrigger 
           className="flex overflow-hidden items-center p-0 whitespace-nowrap [&>span]:max-w-24 [&>span]:overflow-hidden [&>span]:text-ellipsis shadow-none font-medium border-none text-xs hover:underline bg-transparent h-auto ml-1.5">
           <div className="max-w-22 truncate">{getLabel()}</div>
@@ -178,7 +183,7 @@ export const SelectFilter = (props: SelectFilterOpts) => {
               checked={filterValue === 'all'}
               onCheckedChange={() => onSetValue('all', true)}
               className="text-xs text-muted-foreground py-1">
-              All
+              {t('annotationList.filter.all')}
             </DropdownMenuCheckboxItem>
 
             <DropdownMenuCheckboxItem
@@ -186,7 +191,7 @@ export const SelectFilter = (props: SelectFilterOpts) => {
               checked={filterValue === 'with_entity'}
               onCheckedChange={checked => onSetValue('with_entity', checked)}
               className="text-xs text-muted-foreground py-1">
-              With Entity
+              {t('annotationList.filter.withEntity')}
             </DropdownMenuCheckboxItem>
 
             <DropdownMenuCheckboxItem 
@@ -194,7 +199,7 @@ export const SelectFilter = (props: SelectFilterOpts) => {
               checked={filterValue === 'without_entity'}
               onCheckedChange={checked => onSetValue('without_entity', checked)}
               className="text-xs text-muted-foreground py-1">
-              Without Entity
+              {t('annotationList.filter.withoutEntity')}
             </DropdownMenuCheckboxItem>
 
             <DropdownMenuCheckboxItem 
@@ -202,7 +207,7 @@ export const SelectFilter = (props: SelectFilterOpts) => {
               checked={filterValue === 'with_relationship'}
               onCheckedChange={checked => onSetValue('with_relationship', checked)}
               className="text-xs text-muted-foreground py-1">
-              With Relation
+              {t('annotationList.filter.withRelation')}
             </DropdownMenuCheckboxItem>
           </DropdownMenuGroup>
 
@@ -210,7 +215,7 @@ export const SelectFilter = (props: SelectFilterOpts) => {
             <DropdownMenuGroup>
               <DropdownMenuLabel
                 className="text-xs py-1">
-                Entity Classes
+                {t('annotationList.filter.entityClasses')}
               </DropdownMenuLabel>
 
               {props.entityTypes.map(type => (
@@ -229,7 +234,7 @@ export const SelectFilter = (props: SelectFilterOpts) => {
             <DropdownMenuGroup>
               <DropdownMenuLabel
                 className="text-xs py-1">
-                Relationship Types
+                {t('annotationList.filter.relationshipTypes')}
               </DropdownMenuLabel>
               {props.relationshipNames.map(name => (
                 <DropdownMenuCheckboxItem 

--- a/src/pages/annotate/SidebarSection/AnnotationList/SelectListOrder.tsx
+++ b/src/pages/annotate/SidebarSection/AnnotationList/SelectListOrder.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { W3CImageAnnotation } from '@annotorious/react';
 import { useDataModel } from '@/store';
 import { usePersistentState } from '@/utils/usePersistentState';
@@ -34,6 +35,8 @@ const SORT_BY_CREATED_DESCENDING = (a: W3CImageAnnotation, b: W3CImageAnnotation
 export const DEFAULT_SORTING = SORT_BY_CREATED_DESCENDING;
 
 export const SelectListOrder = (props: SelectListOrderProps) => {
+
+  const { t } = useTranslation('annotate');
 
   const datamodel = useDataModel();
 
@@ -80,10 +83,10 @@ export const SelectListOrder = (props: SelectListOrderProps) => {
         </SelectTrigger>
 
         <SelectContent>
-          <SelectItem value="recent">recent</SelectItem>
-          <SelectItem value="oldest">oldest</SelectItem>
-          <SelectItem value="entity">entity</SelectItem>
-          <SelectItem value="custom">custom</SelectItem>
+          <SelectItem value="recent">{t('annotationList.order.recent')}</SelectItem>
+          <SelectItem value="oldest">{t('annotationList.order.oldest')}</SelectItem>
+          <SelectItem value="entity">{t('annotationList.order.entity')}</SelectItem>
+          <SelectItem value="custom">{t('annotationList.order.custom')}</SelectItem>
         </SelectContent>
       </Select>
     </div>

--- a/src/pages/annotate/SidebarSection/CurrentSelection/CurrentSelection.tsx
+++ b/src/pages/annotate/SidebarSection/CurrentSelection/CurrentSelection.tsx
@@ -1,5 +1,6 @@
 import { Trash2 } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ImageAnnotation, createBody } from '@annotorious/react';
 import { useAnnotoriousManifold, useSelection } from '@annotorious/react-manifold';
 import { isW3CRelationLinkAnnotation } from '@annotorious/plugin-wires-react';
@@ -20,6 +21,8 @@ interface SearchDialogState {
 }
 
 export const CurrentSelection = () => {
+
+  const { t } = useTranslation('annotate');
 
   const store = useStore();
 
@@ -127,7 +130,7 @@ export const CurrentSelection = () => {
     <>
       {selected.length === 0 ? (
         <div className="flex h-full rounded text-sm justify-center items-center w-full text-muted-foreground">
-          No annotation selected
+          {t('currentSelection.noAnnotationSelected')}
         </div> 
       ) : selected.length === 1 ? (
         <div 
@@ -140,11 +143,11 @@ export const CurrentSelection = () => {
                   ref={ref}
                   onClick={() => setSearchDialogState({ open: true })}
                   onKeyDown={onKeyDown}
-                  className="px-3 mr-2 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2">Add Tag</Button>
+                  className="px-3 mr-2 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2">{t('currentSelection.addTag')}</Button>
 
                 <Button
                   onClick={() => setShowAsEmpty(false)}
-                  variant="outline">Add Note</Button>
+                  variant="outline">{t('currentSelection.addNote')}</Button>
               </div>
             </div>
           ) : (
@@ -157,10 +160,10 @@ export const CurrentSelection = () => {
             <ConfirmedDelete
               variant="destructive" 
               className="w-full mt-2 mb-2"
-              title="Delete Annotation"
-              message="Are you sure you want to delete this annotation?"
+              title={t('currentSelection.deleteAnnotation')}
+              message={t('currentSelection.confirmDeleteAnnotation')}
               onConfirm={() => onDelete(selected[0])}>
-              <Trash2 className="w-4 h-4 mr-2" /> Delete Annotation
+              <Trash2 className="w-4 h-4 mr-2" /> {t('currentSelection.deleteAnnotation')}
             </ConfirmedDelete>
           </footer>
         </div>

--- a/src/pages/annotate/SidebarSection/CurrentSelection/MultiSelectionTools/Compare/CompareDialog.tsx
+++ b/src/pages/annotate/SidebarSection/CurrentSelection/MultiSelectionTools/Compare/CompareDialog.tsx
@@ -1,4 +1,5 @@
 import { X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { ImageAnnotation } from '@annotorious/react';
 import { DialogClose } from '@radix-ui/react-dialog';
 import { Button } from '@/ui/Button';
@@ -24,6 +25,8 @@ interface CompareDialogProps {
 
 export const CompareDialog = (props: CompareDialogProps) => {
 
+  const { t } = useTranslation('annotate');
+
   const onOpenChange = (open: boolean) => {
     if (!open)
       props.onClose();
@@ -40,7 +43,7 @@ export const CompareDialog = (props: CompareDialogProps) => {
           overflow-hidden relative gap-1">
         <div className="flex items-center justify-between w-full px-5 pt-3 pb-2">
           <DialogTitle className="font-medium text-base">
-            Compare {props.selected.length} Annotations
+            {t('multiSelection.compareDialogTitle', { count: props.selected.length })}
           </DialogTitle>
 
           <DialogClose asChild>
@@ -54,7 +57,7 @@ export const CompareDialog = (props: CompareDialogProps) => {
         </div>
 
         <DialogDescription className="sr-only">
-          Compare {props.selected.length} Annotations
+          {t('multiSelection.compareDialogTitle', { count: props.selected.length })}
         </DialogDescription>
         
         <div className="grow relative overflow-x-auto overflow-y-hidden px-4 pb-3">

--- a/src/pages/annotate/SidebarSection/CurrentSelection/MultiSelectionTools/MultiSelectionThumbnails.tsx
+++ b/src/pages/annotate/SidebarSection/CurrentSelection/MultiSelectionTools/MultiSelectionThumbnails.tsx
@@ -1,6 +1,7 @@
 import { AnnotationThumbnail } from '@/components/AnnotationThumbnail';
 import { ImageAnnotation } from '@annotorious/react';
 import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 
 interface MultiSelectionThumbnailsProps {
 
@@ -15,6 +16,8 @@ const stackStyles = [
 ];
 
 export const MultiSelectionThumbnails = (props: MultiSelectionThumbnailsProps) => {
+
+  const { t } = useTranslation('annotate');
 
   const first = useMemo(() => [...props.selected].slice(0, 3).reverse(), [props.selected]);
 
@@ -38,7 +41,7 @@ export const MultiSelectionThumbnails = (props: MultiSelectionThumbnailsProps) =
       </div>
 
       <div className="h-full px-1 py-2 font-medium">
-        {props.selected.length} Annotations
+        {t('multiSelection.annotations', { count: props.selected.length })}
       </div>
     </div>
   )

--- a/src/pages/annotate/SidebarSection/CurrentSelection/MultiSelectionTools/MultiSelectionTools.tsx
+++ b/src/pages/annotate/SidebarSection/CurrentSelection/MultiSelectionTools/MultiSelectionTools.tsx
@@ -6,6 +6,7 @@ import { mountPlugin } from '@annotorious/plugin-boolean-operations';
 import { Columns3, Cuboid, Trash2 } from 'lucide-react';
 import { CompareDialog } from './Compare/CompareDialog';
 import { ReactNode, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { MultiSelectionThumbnails } from './MultiSelectionThumbnails';
 
 interface MultiSelectionOptionsProps {
@@ -21,6 +22,8 @@ interface MultiSelectionOptionsProps {
 }
 
 export const MultiSelectionTools = (props: MultiSelectionOptionsProps) => {
+
+  const { t } = useTranslation('annotate');
 
   const [showCompareDialog, setShowCompareDialog] = useState(false);
 
@@ -95,27 +98,27 @@ export const MultiSelectionTools = (props: MultiSelectionOptionsProps) => {
 
         <div className="space-y-4">
           {renderButton(
-            'Compare', 'View selected annotations side by side.',
+            t('multiSelection.compare'), t('multiSelection.compareHint'),
             <Columns3 className="size-5" />,
             () => setShowCompareDialog(true)
           )}
 
           {renderButton(
-            'Add Tag', 'Apply the same tag to all selected annotations.',
+            t('multiSelection.addTag'), t('multiSelection.addTagHint'),
             <Cuboid className="size-5" />,
             () => props.onAddTag()
           )}
 
           {renderButton(
-            'Merge', 'Combine selected annotations. Preserves all tags and concatenates notes in the order of selection.',
+            t('multiSelection.merge'), t('multiSelection.mergeHint'),
             <Combine className="size-5" />,
             onMergeSelected,
             props.isCrossImageSelection
           )}
 
           {renderButton(
-            'Subtract', 
-            'Keep first annotation, delete all others. Overlapping areas are removed from the first annotation.',
+            t('multiSelection.subtract'),
+            t('multiSelection.subtractHint'),
             <Subtract className="size-5" />,
             () => plugin.subtractSelected(),
             !canSubtract
@@ -133,7 +136,7 @@ export const MultiSelectionTools = (props: MultiSelectionOptionsProps) => {
         className="flex gap-2"
         variant="destructive"
         onClick={props.onDeleteSelected}>
-        <Trash2 className="size-5" /> Delete Selected
+        <Trash2 className="size-5" /> {t('multiSelection.deleteSelected')}
       </Button>
     </div>
   )

--- a/src/pages/annotate/SidebarSection/CurrentSelection/PropertiesForm/PropertiesForm.tsx
+++ b/src/pages/annotate/SidebarSection/CurrentSelection/PropertiesForm/PropertiesForm.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import { dequal } from 'dequal/lite';
+import { useTranslation } from 'react-i18next';
 import { useAnnotoriousManifold } from '@annotorious/react-manifold';
 import { AnnotationBody, ImageAnnotation, W3CAnnotationBody, createBody } from '@annotorious/react';
 import { W3CRelationMetaAnnotation } from '@annotorious/plugin-wires-react';
@@ -31,6 +32,8 @@ interface PropertiesFormProps {
 }
 
 export const PropertiesForm = (props: PropertiesFormProps) => {
+
+  const { t } = useTranslation('annotate');
 
   const { annotation } = props;
 
@@ -283,7 +286,7 @@ export const PropertiesForm = (props: PropertiesFormProps) => {
         <Button 
           disabled={!hasChanges}
           className="w-full" 
-          type="submit">Save</Button> 
+          type="submit">{t('common.save')}</Button>
       </form>
     </PropertyValidation>
   )

--- a/src/pages/annotate/SidebarSection/CurrentSelection/PropertiesForm/PropertiesFormActions.tsx
+++ b/src/pages/annotate/SidebarSection/CurrentSelection/PropertiesForm/PropertiesFormActions.tsx
@@ -1,4 +1,5 @@
 import { Cuboid, NotebookPen } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/ui/Button';
 import { FontSize, FontSizeButton } from '@/components/FontSize';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ui/Tooltip';
@@ -22,6 +23,8 @@ interface PropertiesFormActionsProps {
 
 export const PropertiesFormActions = (props: PropertiesFormActionsProps) => {
 
+  const { t } = useTranslation('annotate');
+
   return (
     <div className="pt-0.5 pb-2 flex gap-1 justify-between text-muted-foreground mb-4">
       <Button 
@@ -29,7 +32,7 @@ export const PropertiesFormActions = (props: PropertiesFormActionsProps) => {
         type="button"
         className="text-xs pl-2 pr-2.5 font-normal py-3.5 h-6 rounded-full whitespace-nowrap"
         onClick={props.onAddTag}>
-        <Cuboid className="h-3.5 w-3.5 mr-1.5" /> Add Tag
+        <Cuboid className="h-3.5 w-3.5 mr-1.5" /> {t('propertiesForm.addTag')}
       </Button>
 
       {props.hasNote ? (
@@ -48,12 +51,12 @@ export const PropertiesFormActions = (props: PropertiesFormActionsProps) => {
                 type="button"
                 className="h-6 w-auto py-3.5 px-2 rounded-full font-normal text-xs"
                 onClick={props.onClearNote}>
-                Clear Note
+                {t('propertiesForm.clearNote')}
               </Button>
             </TooltipTrigger>
 
             <TooltipContent>
-              Clear note
+              {t('propertiesForm.clearNoteTooltip')}
             </TooltipContent>
           </Tooltip>
         </div>
@@ -63,7 +66,7 @@ export const PropertiesFormActions = (props: PropertiesFormActionsProps) => {
           type="button"
           className="text-xs pl-2 pr-2.5 py-3.5 h-6 font-normal rounded-full whitespace-nowrap"
           onClick={props.onAddNote}>
-          <NotebookPen className="h-4 w-4 mr-1" /> Add Note
+          <NotebookPen className="h-4 w-4 mr-1" /> {t('propertiesForm.addNote')}
         </Button>
       )}
     </div>

--- a/src/pages/annotate/SidebarSection/CurrentSelection/PropertiesForm/RelationsList/RelationsList.tsx
+++ b/src/pages/annotate/SidebarSection/CurrentSelection/PropertiesForm/RelationsList/RelationsList.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ImageAnnotation } from '@annotorious/react';
 import { W3CRelationLinkAnnotation, W3CRelationMetaAnnotation } from '@annotorious/plugin-wires-react';
 import { useStore } from '@/store';
@@ -15,6 +16,8 @@ interface RelationsListProps {
 }
 
 export const RelationsList = (props: RelationsListProps) => {
+
+  const { t } = useTranslation('annotate');
 
   const store = useStore();
 
@@ -40,7 +43,7 @@ export const RelationsList = (props: RelationsListProps) => {
     <div>
       <h3 className="font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70 text-sm 
         ml-0.5 flex gap-1.5 pt-4 pb-1 items-center">
-        <span>Related Annotations</span>
+        <span>{t('propertiesForm.relatedAnnotations')}</span>
       </h3>
 
       <ul>

--- a/src/pages/annotate/SidebarSection/CurrentSelection/PropertiesForm/RelationsList/RelationsListItem.tsx
+++ b/src/pages/annotate/SidebarSection/CurrentSelection/PropertiesForm/RelationsList/RelationsListItem.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 import { Trash2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { W3CImageAnnotation } from '@annotorious/react';
 import { AnnotationThumbnail } from '@/components/AnnotationThumbnail';
 import { Combobox, ComboboxOption } from '@/components/Combobox';
@@ -25,6 +26,8 @@ interface RelationsListItemProps {
 }
 
 export const RelationsListItem = (props: RelationsListItemProps) => {
+
+  const { t } = useTranslation('annotate');
 
   const model = useDataModel();
 
@@ -97,14 +100,14 @@ export const RelationsListItem = (props: RelationsListItemProps) => {
 
       <ConfirmedDelete
         asChild
-        message="This action will delete the relation permanently."
+        message={t('propertiesForm.deleteRelationMessage')}
         onConfirm={onDelete}>
         <TooltippedButton 
           variant="ghost" 
           size="icon" 
           type="button"
           className="rounded-full h-8 w-8 hover:text-red-500"
-          tooltip="Delete this relationship">
+          tooltip={t('propertiesForm.deleteRelationTooltip')}>
           <Trash2 className="h-4 w-4" />  
         </TooltippedButton>
       </ConfirmedDelete>

--- a/src/pages/annotate/SidebarSection/CurrentSelection/PropertiesFormSection/PropertiesFormSectionActions.tsx
+++ b/src/pages/annotate/SidebarSection/CurrentSelection/PropertiesFormSection/PropertiesFormSectionActions.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Replace, Settings, Trash2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { EntityTypeEditor } from '@/components/EntityTypeEditor';
 import { TooltippedButton } from '@/components/TooltippedButton';
 import { EntityType } from '@/model';
@@ -21,6 +22,8 @@ interface PropertiesFormSectionActionsProps {
 
 export const PropertiesFormSectionActions = (props: PropertiesFormSectionActionsProps) => {
 
+  const { t } = useTranslation('annotate');
+
   const model = useDataModel();
 
   const [edited, setEdited] = useState<EntityType | undefined>();
@@ -40,7 +43,7 @@ export const PropertiesFormSectionActions = (props: PropertiesFormSectionActions
               type="button"
               size="icon" 
               className="rounded-full h-8 w-8"
-              tooltip="Edit entity schema">
+              tooltip={t('propertiesForm.editEntitySchema')}>
               <Settings className="h-4 w-4" />
             </TooltippedButton>
           </DropdownMenuTrigger>
@@ -69,7 +72,7 @@ export const PropertiesFormSectionActions = (props: PropertiesFormSectionActions
           size="icon" 
           className="rounded-full h-8 w-8"
           type="button"
-          tooltip="Edit entity schema"
+          tooltip={t('propertiesForm.editEntitySchema')}
           onClick={() => setEdited(withoutInherited)}>
           <Settings className="h-4 w-4" />
         </TooltippedButton>
@@ -80,7 +83,7 @@ export const PropertiesFormSectionActions = (props: PropertiesFormSectionActions
         size="icon" 
         type="button"
         className="rounded-full h-8 w-8 -ml-1 hover:text-red-500"
-        tooltip="Delete this tag"
+        tooltip={t('propertiesForm.deleteTag')}
         onClick={props.onDeleteBody}>
         <Trash2 className="h-4 w-4" />
       </TooltippedButton>

--- a/src/pages/annotate/SidebarSection/ImageMetadata/ImageMetadataSection.tsx
+++ b/src/pages/annotate/SidebarSection/ImageMetadata/ImageMetadataSection.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react';
 import { NotebookPen } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { W3CAnnotationBody } from '@annotorious/react';
 import { CanvasInformation, Image } from '@/model';
 import { useImageMetadata } from '@/store';
@@ -20,6 +21,8 @@ interface ImageMetadataSectionProps {
 
 const IIIFManifestMetadataTab = (props: ImageMetadataSectionProps) => {
 
+  const { t } = useTranslation('annotate');
+
   const { manifestId } = props.image as CanvasInformation;
 
   const manifest = useIIIFResource(manifestId);
@@ -32,12 +35,14 @@ const IIIFManifestMetadataTab = (props: ImageMetadataSectionProps) => {
   return metadata ? (
     <IIIFMetadataList 
       metadata={metadata} 
-      emptyMessage="No Manifest Metadata" />
+      emptyMessage={t('imageMetadata.noManifestMetadata')} />
   ) : null;
 
 }
 
 const IIIFCanvasMetadataTab = (props: ImageMetadataSectionProps) => {
+
+  const { t } = useTranslation('annotate');
 
   const { manifestId, id: canvasId } = props.image as CanvasInformation;
 
@@ -59,11 +64,13 @@ const IIIFCanvasMetadataTab = (props: ImageMetadataSectionProps) => {
     <IIIFMetadataList 
       annotations={annotations}
       metadata={metadata} 
-      emptyMessage="No Canvas Metadata" />
+      emptyMessage={t('imageMetadata.noCanvasMetadata')} />
   );
 }
 
 const MyImageMetadataTab = (props: ImageMetadataSectionProps) => {
+
+  const { t } = useTranslation('annotate');
 
   const { image } = props;
 
@@ -98,7 +105,7 @@ const MyImageMetadataTab = (props: ImageMetadataSectionProps) => {
         <Button 
           disabled={!hasChanges(metadata, formState)} 
           className="w-full mb-2">
-          Save Metadata
+          {t('imageMetadata.saveMetadata')}
         </Button>
       </form>
     </PropertyValidation>
@@ -107,6 +114,8 @@ const MyImageMetadataTab = (props: ImageMetadataSectionProps) => {
 }
 
 export const ImageMetadataSection = (props: ImageMetadataSectionProps) => {
+
+  const { t } = useTranslation('annotate');
 
   const { image } = props;
 
@@ -118,19 +127,19 @@ export const ImageMetadataSection = (props: ImageMetadataSectionProps) => {
         <TabsTrigger 
           value="iiif-manifest"
           className="text-xs py-1 flex gap-1 items-center">
-          <IIIFIcon light className="size-3.5 mb-0.5" /> Manifest
+          <IIIFIcon light className="size-3.5 mb-0.5" /> {t('imageMetadata.manifest')}
         </TabsTrigger>
 
         <TabsTrigger 
           value="iiif-canvas"
           className="text-xs py-1 flex gap-1 items-center">
-          <IIIFIcon light className="size-3.5 mb-0.5" /> Canvas
+          <IIIFIcon light className="size-3.5 mb-0.5" /> {t('imageMetadata.canvas')}
         </TabsTrigger>
 
         <TabsTrigger 
           value="my"
           className="text-xs py-1 px-2 flex gap-1">
-          <NotebookPen className="size-3.5" /> My
+          <NotebookPen className="size-3.5" /> {t('imageMetadata.my')}
         </TabsTrigger>
       </TabsList>
       

--- a/src/pages/annotate/SidebarSection/SidebarSection.tsx
+++ b/src/pages/annotate/SidebarSection/SidebarSection.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Funnel, Image, MessagesSquare, SquareMousePointer } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { useSelection } from '@annotorious/react-manifold';
 import * as Tabs from '@radix-ui/react-tabs';
 import { Separator } from '@/ui/Separator';
@@ -17,6 +18,8 @@ interface SidebarSectionProps {
 }
 
 export const SidebarSection = (props: SidebarSectionProps) => {
+
+  const { t } = useTranslation('annotate');
 
   const { selected } = useSelection();
 
@@ -41,7 +44,7 @@ export const SidebarSection = (props: SidebarSectionProps) => {
             <Tabs.Trigger 
               value="selection" 
               className="relative group p-1.5 flex items-center text-xs rounded-md hover:bg-muted">
-              <SquareMousePointer className="h-4 w-4 mr-1" /> Selection
+              <SquareMousePointer className="h-4 w-4 mr-1" /> {t('sidebar.selection')}
               {showSelectionPip && (
                 <div className="absolute top-1 left-1 border border-white group-hover:border-muted size-2 rounded-full bg-orange-400" />
               )}
@@ -53,15 +56,15 @@ export const SidebarSection = (props: SidebarSectionProps) => {
               {props.filterState ? (
                 <Funnel className="size-4 mr-1" /> 
               ) : (
-                <MessagesSquare className="size-4 mr-1" /> 
-              )} List
+                <MessagesSquare className="size-4 mr-1" />
+              )} {t('sidebar.list')}
               {showListPip && (
                 <div className="absolute top-1 left-1 border border-white group-hover:border-muted size-2 rounded-full bg-orange-400" />
               )}
             </Tabs.Trigger>
 
             <Tabs.Trigger value="image-notes" className="p-1.5 flex items-center text-xs rounded-md hover:bg-muted text-muted-foreground">
-              <Image className="h-4 w-4 mr-1" /> Metadata
+              <Image className="h-4 w-4 mr-1" /> {t('sidebar.metadata')}
             </Tabs.Trigger>
           </Tabs.List>
         </section>

--- a/src/pages/annotate/SmartTools/AutoSelect/AutoSelect.tsx
+++ b/src/pages/annotate/SmartTools/AutoSelect/AutoSelect.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Minus, WandSparkles } from 'lucide-react';
 import { ImageAnnotation } from '@annotorious/react';
 import { useAnnotoriousManifold, PluginManifoldProxy } from '@annotorious/react-manifold';
@@ -19,6 +20,8 @@ interface AutoSelectProps {
 }
 
 export const AutoSelect = (props: AutoSelectProps) => {
+
+  const { t } = useTranslation('smartTools');
 
   const { busy, enabled, plugin } = props;
 
@@ -87,7 +90,7 @@ export const AutoSelect = (props: AutoSelectProps) => {
   return (
     <div className="px-3">
       <p className="pt-4 font-medium text-center leading-relaxed">
-        Hover to preview a selection. Click to confirm. Add or remove points to refine.
+        {t('autoSelect.instructions')}
       </p>
 
       <ToggleGroup
@@ -105,7 +108,7 @@ export const AutoSelect = (props: AutoSelectProps) => {
               <WandSparkles className="size-5" />
             )}
           </ToggleGroupItem>
-          <span className="pt-1 text-orange-600/40">Select object</span>
+          <span className="pt-1 text-orange-600/40">{t('autoSelect.selectObject')}</span>
         </div>
 
         <div className="flex flex-col items-center gap-1">
@@ -114,7 +117,7 @@ export const AutoSelect = (props: AutoSelectProps) => {
             className="rounded-md! aspect-square h-12 hover:border-orange-400/70 hover:[&+*]:text-orange-400 border border-orange-500/25 text-orange-400/25 hover:text-orange-400/70 data-[state=on]:bg-orange-400 data-[state=on]:border-orange-400 data-[state=on]:[&+*]:text-orange-400">
             <Minus className="size-5"/>
           </ToggleGroupItem>
-          <span className="pt-1 text-orange-600/40">Remove area</span>
+          <span className="pt-1 text-orange-600/40">{t('autoSelect.removeArea')}</span>
         </div>
       </ToggleGroup>
 
@@ -124,14 +127,14 @@ export const AutoSelect = (props: AutoSelectProps) => {
             disabled={!enabled || !currentAnnotationId}
             onClick={onConfirm}
             className="px-8 rounded-l-md border border-r-0 border-orange-400 py-1.5 bg-orange-400 hover:bg-orange-400/90 disabled:border-orange-300/5 disabled:bg-orange-500/25">
-            Done
+            {t('autoSelect.done')}
           </button>
 
           <button 
             disabled={!enabled || !currentAnnotationId}
             onClick={onReset}
             className="px-8 rounded-r-md py-1.5 bg-transparent text-orange-500 border border-l-0 border-orange-400 hover:bg-orange-500/10 disabled:bg-orange-500/25 disabled:border-orange-300/5 disabled:text-white">
-            Reset
+            {t('autoSelect.reset')}
           </button>
         </div>
       </div>

--- a/src/pages/annotate/SmartTools/EdgeSnap/EdgeSnap.tsx
+++ b/src/pages/annotate/SmartTools/EdgeSnap/EdgeSnap.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Toggle } from '@/ui/Toggle';
 import { Magnet } from 'lucide-react';
 
@@ -10,6 +11,8 @@ interface EdgeSnapProps {
 }
 
 export const EdgeSnap = (props: EdgeSnapProps) => {
+
+  const { t } = useTranslation('smartTools');
 
   return (
     <div className="px-4">
@@ -24,13 +27,12 @@ export const EdgeSnap = (props: EdgeSnapProps) => {
         </div>
 
         <p className="font-medium">
-          Snaps your cursor to nearby edges.
+          {t('edgeSnap.instructions')}
         </p>
       </div>
 
       <p className="pt-3 pb-2 font-light leading-relaxed">
-        Ideal for tracing objects with clear, straight outlines—especially 
-        in high-contrast images.
+        {t('edgeSnap.hint')}
       </p>
     </div>
   )

--- a/src/pages/annotate/SmartTools/SAMInitializing.tsx
+++ b/src/pages/annotate/SmartTools/SAMInitializing.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { PluginManifoldProxy } from '@annotorious/react-manifold';
 import { mountOpenSeadragonPlugin } from '@annotorious/plugin-segment-anything/openseadragon';
 import { Spinner } from '@/components/Spinner';
@@ -15,6 +16,8 @@ interface SAMInitializingProps {
 
 export const SAMInitializing = (props: SAMInitializingProps) => {
 
+  const { t } = useTranslation('smartTools');
+
   const { plugin, downloading, progress } = props;
 
   useEffect(() => {
@@ -26,7 +29,7 @@ export const SAMInitializing = (props: SAMInitializingProps) => {
     <div>
       {downloading ? (
         <div className="min-h-36 flex flex-col items-center p-4 space-y-4 relative">
-          <div>Downloading AI model</div>
+          <div>{t('sam.downloadingModel')}</div>
 
           <div className="w-full bg-stone-200 rounded-full h-0.5">
             <div 
@@ -36,8 +39,7 @@ export const SAMInitializing = (props: SAMInitializingProps) => {
           </div>
 
           <div className="text-muted-foreground text-center leading-relaxed">
-            This may take a while. The model will remain stored in your browser
-            for future uses.
+            {t('sam.downloadHint')}
           </div>
         </div>
       ) : (

--- a/src/pages/annotate/SmartTools/SmartScissors/SmartScissors.tsx
+++ b/src/pages/annotate/SmartTools/SmartScissors/SmartScissors.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Toggle } from '@/ui/Toggle';
 import { ScissorsLineDashed } from 'lucide-react';
 
@@ -10,6 +11,8 @@ interface SmartScissorsProps {
 }
 
 export const SmartScissors = (props: SmartScissorsProps) => {
+
+  const { t } = useTranslation('smartTools');
 
   return (
     <div className="px-4">
@@ -24,12 +27,12 @@ export const SmartScissors = (props: SmartScissorsProps) => {
         </div>
 
         <p className="font-medium">
-          Click to start, move to follow edges. Click again to place points.
+          {t('smartScissors.instructions')}
         </p>
       </div>
 
       <p className="pt-3 pb-2 font-light leading-relaxed">
-        Ideal for quickly tracing complex shapes and curved edges.
+        {t('smartScissors.hint')}
       </p>
     </div>
   )

--- a/src/pages/annotate/SmartTools/SmartToolsPanel.tsx
+++ b/src/pages/annotate/SmartTools/SmartToolsPanel.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
 import { useDraggable } from '@neodrag/react';
 import { CircleX, FlaskConical, Grip, Images, Magnet, ScanText, ScissorsLineDashed, Sparkles, X } from 'lucide-react';
 import { LoadedImage } from '@/model';
@@ -40,6 +41,8 @@ interface SmartToolsPanelProps {
 type SmartTool = 'smart-scissors' | 'edge-snap' | 'auto-select' | 'transcribe' | 'visual-search'; 
 
 export const SmartToolsPanel = (props: SmartToolsPanelProps) => {
+
+  const { t } = useTranslation('smartTools');
 
   const el = useRef(null);
 
@@ -123,7 +126,7 @@ export const SmartToolsPanel = (props: SmartToolsPanelProps) => {
       <div className="flex items-center justify-between gap-1.5 text-xs font-semibold py-1 px-2 border-b border-stone-200 cursor-grab drag-handle">
         <div className="flex items-center gap-1.5">
           <Grip className="size-4" />
-          <span>Smart Tools</span>
+          <span>{t('panel.title')}</span>
         </div>
 
         <Button
@@ -143,7 +146,7 @@ export const SmartToolsPanel = (props: SmartToolsPanelProps) => {
             <AccordionTrigger 
               className="text-xs font-normal hover:no-underline overflow-hidden p-2 gap-2 justify-start">
               <span className="flex grow items-center gap-2 justify-start">
-                <ScissorsLineDashed className="size-4" /> Smart Scissors
+                <ScissorsLineDashed className="size-4" /> {t('panel.smartScissors')}
               </span>
             </AccordionTrigger>
 
@@ -158,7 +161,7 @@ export const SmartToolsPanel = (props: SmartToolsPanelProps) => {
             <AccordionTrigger 
               className="text-xs font-normal border-t hover:no-underline overflow-hidden p-2 gap-2 justify-start">
               <span className="flex grow items-center gap-2 justify-start">
-                <Magnet className="size-4" /> Edge Snap
+                <Magnet className="size-4" /> {t('panel.edgeSnap')}
               </span>
             </AccordionTrigger>
 
@@ -173,7 +176,7 @@ export const SmartToolsPanel = (props: SmartToolsPanelProps) => {
             <AccordionTrigger 
               className="text-xs font-normal border-t hover:no-underline overflow-hidden p-2">
               <span className="flex grow items-center gap-2 justify-start">
-                <Sparkles className="size-4" /> Auto Select
+                <Sparkles className="size-4" /> {t('panel.autoSelect')}
               </span>
             </AccordionTrigger>
 
@@ -198,7 +201,7 @@ export const SmartToolsPanel = (props: SmartToolsPanelProps) => {
               <AccordionTrigger 
                 className="text-xs font-normal border-t hover:no-underline overflow-hidden p-2">
                 <span className="flex grow items-center gap-2 justify-start">
-                  <ScanText className="size-4" /> Auto Transcribe
+                  <ScanText className="size-4" /> {t('panel.autoTranscribe')}
                 </span>
               </AccordionTrigger>
 
@@ -214,11 +217,11 @@ export const SmartToolsPanel = (props: SmartToolsPanelProps) => {
               className="text-xs font-normal border-t hover:no-underline overflow-hidden p-2 disabled:text-muted-foreground/30">
               {visualSearchAvailable ? (
                 <span className="flex grow items-center gap-2 justify-start">
-                  <Images className="size-4" /> Visual Search
+                  <Images className="size-4" /> {t('panel.visualSearch')}
                 </span>
               ) : (
                 <span className="flex grow items-center gap-2 justify-start text-destructive">
-                  <CircleX className="size-4" /> Visual Search
+                  <CircleX className="size-4" /> {t('panel.visualSearch')}
                 </span>
               )}
             </AccordionTrigger>
@@ -237,16 +240,18 @@ export const SmartToolsPanel = (props: SmartToolsPanelProps) => {
             </div>
 
             <div className="text font-medium text-orange-400">
-              Not Supported
+              {t('panel.notSupported.title')}
             </div>
 
             <p className="pt-4 text-xs text-muted-foreground font-light leading-relaxed">
-              Smart Tools use experimental WebGPU technology not 
-              available in your browser. Please switch to a recent version 
-              of Chrome or Edge to use this 
-              feature. <a 
-                className="underline text-slate-800"
-                href="https://developer.mozilla.org/en-US/docs/Web/API/WebGPU_API#browser_compatibility" target="_blank">View browser compatibility</a>.
+              <Trans
+                ns="smartTools"
+                i18nKey="panel.notSupported.description"
+                components={{
+                  compatLink: <a
+                    className="underline text-slate-800"
+                    href="https://developer.mozilla.org/en-US/docs/Web/API/WebGPU_API#browser_compatibility" target="_blank" />
+                }} />
             </p>
           </div>
         </div>

--- a/src/pages/annotate/SmartTools/Transcribe/AIConsent/AIConsent.tsx
+++ b/src/pages/annotate/SmartTools/Transcribe/AIConsent/AIConsent.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
 import { TriangleAlert } from 'lucide-react';
 import { Checkbox } from '@/ui/Checkbox';
 import { Label } from '@/ui/Label';
@@ -20,6 +21,8 @@ interface AIConsentProps {
 
 export const AIConsent = (props: AIConsentProps) => {
 
+  const { t } = useTranslation('smartTools');
+
   const [open, setOpen] = useState(!props.optIn);
   
   const [checked, _setChecked] = useState(props.optIn);
@@ -37,47 +40,46 @@ export const AIConsent = (props: AIConsentProps) => {
       <AlertDialogContent
         className="max-w-2xl">
         <AlertDialogTitle className="flex gap-2 items-center text-destructive">
-          <TriangleAlert className="size-5" /> Before You Use Auto Transcribe
+          <TriangleAlert className="size-5" /> {t('transcribe.consent.title')}
         </AlertDialogTitle>
 
         <AlertDialogDescription className="leading-relaxed space-y-4">
           <p>
-            The IMMARKUS Auto Transcribe tool allows you to connect to external 
-            AI platforms (e.g. Google, Microsoft Azure, OpenAI). Please read and 
-            confirm the following before continuing:
+            {t('transcribe.consent.intro')}
           </p>
 
           <ol className="space-y-4 list-decimal pl-5">
             <li className="pl-1">
-              <strong>External Processing</strong>: When you use the Auto Transcribe tool, 
-              any images or image portions you submit will be sent to the selected 
-              third-party service for processing.
+              <Trans
+                ns="smartTools"
+                i18nKey="transcribe.consent.externalProcessing"
+                components={{ strong: <strong /> }} />
             </li>
 
             <li className="pl-1">
-              <strong>Your Own Keys</strong>: For services that require an API key, you 
-              must provide your own key. The key is stored locally in your browser 
-              and used only to connect directly to the intended AI service. IMMARKUS 
-              does not transmit or store your key elsewhere.
+              <Trans
+                ns="smartTools"
+                i18nKey="transcribe.consent.ownKeys"
+                components={{ strong: <strong /> }} />
             </li>
 
             <li className="pl-1">
-              <strong>Image Rights & Responsibility</strong>: Ensure that you have the 
-              right to upload and process any materials you use. Do not send copyrighted, 
-              personal, or sensitive data to external service unless you understand and 
-              accept their terms of use.
+              <Trans
+                ns="smartTools"
+                i18nKey="transcribe.consent.imageRights"
+                components={{ strong: <strong /> }} />
             </li>
 
             <li className="pl-1">
-              <strong>No Hidden Transfers</strong>: IMMARKUS itself does not send your 
-              data anywhere. Only the AI services you choose to connect to will receive 
-              the data you submit.
+              <Trans
+                ns="smartTools"
+                i18nKey="transcribe.consent.noHiddenTransfers"
+                components={{ strong: <strong /> }} />
             </li>
           </ol>
 
           <p>
-            By continuing, you confirm that you have read and understood this information 
-            and accept responsibility for your use of external AI services.
+            {t('transcribe.consent.confirmation')}
           </p>
 
           <div className="p-4 flex gap-2 items-center font-medium border rounded-md mb-6">
@@ -85,11 +87,11 @@ export const AIConsent = (props: AIConsentProps) => {
               id="ai-opt-in"
               checked={checked}
               onCheckedChange={checked => setChecked(checked as boolean)} />
-            <Label htmlFor="ai-opt-in">I Understand and Agree</Label>
+            <Label htmlFor="ai-opt-in">{t('transcribe.consent.agree')}</Label>
           </div>
 
           <AlertDialogAction className="w-full">
-            Close
+            {t('transcribe.consent.close')}
           </AlertDialogAction>
         </AlertDialogDescription>
       </AlertDialogContent>

--- a/src/pages/annotate/SmartTools/Transcribe/Transcribe.tsx
+++ b/src/pages/annotate/SmartTools/Transcribe/Transcribe.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Annotorious, ImageAnnotation, Origin, serializeW3CImageAnnotation} from '@annotorious/react';
 import { useAnnotoriousManifold } from '@annotorious/react-manifold';
 import { LoadedImage } from '@/model';
@@ -24,6 +25,8 @@ interface TranscribeProps {
 }
 
 export const Transcribe = (props: TranscribeProps) => {
+
+  const { t } = useTranslation('smartTools');
 
   const store = useStore();
 
@@ -71,11 +74,11 @@ export const Transcribe = (props: TranscribeProps) => {
       <div className="pt-6 pb-1 px-0.5 flex gap-3 items-start leading-relaxed">
         {props.images.length === 1 ? (
             <p className="font-medium">
-              Automatically transcribe this image, or parts of it.
+              {t('transcribe.transcribeThisImage')}
             </p>
         ) : (
           <p className="font-medium">
-            Select an image to transcribe automatically.
+            {t('transcribe.selectImageToTranscribe')}
           </p>
         )}
       </div>
@@ -88,13 +91,12 @@ export const Transcribe = (props: TranscribeProps) => {
             onCheckedChange={checked => setOptIn(checked as boolean)} />
 
           <Label htmlFor="ai-opt-in-compact">
-            <strong className="font-semibold text-xs">Enable external AI tools.</strong>
+            <strong className="font-semibold text-xs">{t('transcribe.enableExternalAI')}</strong>
           </Label>
         </div>
         
         <p>
-          I understand that images I send are processed by 3rd-party services
-          and that I’m responsible for what I upload.
+          {t('transcribe.disclaimer')}
         </p>
       </div>
 

--- a/src/pages/annotate/SmartTools/Transcribe/TranscriptionDialog/TranscriptionControls/ProcessingStateBadge.tsx
+++ b/src/pages/annotate/SmartTools/Transcribe/TranscriptionDialog/TranscriptionControls/ProcessingStateBadge.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { CloudAlert, CloudCheck, Info } from 'lucide-react';
 import { Popover, PopoverContent, PopoverTrigger } from '@/ui/Popover';
 import { Spinner } from '@/components/Spinner';
@@ -13,6 +14,8 @@ interface ProcessingStateBadgeProps {
 
 export const ProcessingStateBadge = (props: ProcessingStateBadgeProps) => {
 
+  const { t } = useTranslation('smartTools');
+
   const state = props.processingState;
 
   const isError = state === 'compressing_failed' || state === 'ocr_failed';
@@ -21,11 +24,11 @@ export const ProcessingStateBadge = (props: ProcessingStateBadgeProps) => {
     <div className="w-full bg-destructive text-white rounded-md h-10 gap-2 flex items-center justify-center text-sm">
       <CloudAlert className="size-5 mb-[1px]" /> 
       {state === 'compressing_failed' ? (
-        <span>Image compression failed</span>
+        <span>{t('transcribe.status.compressionFailed')}</span>
       ) : state === 'ocr_failed' ? (
         <>
           <span>
-            OCR Service Error
+            {t('transcribe.status.ocrError')}
           </span>
 
           {props.lastError && (
@@ -38,7 +41,7 @@ export const ProcessingStateBadge = (props: ProcessingStateBadgeProps) => {
                 side="top"
                 sideOffset={6}
                 className="text-xs px-2.5 py-2 w-72 leading-relaxed">
-                <h3 className="font-semibold">OCR service responded:</h3>
+                <h3 className="font-semibold">{t('transcribe.status.ocrResponded')}</h3>
                 <p className="italic mt-1">
                   "{props.lastError}"
                 </p>
@@ -50,24 +53,24 @@ export const ProcessingStateBadge = (props: ProcessingStateBadgeProps) => {
     </div>
   ) : state === 'success_empty' ? (
     <div className="w-full bg-orange-400 h-10 text-white rounded-md flex items-center justify-center gap-2 text-sm">
-      <CloudAlert className="size-5 mb-[1px]" /> No Results
+      <CloudAlert className="size-5 mb-[1px]" /> {t('transcribe.status.noResults')}
     </div>
   ) : state === 'success' ? (
     <div className="w-full bg-green-600 h-10 text-white rounded-md flex items-center justify-center gap-2 text-sm">
-      <CloudCheck className="size-5 mb-[1px]" /> Success
+      <CloudCheck className="size-5 mb-[1px]" /> {t('transcribe.status.success')}
     </div>
   ) : (
     <div className="w-full bg-black text-white h-10 rounded-md flex items-center justify-center px-4 gap-2.5 text-sm">
       <Spinner className="size-5 mb-[1px]" />
 
-      {state === 'cropping' ? ( 
-        <span>Cropping Image</span>
+      {state === 'cropping' ? (
+        <span>{t('transcribe.status.cropping')}</span>
       ) : state === 'fetching_iiif' ? (
-        <span>Fetching IIIF Image</span>
+        <span>{t('transcribe.status.fetchingIIIF')}</span>
       ) : state === 'compressing' ? (
-        <span>Compressing Image</span>
+        <span>{t('transcribe.status.compressing')}</span>
       ) : state === 'pending' ? (
-        <span>Processing</span>
+        <span>{t('transcribe.status.processing')}</span>
       ) : null}
     </div>
   )

--- a/src/pages/annotate/SmartTools/Transcribe/TranscriptionDialog/TranscriptionControls/TranscriptionControls.tsx
+++ b/src/pages/annotate/SmartTools/Transcribe/TranscriptionDialog/TranscriptionControls/TranscriptionControls.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { CircleCheck, KeyRound, ScanText, SquareDashedMousePointer } from 'lucide-react';
 import { Button } from '@/ui/Button';
 import { Label } from '@/ui/Label';
@@ -42,6 +43,8 @@ interface TranscriptionControlsProps {
 const connectors = ServiceRegistry.listAvailableConnectors('TRANSCRIPTION');
 
 export const TranscriptionControls = (props: TranscriptionControlsProps) => {
+
+  const { t } = useTranslation('smartTools');
 
   const { connectorId, serviceOptions } = props.options;
 
@@ -117,7 +120,7 @@ export const TranscriptionControls = (props: TranscriptionControlsProps) => {
     <div className="pr-2 py-4 min-h-full flex flex-col">
       <div className="space-y-8 flex-1">
         <fieldset className="space-y-2">
-          <Label className="font-semibold">Service</Label>
+          <Label className="font-semibold">{t('transcribe.controls.service')}</Label>
 
           <Select
             value={connectorConfig.id}
@@ -129,7 +132,7 @@ export const TranscriptionControls = (props: TranscriptionControlsProps) => {
                   {connectorConfig.displayName}
                   {connectorConfig.requiresKey && (
                     <span className="rounded-full mb-px text-[11px] font-medium flex gap-1.5 items-center border text-amber-500 border-amber-400 bg-orange-50 pl-2 pr-2.5 py-0.5">
-                      <KeyRound className="size-3" /> API Key Required
+                      <KeyRound className="size-3" /> {t('transcribe.controls.apiKeyRequired')}
                     </span>
                   )}
                 </h4>
@@ -180,19 +183,18 @@ export const TranscriptionControls = (props: TranscriptionControlsProps) => {
               {props.region ? (
                 <>
                   <CircleCheck className="size-4.5 mb-0.5" />
-                  Area Selected
+                  {t('transcribe.controls.areaSelected')}
                 </>
               ) : (
                 <>
-                  <SquareDashedMousePointer className="size-4.5 mb-0.5" /> 
-                  Select Area to Transcribe
+                  <SquareDashedMousePointer className="size-4.5 mb-0.5" />
+                  {t('transcribe.controls.selectAreaToTranscribe')}
                 </>
               )} 
             </h5>
 
             <p>
-              This service returns transcriptions without bounding box information. Select the area you 
-              want to transcribe. The result will be inserted as a single annotation.
+              {t('transcribe.controls.regionHint')}
             </p>
           </div>
         )}
@@ -206,7 +208,7 @@ export const TranscriptionControls = (props: TranscriptionControlsProps) => {
             className="w-full flex gap-2 1.5"
             onClick={() => props.onSubmit()}
             disabled={!canSumbit}>
-            <ScanText className="size-4.5" /> Run Transcription
+            <ScanText className="size-4.5" /> {t('transcribe.controls.runTranscription')}
           </Button>
         )}
 
@@ -214,7 +216,7 @@ export const TranscriptionControls = (props: TranscriptionControlsProps) => {
           variant="outline"
           className="w-full"
           onClick={props.onCancel}>
-          Cancel
+          {t('transcribe.controls.cancel')}
         </Button>
       </div>
     </div>

--- a/src/pages/annotate/SmartTools/Transcribe/TranscriptionDialog/TranscriptionDialog.tsx
+++ b/src/pages/annotate/SmartTools/Transcribe/TranscriptionDialog/TranscriptionDialog.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ImageAnnotation } from '@annotorious/react';
 import { Button } from '@/ui/Button';
 import { TooltipProvider } from '@/ui/Tooltip';
@@ -49,6 +50,8 @@ interface TranscriptionDialogProps {
 }
 
 export const TranscriptionDialog = (props: TranscriptionDialogProps) => {
+
+  const { t } = useTranslation('smartTools');
 
   const [open, setOpen] = useState(false);
 
@@ -176,7 +179,7 @@ export const TranscriptionDialog = (props: TranscriptionDialogProps) => {
         <Button 
           disabled={props.disabled}
           className="bg-orange-400 hover:bg-orange-400/90 w-full h-9 mt-3 tracking-wide">
-          Select Service
+          {t('transcribe.selectService')}
         </Button>
       </DialogTrigger>
 
@@ -184,11 +187,11 @@ export const TranscriptionDialog = (props: TranscriptionDialogProps) => {
         closeIcon={false}
         className="rounded-lg w-11/12 h-11/12 max-w-11/12 p-0 overflow-hidden relative">
         <DialogTitle className="sr-only">
-          Auto Transcribe
+          {t('transcribe.dialogTitle')}
         </DialogTitle>
 
         <DialogDescription className="sr-only">
-          Submit this image for automatic transcription.
+          {t('transcribe.dialogDescription')}
         </DialogDescription>
         
         <div className="flex h-full gap-4 overflow-hidden relative">

--- a/src/pages/annotate/SmartTools/Transcribe/TranscriptionDialog/TranscriptionPreview/NavControls/NavControls.tsx
+++ b/src/pages/annotate/SmartTools/Transcribe/TranscriptionDialog/TranscriptionPreview/NavControls/NavControls.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { RotateCcwSquare, RotateCwSquare, ZoomIn, ZoomOut } from 'lucide-react';
 import { useViewer } from '@annotorious/react';
 import { Rotation } from '@/services';
@@ -11,6 +12,8 @@ interface NavControlsProps {
 }
 
 export const NavControls = (props: NavControlsProps) => {
+
+  const { t } = useTranslation('smartTools');
 
   const viewer = useViewer();
 
@@ -35,7 +38,7 @@ export const NavControls = (props: NavControlsProps) => {
         </TooltipTrigger>
 
         <TooltipContent collisionPadding={20}>
-          Rotate counter-clockwise
+          {t('transcribe.nav.rotateCounterClockwise')}
         </TooltipContent>
       </Tooltip>
 
@@ -50,7 +53,7 @@ export const NavControls = (props: NavControlsProps) => {
         </TooltipTrigger>
 
         <TooltipContent collisionPadding={20}>
-          Rotate clockwise
+          {t('transcribe.nav.rotateClockwise')}
         </TooltipContent>
       </Tooltip>
 
@@ -65,7 +68,7 @@ export const NavControls = (props: NavControlsProps) => {
         </TooltipTrigger>
 
         <TooltipContent collisionPadding={20}>
-          Zoom in
+          {t('transcribe.nav.zoomIn')}
         </TooltipContent>
       </Tooltip>
 
@@ -80,7 +83,7 @@ export const NavControls = (props: NavControlsProps) => {
         </TooltipTrigger>
 
         <TooltipContent collisionPadding={20}>
-          Zoom out
+          {t('transcribe.nav.zoomOut')}
         </TooltipContent>
       </Tooltip>
     </div>

--- a/src/pages/annotate/SmartTools/Transcribe/TranscriptionDialog/TranscriptionPreview/ResultBadge/ResultBadge.tsx
+++ b/src/pages/annotate/SmartTools/Transcribe/TranscriptionDialog/TranscriptionPreview/ResultBadge/ResultBadge.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { FileWarning, ScanText, Trash2 } from 'lucide-react';
 import { Button } from '@/ui/Button';
 
@@ -13,13 +14,15 @@ interface ResultBadgeProps {
 
 export const ResultBadge = (props: ResultBadgeProps) => {
 
+  const { t } = useTranslation('smartTools');
+
   return props.count > 0 ? (
     <div 
       className="absolute bottom-2 left-2 z-10 bg-black text-white py-1.5 pl-3 pr-2 rounded-md shadow-md flex gap-8 items-center">
       
       <div className="flex gap-2 text-sm items-center font-light whitespace-nowrap">
         <ScanText className="size-4.5" />
-        {props.count.toLocaleString()} Annotations
+        {t('transcribe.resultBadge.annotationCount', { count: props.count })}
 
         <button 
           className="rounded p-2 hover:bg-white/25 -ml-1"
@@ -31,7 +34,7 @@ export const ResultBadge = (props: ResultBadgeProps) => {
       <Button
         className="h-8 rounded-sm bg-green-600 whitespace-nowrap"
         onClick={props.onImport}>
-        Import to IMMARKUS
+        {t('transcribe.resultBadge.importToImmarkus')}
       </Button>
     </div>
   ) : (
@@ -39,7 +42,7 @@ export const ResultBadge = (props: ResultBadgeProps) => {
       className="absolute bottom-2 left-2 z-10 bg-black text-white py-1.5 pl-3 pr-3.5 rounded-md shadow-md flex gap-8 items-center">
       <div className="flex gap-2 h-7 text-sm items-center font-light whitespace-nowrap">
         <FileWarning className="size-4.5" />
-        No Results
+        {t('transcribe.resultBadge.noResults')}
       </div>
     </div>
   )

--- a/src/pages/annotate/SmartTools/Transcribe/TranscriptionDialog/TranscriptionPreview/SelectRegion/SelectRegion.tsx
+++ b/src/pages/annotate/SmartTools/Transcribe/TranscriptionDialog/TranscriptionPreview/SelectRegion/SelectRegion.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { SquareDashedMousePointer, X } from 'lucide-react';
 import { Region } from '@/services';
 import { Button } from '@/ui/Button';
@@ -17,6 +18,8 @@ interface SelectRegionProps {
 }
 
 export const SelectRegion = (props: SelectRegionProps) => {
+
+  const { t } = useTranslation('smartTools');
 
   const [pressed, setPressed] = useState(false);
 
@@ -67,7 +70,7 @@ export const SelectRegion = (props: SelectRegionProps) => {
               variant="ghost"
               className="absolute text-xs gap-1.5 top-2 left-2 z-10 bg-white shadow-xs px-2.5 py-2 h-auto pointer-events-auto"
               onClick={onClearRegion}>
-              <X className="size-4.5" /> Clear Selection
+              <X className="size-4.5" /> {t('transcribe.selectRegion.clearSelection')}
             </Button>
           </TooltipTrigger>
         </Tooltip>
@@ -86,7 +89,7 @@ export const SelectRegion = (props: SelectRegionProps) => {
 
           <TooltipContent
             collisionPadding={20}>
-            Select a region (optional)
+            {t('transcribe.selectRegion.selectRegionOptional')}
           </TooltipContent>
         </Tooltip>
       )}

--- a/src/pages/annotate/SmartTools/VisualSearch/ImageSearchDialog/ImagePreview/ImagePreviewToolbar.tsx
+++ b/src/pages/annotate/SmartTools/VisualSearch/ImageSearchDialog/ImagePreview/ImagePreviewToolbar.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ChevronLeft, ImageUp, Square, SquareCheckBig, ZoomIn, ZoomOut } from 'lucide-react';
 import { ImageAnnotation, useViewer } from '@annotorious/react';
 import { Button } from '@/ui/Button';
@@ -22,6 +23,8 @@ interface ImagePreviewToolbarProps {
 }
 
 export const ImagePreviewToolbar = (props: ImagePreviewToolbarProps) => {
+
+  const { t } = useTranslation('smartTools');
 
   const { selected } = props;
 
@@ -48,7 +51,7 @@ export const ImagePreviewToolbar = (props: ImagePreviewToolbarProps) => {
           disabled={isClosing}
           className="absolute flex gap-1 items-center text-xs top-4 left-4 rounded pl-1.5 pr-3 py-2.5 bg-black hover:bg-neutral-700 text-white disabled:opacity-50"
           onClick={onClose}>
-          <ChevronLeft className="size-4" /> Back
+          <ChevronLeft className="size-4" /> {t('visualSearch.preview.back')}
         </button>
       )}
 
@@ -76,8 +79,8 @@ export const ImagePreviewToolbar = (props: ImagePreviewToolbarProps) => {
             {props.isAllSelected ? (
               <SquareCheckBig className="size-4" /> 
             ) : (
-              <Square className="size-4" /> 
-            )} Select All
+              <Square className="size-4" />
+            )} {t('visualSearch.preview.selectAll')}
           </button>
 
           <Button
@@ -89,9 +92,9 @@ export const ImagePreviewToolbar = (props: ImagePreviewToolbarProps) => {
             onClick={props.onImportSelected}>
             <ImageUp className="size-4" />
             {selected.length === 0 ? (
-              'Import Selected Annotations'
+              t('visualSearch.preview.importSelectedAnnotations')
             ) : (
-              `Import ${selected.length.toLocaleString()} Annotation${selected.length > 1 ? 's' : ''}`
+              t('visualSearch.preview.importAnnotations', { count: selected.length })
             )}
           </Button>
         </div>

--- a/src/pages/annotate/SmartTools/VisualSearch/ImageSearchDialog/ImageSearchDialog.tsx
+++ b/src/pages/annotate/SmartTools/VisualSearch/ImageSearchDialog/ImageSearchDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Annotorious, type ImageAnnotation } from '@annotorious/react';
 import { LoadedImage } from '@/model';
 import { VisualSearch } from '@/utils/useVisualSearch';
@@ -40,7 +41,9 @@ interface ImageSearchDialogProps {
 
 }
 
-export const ImageSearchDialog = (props: ImageSearchDialogProps) => {  
+export const ImageSearchDialog = (props: ImageSearchDialogProps) => {
+
+  const { t } = useTranslation('smartTools');
 
   const { sourceImage, imagesInWorkspace } = props;
 
@@ -248,7 +251,7 @@ export const ImageSearchDialog = (props: ImageSearchDialogProps) => {
                     <Progress 
                       value={downloadStatus.progress} 
                       className="bg-white [&>div]:bg-orange-400 h-1 w-40" />
-                    <span>Dowloading embedding model</span>
+                    <span>{t('visualSearch.dialog.downloadingModel')}</span>
                   </div>
                 </div>
               ) : (
@@ -265,17 +268,16 @@ export const ImageSearchDialog = (props: ImageSearchDialogProps) => {
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>
-              Discard selected results?
+              {t('visualSearch.dialog.discardTitle')}
             </AlertDialogTitle>
             <AlertDialogDescription className="leading-relaxed">
-              You have selected {selectedForImport.length} result{selectedForImport.length !== 1 ? 's' : ''} for import.
-              If you continue, your selection will be lost.
+              {t('visualSearch.dialog.discardDescription', { count: selectedForImport.length })}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogCancel>{t('visualSearch.dialog.cancel')}</AlertDialogCancel>
             <AlertDialogAction onClick={onConfirmDiscard}>
-              Discard Selection
+              {t('visualSearch.dialog.discardSelection')}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/pages/annotate/SmartTools/VisualSearch/ImageSearchDialog/Sidebar/Sidebar.tsx
+++ b/src/pages/annotate/SmartTools/VisualSearch/ImageSearchDialog/Sidebar/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ArrowDownWideNarrow, Search, Square, SquareCheckBig, SquareDot, X } from 'lucide-react';
 import { LoadedImage } from '@/model';
 import { cn } from '@/ui/utils';
@@ -37,6 +38,8 @@ interface SidebarProps {
 type ResultSorting = 'hits' | 'score';
 
 export const Sidebar = (props: SidebarProps) => {
+
+  const { t } = useTranslation('smartTools');
 
   const { selectedImages } = props;
 
@@ -133,7 +136,7 @@ export const Sidebar = (props: SidebarProps) => {
           ) : (
             <SquareDot className="size-4" />
           )}
-          Select All
+          {t('visualSearch.sidebar.selectAll')}
         </Button>
 
         <div className="flex items-center text-muted-foreground">
@@ -193,11 +196,11 @@ export const Sidebar = (props: SidebarProps) => {
             
             <SelectContent>
               <SelectItem value="hits">
-                Number of matches
+                {t('visualSearch.sidebar.sortByMatches')}
               </SelectItem>
 
               <SelectItem value="score">
-                Best match
+                {t('visualSearch.sidebar.sortByScore')}
               </SelectItem>
             </SelectContent>
           </Select>

--- a/src/pages/annotate/SmartTools/VisualSearch/ImageSearchDialog/Sidebar/SidebarImageItem.tsx
+++ b/src/pages/annotate/SmartTools/VisualSearch/ImageSearchDialog/Sidebar/SidebarImageItem.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
 import { useInView } from 'react-intersection-observer';
 import { TooltipPortal } from '@radix-ui/react-tooltip';
 import { LoadedImage } from '@/model';
@@ -34,7 +35,9 @@ interface SidebarImageItemProps {
 }
 
 export const SidebarImageItem = (props: SidebarImageItemProps) => {
-  
+
+  const { t } = useTranslation('smartTools');
+
   const { image, isSourceImage } = props;
 
   const isDisabled = props.isPreviewOpen && !props.isCurrentPreview;
@@ -93,8 +96,12 @@ export const SidebarImageItem = (props: SidebarImageItemProps) => {
           </div>
 
           <div className="text-[11px] text-muted-foreground">
-            <strong className="font-semibold">{props.matches} hits</strong> · {Math.round(100 * props.topScore) / 100} best 
-            score {props.isSourceImage ? (
+            <Trans
+              ns="smartTools"
+              i18nKey="visualSearch.sidebar.hitsAndScore"
+              count={props.matches}
+              values={{ score: Math.round(100 * props.topScore) / 100 }}
+              components={{ strong: <strong className="font-semibold" /> }} /> {props.isSourceImage ? (
               <>· <Tooltip>
                   <TooltipTrigger asChild>
                     <Badge 
@@ -102,13 +109,13 @@ export const SidebarImageItem = (props: SidebarImageItemProps) => {
                       style={{ 
                         backgroundColor: THIS_IMAGE_COLOR
                       }}>
-                      Source
+                      {t('visualSearch.sidebar.sourceBadge')}
                     </Badge>
                   </TooltipTrigger>
 
                   <TooltipPortal>
                     <TooltipContent>
-                        This image contains the query annotation
+                        {t('visualSearch.sidebar.sourceTooltip')}
                     </TooltipContent>
                   </TooltipPortal>
                 </Tooltip>
@@ -118,13 +125,13 @@ export const SidebarImageItem = (props: SidebarImageItemProps) => {
                 <TooltipTrigger asChild>
                   <Badge 
                     className="text-[11px] font-medium rounded-md py-px px-1.25 bg-orange-400 hover:bg-orange-400">
-                    Open
+                    {t('visualSearch.sidebar.openBadge')}
                   </Badge>
                 </TooltipTrigger>
 
                 <TooltipPortal>
                   <TooltipContent>
-                    This image is currently open in your workspace
+                    {t('visualSearch.sidebar.openTooltip')}
                   </TooltipContent>
                 </TooltipPortal>
                 </Tooltip>

--- a/src/pages/annotate/SmartTools/VisualSearch/ImageSearchDialog/Toolbar/Toolbar.tsx
+++ b/src/pages/annotate/SmartTools/VisualSearch/ImageSearchDialog/Toolbar/Toolbar.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Grid2X2, Grid3X3, Square, X } from 'lucide-react';
 import { LoadedImage } from '@/model';
 import { Button } from '@/ui/Button';
@@ -36,6 +37,8 @@ interface ToolbarProps {
 
 export const Toolbar = (props: ToolbarProps) => {
 
+  const { t } = useTranslation('smartTools');
+
   return (
     <DialogHeader className="flex flex-row justify-between border-b bg-white">
       <DialogTitle className="m-0 p-2">
@@ -50,9 +53,9 @@ export const Toolbar = (props: ToolbarProps) => {
           
           <div className="p-0.5 text-xs font-normal text-muted-foreground">
             {props.results ? (
-              <span>Showing {props.results.length.toLocaleString()} matches</span>
+              <span>{t('visualSearch.toolbar.showingMatches', { count: props.results.length })}</span>
             ) : (
-              <span>Searching...</span>
+              <span>{t('visualSearch.toolbar.searching')}</span>
             )}
           </div>
         </div>
@@ -60,7 +63,7 @@ export const Toolbar = (props: ToolbarProps) => {
 
       <VisuallyHidden>
         <DialogDescription>
-          Visual similarity search results for the selected image region
+          {t('visualSearch.toolbar.dialogDescription')}
         </DialogDescription>
       </VisuallyHidden>
 
@@ -69,7 +72,7 @@ export const Toolbar = (props: ToolbarProps) => {
           'text-xs font-normal',
           props.disabled && 'opacity-50'
         )}>
-          Search inside
+          {t('visualSearch.toolbar.searchInside')}
         </Label>
 
         <ToggleGroup
@@ -81,20 +84,20 @@ export const Toolbar = (props: ToolbarProps) => {
           <ToggleGroupItem 
             value="this"
             className="text-xs font-normal">
-            Source Image
+            {t('visualSearch.toolbar.sourceImage')}
           </ToggleGroupItem>
 
           <ToggleGroupItem
             disabled={props.imagesInWorkspace.length < 2}
             value="workspace"
             className="text-xs font-normal">
-            Currently Open Images
+            {t('visualSearch.toolbar.currentlyOpenImages')}
           </ToggleGroupItem>
 
           <ToggleGroupItem
             value="all"
             className="text-xs font-normal">
-            All Images
+            {t('visualSearch.toolbar.allImages')}
           </ToggleGroupItem>
         </ToggleGroup>
       </div>
@@ -114,7 +117,7 @@ export const Toolbar = (props: ToolbarProps) => {
                 </ToggleGroupItem>
               </div>
             </TooltipTrigger>
-            <TooltipContent>Small Thumbnails</TooltipContent>
+            <TooltipContent>{t('visualSearch.toolbar.smallThumbnails')}</TooltipContent>
           </Tooltip>
 
           <Tooltip>
@@ -125,7 +128,7 @@ export const Toolbar = (props: ToolbarProps) => {
                 </ToggleGroupItem>
               </div>
             </TooltipTrigger>
-            <TooltipContent>Medium Thumbnails</TooltipContent>
+            <TooltipContent>{t('visualSearch.toolbar.mediumThumbnails')}</TooltipContent>
           </Tooltip>
 
           <Tooltip>
@@ -136,7 +139,7 @@ export const Toolbar = (props: ToolbarProps) => {
                 </ToggleGroupItem>
               </div>
             </TooltipTrigger>
-            <TooltipContent>Large Thumbnails</TooltipContent>
+            <TooltipContent>{t('visualSearch.toolbar.largeThumbnails')}</TooltipContent>
           </Tooltip>
         </ToggleGroup>
 

--- a/src/pages/annotate/SmartTools/VisualSearch/VisualSearch.tsx
+++ b/src/pages/annotate/SmartTools/VisualSearch/VisualSearch.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { Images, TriangleAlert } from 'lucide-react';
 import { ImageAnnotation } from '@annotorious/react';
@@ -16,6 +17,8 @@ interface VisualSearchProps {
 }
 
 export const VisualSearch = (props: VisualSearchProps) => {
+
+  const { t } = useTranslation('smartTools');
 
   const vs = useVisualSearch();
 
@@ -40,14 +43,20 @@ export const VisualSearch = (props: VisualSearchProps) => {
   return (
     <div className="px-4">
       <p className="pt-4 font-medium leading-relaxed text-center">
-        Search your collection for visually similar elements.
+        {t('visualSearch.description')}
       </p>
 
       <div className="pt-3">
         {indexStatus.state === 'index_missing' ? (
           <Alert variant="destructive" className="rounded-sm py-1.5 px-2 leading-relaxed">
-            Your collection is not indexed. Go 
-            to <span><Images className="size-3.5 inline-block" /> <Link to="/visual-search" className="font-semibold hover:underline">Visual Search</Link></span> to learn more.
+            <Trans
+              ns="smartTools"
+              i18nKey="visualSearch.notIndexed"
+              components={{
+                nowrap: <span />,
+                icon: <Images className="size-3.5 inline-block" />,
+                searchLink: <Link to="/visual-search" className="font-semibold hover:underline" />
+              }} />
           </Alert>
         ) : selected.length === 1 ? (
           <div className="space-y-3 pt-1.5">
@@ -55,17 +64,17 @@ export const VisualSearch = (props: VisualSearchProps) => {
               <Button 
                 className="bg-orange-400 hover:bg-orange-400/90 w-full h-9 tracking-wide"
                 onClick={onOpenSearchDialog}>
-                Search Inside Images
+                {t('visualSearch.searchInsideImages')}
               </Button>
 
               <p className="font-light text-center py-1.5 px-2">
-                Discover similar patterns across all images.
+                {t('visualSearch.discoverSimilar')}
               </p>
             </div>
           </div>
         ) : (
           <p className="p-1.5 text-center font-light leading-relaxed rounded border border-dashed border-gray-500">
-            Select an annotation to start.
+            {t('visualSearch.selectAnnotation')}
           </p>
         )}
 
@@ -73,8 +82,12 @@ export const VisualSearch = (props: VisualSearchProps) => {
           <div className="text-amber-600 mt-4 flex gap-1.5 items-start">
             <TriangleAlert className="inline size-4 shrink-0" /> 
             <p>
-              Your search index is outdated. Go 
-              to <Link to="/visual-search" className="underline">Visual Search</Link> to learn more.
+              <Trans
+                ns="smartTools"
+                i18nKey="visualSearch.indexOutdated"
+                components={{
+                  searchLink: <Link to="/visual-search" className="underline" />
+                }} />
             </p>
           </div>
         )}

--- a/src/pages/annotate/WorkspaceSection/AnnotatableImage.tsx
+++ b/src/pages/annotate/WorkspaceSection/AnnotatableImage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import type OpenSeadragon from 'openseadragon';
 import type { History } from '@annotorious/core';
 import { Annotorious, OpenSeadragonViewer } from '@annotorious/react-manifold';
@@ -71,6 +72,8 @@ const HistoryConsumer = (props: HistoryConsumerProps) => {
 
 export const AnnotatableImage = (props: AnnotatableImageProps) => {
 
+  const { t } = useTranslation('annotate');
+
   const { image } = props;
 
   const { setSavingState } = useSavingState();
@@ -88,7 +91,7 @@ export const AnnotatableImage = (props: AnnotatableImageProps) => {
 
     setSavingState({
       value: 'failed',
-      message: `Could not save the last annotation. Error: ${error.message}`
+      message: t('savingState.couldNotSaveAnnotation', { message: error.message })
     });
   }
 


### PR DESCRIPTION
Second of the page-by-page translation PRs (after #322 scaffold and #323 shared/test setup).

## What's in this one

- **`annotate` + `smartTools` namespaces**, wired into `src/i18n/index.ts`
- Translates `src/pages/annotate`: header tools, sidebar sections, relation editor, current-selection / properties forms, annotation list, pagination, and the smart-tools panel (auto-select, edge-snap, smart scissors, transcribe incl. the AI-consent dialog, visual search)
- Adds `src/i18n/dateLocale.ts` — date-fns locale follows the active UI language (used by the annotation-list timestamps; later page PRs reuse it)
- `e2e/annotate.spec.ts` — exercises the empty workspace, an opened image's toolbar/tooltips/sidebar, and the smart-tools panel, in both languages

## Notes

- i18next plurals replace hand-rolled `+ 's'` suffixes; `<Trans>` for strings with inline links/markup/icons.
- Deliberately left untranslated (as flagged in #305): the `src/services` ServiceRegistry-driven strings (transcription service names, API-key instructions) — those need a config-level i18n approach rather than static keys, happy to tackle separately.
- `npm test` (vitest parity) now also covers the annotate/smartTools namespaces; `npm run test:e2e` includes the annotate spec.

## Remaining in the series

3. Images · 4. Knowledge graph · 5. Smaller pages (data model, export, settings, about, X-MARKUS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)