### PR TITLE
i18n (3/5): knowledge graph page

### DIFF
--- a/e2e/knowledgegraph.spec.ts
+++ b/e2e/knowledgegraph.spec.ts
@@ -1,0 +1,252 @@
+import { Page, expect, test } from '@playwright/test';
+import { findRawTranslationKeys, mockWorkFolder, openWorkFolder, setLanguage } from './helpers';
+
+/**
+ * E2E i18n checks for the Knowledge Graph page (namespace `knowledgegraph`).
+ *
+ * Notes:
+ * - Navigation happens via the sidebar link (client-side, no reload), because a
+ *   full reload would restore the work-folder handle from IndexedDB where our
+ *   mocked requestPermission() monkey-patch is not preserved.
+ * - The force-graph canvas renders data values (file names) — not translatable,
+ *   intentionally not asserted on.
+ * - Default settings: graphMode=HIERARCHY, includeFolders=off, legend expanded.
+ *   Therefore folder-related and relationship legend entries must be ABSENT.
+ */
+
+// The force-graph physics simulation is CPU-heavy. Running several graph pages
+// in parallel workers starves the browser main thread and makes actionability
+// checks (hover/click) time out. Run this file's tests sequentially instead.
+test.describe.configure({ mode: 'default' });
+
+const SIDEBAR_LINK = { en: 'Knowledge Graph', ja: 'ナレッジグラフ' };
+
+/** Collects uncaught page errors for the no-crash assertion. */
+const collectPageErrors = (page: Page): string[] => {
+  const errors: string[] = [];
+  page.on('pageerror', err => errors.push(String(err)));
+  return errors;
+};
+
+/** Boots the app in the given language, opens the mocked work folder and
+ *  navigates (client-side) to the Knowledge Graph page. */
+const gotoKnowledgeGraph = async (page: Page, lang: 'en' | 'ja') => {
+  await setLanguage(page, lang);
+  await mockWorkFolder(page);
+  await page.goto('/');
+  await openWorkFolder(page);
+  await page.getByRole('link', { name: SIDEBAR_LINK[lang] }).click();
+  await page.waitForURL(/#\/graph/);
+  // Page heading doubles as "graph page is mounted" signal
+  await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+};
+
+test.describe('knowledge graph page i18n', () => {
+
+  test('shows translated title, description and legend (en)', async ({ page }) => {
+    const errors = collectPageErrors(page);
+    await gotoKnowledgeGraph(page, 'en');
+
+    const main = page.locator('main');
+
+    // knowledgeGraph.* intro
+    await expect(page.getByRole('heading', { name: 'Knowledge Graph', level: 1 })).toBeVisible();
+    await expect(main.getByText('Explore connections between images and entities', { exact: false })).toBeVisible();
+
+    // legend.* — node entries (legend is expanded by default)
+    await expect(main.getByText('Nodes', { exact: true })).toBeVisible();
+    await expect(main.getByText('Entity Class', { exact: true })).toBeVisible();
+    await expect(main.getByText('Image', { exact: true })).toBeVisible();
+    // includeFolders is off by default → no sub-folder node entry
+    await expect(main.getByText('Sub-Folder', { exact: true })).toBeHidden();
+
+    // legend.* — edge entries for HIERARCHY mode without folders
+    await expect(main.getByText('Edges', { exact: true })).toBeVisible();
+    await expect(main.getByText('Entity class hierarchy', { exact: true })).toBeVisible();
+    await expect(main.getByText('Entity Annotations', { exact: true })).toBeVisible();
+    await expect(main.getByText('Folder structure', { exact: true })).toBeHidden();
+    // legend.relationship.* only shows in RELATIONS graph mode
+    await expect(main.getByText('Connections based on Relationships', { exact: false })).toBeHidden();
+
+    expect(await findRawTranslationKeys(page)).toEqual([]);
+    expect(errors).toEqual([]);
+  });
+
+  test('shows translated title, description and legend (ja)', async ({ page }) => {
+    const errors = collectPageErrors(page);
+    await gotoKnowledgeGraph(page, 'ja');
+
+    const main = page.locator('main');
+
+    // knowledgeGraph.* intro
+    await expect(page.getByRole('heading', { name: 'ナレッジグラフ', level: 1 })).toBeVisible();
+    await expect(main.getByText('画像とエンティティのつながりを探索できます', { exact: false })).toBeVisible();
+
+    // legend.* — node entries
+    await expect(main.getByText('ノード', { exact: true })).toBeVisible();
+    await expect(main.getByText('エンティティクラス', { exact: true })).toBeVisible();
+    await expect(main.getByText('画像', { exact: true })).toBeVisible();
+    await expect(main.getByText('サブフォルダ', { exact: true })).toBeHidden();
+
+    // legend.* — edge entries
+    await expect(main.getByText('エッジ', { exact: true })).toBeVisible();
+    await expect(main.getByText('エンティティクラス階層', { exact: true })).toBeVisible();
+    await expect(main.getByText('エンティティアノテーション', { exact: true })).toBeVisible();
+    await expect(main.getByText('フォルダ構造', { exact: true })).toBeHidden();
+
+    expect(await findRawTranslationKeys(page)).toEqual([]);
+    expect(errors).toEqual([]);
+  });
+
+  test('graph controls have translated tooltips (en)', async ({ page }) => {
+    const errors = collectPageErrors(page);
+    await gotoKnowledgeGraph(page, 'en');
+
+    const main = page.locator('main');
+
+    // Fullscreen toggle (top right, icon-only → identified via lucide icon)
+    await main.locator('button:has(.lucide-fullscreen)').hover();
+    await expect(page.getByRole('tooltip', { name: 'Toggle fullscreen' })).toBeVisible();
+
+    // Graph search button
+    await main.locator('button:has(.lucide-search)').hover();
+    await expect(page.getByRole('tooltip', { name: 'Graph search' })).toBeVisible();
+
+    // Settings button: visible label + tooltip
+    const settingsButton = page.getByRole('button', { name: 'Settings', exact: true });
+    await expect(settingsButton).toBeVisible();
+    await settingsButton.hover();
+    await expect(page.getByRole('tooltip', { name: 'Graph settings' })).toBeVisible();
+
+    expect(errors).toEqual([]);
+  });
+
+  test('graph controls have translated tooltips (ja)', async ({ page }) => {
+    const errors = collectPageErrors(page);
+    await gotoKnowledgeGraph(page, 'ja');
+
+    const main = page.locator('main');
+
+    await main.locator('button:has(.lucide-fullscreen)').hover();
+    await expect(page.getByRole('tooltip', { name: '全画面表示を切り替え' })).toBeVisible();
+
+    await main.locator('button:has(.lucide-search)').hover();
+    await expect(page.getByRole('tooltip', { name: 'グラフ検索' })).toBeVisible();
+
+    const settingsButton = page.getByRole('button', { name: '設定', exact: true });
+    await expect(settingsButton).toBeVisible();
+    await settingsButton.hover();
+    await expect(page.getByRole('tooltip', { name: 'グラフ設定' })).toBeVisible();
+
+    expect(errors).toEqual([]);
+  });
+
+  test('settings panel is fully translated (en)', async ({ page }) => {
+    const errors = collectPageErrors(page);
+    await gotoKnowledgeGraph(page, 'en');
+
+    const main = page.locator('main');
+    await page.getByRole('button', { name: 'Settings', exact: true }).click();
+
+    // settingsPanel.graphType.*
+    await expect(main.getByText('Graph Type', { exact: true })).toBeVisible();
+    await expect(main.getByText('Select how you want to visualize your data.')).toBeVisible();
+    await expect(main.getByText('Hierarchy & Annotations', { exact: true })).toBeVisible();
+    await expect(main.getByText('Relationships', { exact: true })).toBeVisible();
+
+    // settingsPanel toggles
+    await expect(main.getByText('Hide labels', { exact: true })).toBeVisible();
+    await expect(main.getByText("Don't show text labels for graph nodes", { exact: false })).toBeVisible();
+    await expect(main.getByText('Show sub-folders as nodes', { exact: true })).toBeVisible();
+    await expect(main.getByText('Hide unconnected nodes', { exact: true })).toBeVisible();
+
+    // Expand "Hide for specific node types"
+    await main.getByText('Hide for specific node types', { exact: true }).click();
+    await expect(main.getByText('Image labels', { exact: true })).toBeVisible();
+    await expect(main.getByText('Entity class labels', { exact: true })).toBeVisible();
+    // includeFolders off → no sub-folder label switch
+    await expect(main.getByText('Sub-folder labels', { exact: true })).toBeHidden();
+
+    expect(await findRawTranslationKeys(page)).toEqual([]);
+    expect(errors).toEqual([]);
+  });
+
+  test('settings panel is fully translated (ja)', async ({ page }) => {
+    const errors = collectPageErrors(page);
+    await gotoKnowledgeGraph(page, 'ja');
+
+    const main = page.locator('main');
+    await page.getByRole('button', { name: '設定', exact: true }).click();
+
+    await expect(main.getByText('グラフタイプ', { exact: true })).toBeVisible();
+    await expect(main.getByText('データの可視化方法を選択します。')).toBeVisible();
+    await expect(main.getByText('階層とアノテーション', { exact: true })).toBeVisible();
+    await expect(main.getByText('リレーション', { exact: true })).toBeVisible();
+
+    await expect(main.getByText('ラベルを非表示', { exact: true })).toBeVisible();
+    await expect(main.getByText('グラフノードのテキストラベルを表示しません', { exact: false })).toBeVisible();
+    await expect(main.getByText('サブフォルダをノードとして表示', { exact: true })).toBeVisible();
+    await expect(main.getByText('接続のないノードを非表示', { exact: true })).toBeVisible();
+
+    await main.getByText('特定のノードタイプのみ非表示', { exact: true }).click();
+    await expect(main.getByText('画像ラベル', { exact: true })).toBeVisible();
+    await expect(main.getByText('エンティティクラスラベル', { exact: true })).toBeVisible();
+    await expect(main.getByText('サブフォルダラベル', { exact: true })).toBeHidden();
+
+    expect(await findRawTranslationKeys(page)).toEqual([]);
+    expect(errors).toEqual([]);
+  });
+
+  test('graph search dialog is translated (en)', async ({ page }) => {
+    const errors = collectPageErrors(page);
+    await gotoKnowledgeGraph(page, 'en');
+
+    await page.locator('main button:has(.lucide-search)').click();
+    // Move pointer away so the button tooltip ("Graph search") closes and
+    // does not collide with the dialog title assertion below.
+    await page.mouse.move(0, 0);
+    await expect(page.getByRole('tooltip')).toBeHidden();
+
+    // graphSearch.* — the dialog is portalled to document.body
+    await expect(page.getByText('Graph Search', { exact: true })).toBeVisible();
+    await expect(page.getByText('Find', { exact: true })).toBeVisible();
+
+    const nodeTypeSelect = page.getByRole('combobox');
+    await expect(nodeTypeSelect).toContainText('select node type...');
+
+    // Default HIERARCHY mode without folders → only "images" is offered
+    await nodeTypeSelect.click();
+    await expect(page.getByRole('option', { name: 'images', exact: true })).toBeVisible();
+    await expect(page.getByRole('option', { name: 'entity classes', exact: true })).toBeHidden();
+    await expect(page.getByRole('option', { name: 'sub-folders', exact: true })).toBeHidden();
+    await page.keyboard.press('Escape');
+
+    expect(await findRawTranslationKeys(page)).toEqual([]);
+    expect(errors).toEqual([]);
+  });
+
+  test('graph search dialog is translated (ja)', async ({ page }) => {
+    const errors = collectPageErrors(page);
+    await gotoKnowledgeGraph(page, 'ja');
+
+    await page.locator('main button:has(.lucide-search)').click();
+    await page.mouse.move(0, 0);
+    await expect(page.getByRole('tooltip')).toBeHidden();
+
+    await expect(page.getByText('グラフ検索', { exact: true })).toBeVisible();
+    await expect(page.getByText('検索対象', { exact: true })).toBeVisible();
+
+    const nodeTypeSelect = page.getByRole('combobox');
+    await expect(nodeTypeSelect).toContainText('ノードタイプを選択...');
+
+    await nodeTypeSelect.click();
+    await expect(page.getByRole('option', { name: '画像', exact: true })).toBeVisible();
+    await expect(page.getByRole('option', { name: 'エンティティクラス', exact: true })).toBeHidden();
+    await expect(page.getByRole('option', { name: 'サブフォルダ', exact: true })).toBeHidden();
+    await page.keyboard.press('Escape');
+
+    expect(await findRawTranslationKeys(page)).toEqual([]);
+    expect(errors).toEqual([]);
+  });
+
+});

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -4,12 +4,14 @@ import { initReactI18next } from 'react-i18next';
 
 import enAnnotate from '../locales/en/annotate.json';
 import enCommon from '../locales/en/common.json';
+import enKnowledgegraph from '../locales/en/knowledgegraph.json';
 import enSmartTools from '../locales/en/smartTools.json';
 import enStart from '../locales/en/start.json';
 import enUi from '../locales/en/ui.json';
 
 import jaAnnotate from '../locales/ja/annotate.json';
 import jaCommon from '../locales/ja/common.json';
+import jaKnowledgegraph from '../locales/ja/knowledgegraph.json';
 import jaSmartTools from '../locales/ja/smartTools.json';
 import jaStart from '../locales/ja/start.json';
 import jaUi from '../locales/ja/ui.json';
@@ -27,6 +29,7 @@ i18n
       en: {
         annotate: enAnnotate,
         common: enCommon,
+        knowledgegraph: enKnowledgegraph,
         smartTools: enSmartTools,
         start: enStart,
         ui: enUi
@@ -34,6 +37,7 @@ i18n
       ja: {
         annotate: jaAnnotate,
         common: jaCommon,
+        knowledgegraph: jaKnowledgegraph,
         smartTools: jaSmartTools,
         start: jaStart,
         ui: jaUi

--- a/src/locales/en/knowledgegraph.json
+++ b/src/locales/en/knowledgegraph.json
@@ -1,0 +1,154 @@
+{
+  "knowledgeGraph": {
+    "title": "Knowledge Graph",
+    "description": "Explore connections between images and entities. Zoom and pan the graph with your mouse. Grab and pull a node to re-arrange the graph. Click a node to see more information."
+  },
+  "graphControls": {
+    "toggleFullscreen": "Toggle fullscreen",
+    "unpinAllNodes": "Un-pin all pinned nodes",
+    "graphSearch": "Graph search",
+    "graphSettings": "Graph settings",
+    "settings": "Settings"
+  },
+  "settingsPanel": {
+    "graphType": {
+      "title": "Graph Type",
+      "description": "Select how you want to visualize your data.",
+      "hierarchy": "Hierarchy & Annotations",
+      "hierarchyDescription": "Visualize the data model hierarchy, folder structure and entity annotations.",
+      "relations": "Relationships",
+      "relationsDescription": "Visualize the Relationships between annotations. Data model hierarchy and entity annotations are shown on hover."
+    },
+    "hideLabels": "Hide labels",
+    "hideLabelsDescription": "Don't show text labels for graph nodes. A hover tooltip will be used instead.",
+    "hideForSpecificNodeTypes": "Hide for specific node types",
+    "imageLabels": "Image labels",
+    "subFolderLabels": "Sub-folder labels",
+    "entityClassLabels": "Entity class labels",
+    "showSubFolders": "Show sub-folders as nodes",
+    "showSubFoldersDescription": "Include sub-folders inside your workfolder as nodes in the graph.",
+    "hideUnconnectedNodes": "Hide unconnected nodes",
+    "hideUnconnectedNodesDescription": "Remove nodes without any connections from the graph."
+  },
+  "legend": {
+    "nodes": "Nodes",
+    "edges": "Edges",
+    "entityClass": "Entity Class",
+    "subFolder": "Sub-Folder",
+    "image": "Image",
+    "relationship": {
+      "title": "Relationship",
+      "description": "Connections based on Relationships between your annotations."
+    },
+    "entityClassHierarchy": {
+      "title": "Entity class hierarchy",
+      "description": "Links between parent- and child Entity Classes in your data model."
+    },
+    "folderStructure": {
+      "title": "Folder structure",
+      "description": "File structure of sub-folders and image files in your project directory."
+    },
+    "entityAnnotations": {
+      "title": "Entity Annotations",
+      "description": "Connections between images and Entity Classes, based on the tags in your annotations."
+    }
+  },
+  "graphView": {
+    "linkLabels": {
+      "subFolder": "Sub-Folder",
+      "imageInSubFolder": "Image is in Sub-Folder",
+      "entityClassHierarchy": "Entity Class Hierarchy",
+      "hasEntityAnnotations_one": "Image has {{count}} entity annotation",
+      "hasEntityAnnotations_other": "Image has {{count}} entity annotations",
+      "relationshipsInsideImage_one": "{{count}} Relationship inside this image ({{relations}})",
+      "relationshipsInsideImage_other": "{{count}} Relationships inside this image ({{relations}})",
+      "relationshipsBetweenImages_one": "{{count}} Relationship between these images ({{relations}})",
+      "relationshipsBetweenImages_other": "{{count}} Relationships between these images ({{relations}})",
+      "relationshipsBetweenEntities_one": "{{count}} Relationship between entities of this class ({{relations}})",
+      "relationshipsBetweenEntities_other": "{{count}} Relationships between entities of this class ({{relations}})",
+      "connectedViaRelationships_one": "Connected via {{count}} Relationship ({{relations}})",
+      "connectedViaRelationships_other": "Connected via {{count}} Relationships ({{relations}})"
+    }
+  },
+  "graphSearch": {
+    "title": "Graph Search",
+    "find": "Find",
+    "selectNodeType": "select node type...",
+    "objectTypes": {
+      "entityClasses": "entity classes",
+      "subFolders": "sub-folders",
+      "images": "images"
+    },
+    "operators": {
+      "and": "and",
+      "or": "or"
+    },
+    "conditionTypes": {
+      "where": "where",
+      "withRelationship": "with relationship",
+      "withEntity": "with entity",
+      "withNote": "with note",
+      "withIiifMetadata": "with IIIF metadata"
+    },
+    "comparators": {
+      "is": "is",
+      "isEmpty": "is empty",
+      "isNotEmpty": "is not empty"
+    },
+    "builtInAttributes": {
+      "folderName": "folder name",
+      "imageFilename": "image filename"
+    },
+    "attributePrefix": {
+      "folder": "folder",
+      "image": "image"
+    },
+    "addCondition": "Add Condition",
+    "clearAll": "Clear All",
+    "subCondition": "Sub-Condition",
+    "where": "where",
+    "noMatches": "No matches",
+    "openInWorkspace": "Open in workspace",
+    "searchPlaceholder": "Search...",
+    "export": {
+      "export": "Export",
+      "metadata": "Export metadata",
+      "annotations": "Export annotations",
+      "relationships": "Export relationships",
+      "exporting": "Exporting XLSX. This may take a while."
+    }
+  },
+  "selectionDetails": {
+    "annotationViewLink": {
+      "currentlyOpen": "Currently open in workspace",
+      "openImage": "Open image",
+      "addToWorkspace": "Add to workspace"
+    },
+    "copyManifestUrl": "Copy manifest URL to clipboard",
+    "entityType": {
+      "noDescription": "No description",
+      "annotationsLabel_one": "Annotation",
+      "annotationsLabel_other": "Annotations",
+      "relationshipsLabel_one": "Relationship",
+      "relationshipsLabel_other": "Relationships"
+    },
+    "image": {
+      "annotationsTab": "Annotations",
+      "relationshipsTab": "Relationships",
+      "metadataTab": "Metadata",
+      "dimensions": "{{width}} x {{height}} px"
+    },
+    "folder": {
+      "imageCount_one": "{{count}} Image",
+      "imageCount_other": "{{count}} Images",
+      "subFolderCount_one": "{{count}} Sub-Folder",
+      "subFolderCount_other": "{{count}} Sub-Folders",
+      "open": "Open"
+    },
+    "metadata": {
+      "save": "Save",
+      "iiifTab": "IIIF",
+      "myTab": "My"
+    }
+  }
+}

--- a/src/locales/ja/knowledgegraph.json
+++ b/src/locales/ja/knowledgegraph.json
@@ -1,0 +1,145 @@
+{
+  "knowledgeGraph": {
+    "title": "ナレッジグラフ",
+    "description": "画像とエンティティのつながりを探索できます。マウスでグラフのズームやパンができます。ノードをドラッグするとグラフを並べ替えられます。ノードをクリックすると詳細が表示されます。"
+  },
+  "graphControls": {
+    "toggleFullscreen": "全画面表示を切り替え",
+    "unpinAllNodes": "すべてのノードのピン留めを解除",
+    "graphSearch": "グラフ検索",
+    "graphSettings": "グラフ設定",
+    "settings": "設定"
+  },
+  "settingsPanel": {
+    "graphType": {
+      "title": "グラフタイプ",
+      "description": "データの可視化方法を選択します。",
+      "hierarchy": "階層とアノテーション",
+      "hierarchyDescription": "データモデルの階層、フォルダ構造、エンティティアノテーションを可視化します。",
+      "relations": "リレーション",
+      "relationsDescription": "アノテーション間のリレーションを可視化します。データモデルの階層とエンティティアノテーションはホバー時に表示されます。"
+    },
+    "hideLabels": "ラベルを非表示",
+    "hideLabelsDescription": "グラフノードのテキストラベルを表示しません。代わりにホバー時のツールチップが使用されます。",
+    "hideForSpecificNodeTypes": "特定のノードタイプのみ非表示",
+    "imageLabels": "画像ラベル",
+    "subFolderLabels": "サブフォルダラベル",
+    "entityClassLabels": "エンティティクラスラベル",
+    "showSubFolders": "サブフォルダをノードとして表示",
+    "showSubFoldersDescription": "作業フォルダ内のサブフォルダをグラフのノードとして含めます。",
+    "hideUnconnectedNodes": "接続のないノードを非表示",
+    "hideUnconnectedNodesDescription": "接続を持たないノードをグラフから取り除きます。"
+  },
+  "legend": {
+    "nodes": "ノード",
+    "edges": "エッジ",
+    "entityClass": "エンティティクラス",
+    "subFolder": "サブフォルダ",
+    "image": "画像",
+    "relationship": {
+      "title": "リレーション",
+      "description": "アノテーション間のリレーションに基づく接続です。"
+    },
+    "entityClassHierarchy": {
+      "title": "エンティティクラス階層",
+      "description": "データモデル内の親エンティティクラスと子エンティティクラスを結ぶリンクです。"
+    },
+    "folderStructure": {
+      "title": "フォルダ構造",
+      "description": "プロジェクトディレクトリ内のサブフォルダと画像ファイルのファイル構造です。"
+    },
+    "entityAnnotations": {
+      "title": "エンティティアノテーション",
+      "description": "アノテーションのタグに基づく、画像とエンティティクラスの間の接続です。"
+    }
+  },
+  "graphView": {
+    "linkLabels": {
+      "subFolder": "サブフォルダ",
+      "imageInSubFolder": "画像はサブフォルダ内にあります",
+      "entityClassHierarchy": "エンティティクラス階層",
+      "hasEntityAnnotations_other": "画像には {{count}} 件のエンティティアノテーションがあります",
+      "relationshipsInsideImage_other": "この画像内のリレーション {{count}} 件（{{relations}}）",
+      "relationshipsBetweenImages_other": "これらの画像間のリレーション {{count}} 件（{{relations}}）",
+      "relationshipsBetweenEntities_other": "このクラスのエンティティ間のリレーション {{count}} 件（{{relations}}）",
+      "connectedViaRelationships_other": "{{count}} 件のリレーションで接続（{{relations}}）"
+    }
+  },
+  "graphSearch": {
+    "title": "グラフ検索",
+    "find": "検索対象",
+    "selectNodeType": "ノードタイプを選択...",
+    "objectTypes": {
+      "entityClasses": "エンティティクラス",
+      "subFolders": "サブフォルダ",
+      "images": "画像"
+    },
+    "operators": {
+      "and": "かつ",
+      "or": "または"
+    },
+    "conditionTypes": {
+      "where": "条件",
+      "withRelationship": "リレーションを持つ",
+      "withEntity": "エンティティを持つ",
+      "withNote": "メモを持つ",
+      "withIiifMetadata": "IIIF メタデータを持つ"
+    },
+    "comparators": {
+      "is": "等しい",
+      "isEmpty": "空である",
+      "isNotEmpty": "空でない"
+    },
+    "builtInAttributes": {
+      "folderName": "フォルダ名",
+      "imageFilename": "画像ファイル名"
+    },
+    "attributePrefix": {
+      "folder": "フォルダ",
+      "image": "画像"
+    },
+    "addCondition": "条件を追加",
+    "clearAll": "すべてクリア",
+    "subCondition": "サブ条件",
+    "where": "条件",
+    "noMatches": "該当なし",
+    "openInWorkspace": "ワークスペースで開く",
+    "searchPlaceholder": "検索...",
+    "export": {
+      "export": "エクスポート",
+      "metadata": "メタデータをエクスポート",
+      "annotations": "アノテーションをエクスポート",
+      "relationships": "リレーションをエクスポート",
+      "exporting": "XLSX をエクスポートしています。しばらくお待ちください。"
+    }
+  },
+  "selectionDetails": {
+    "annotationViewLink": {
+      "currentlyOpen": "現在ワークスペースで開いています",
+      "openImage": "画像を開く",
+      "addToWorkspace": "ワークスペースに追加"
+    },
+    "copyManifestUrl": "マニフェスト URL をクリップボードにコピー",
+    "entityType": {
+      "noDescription": "説明なし",
+      "annotationsLabel_other": "アノテーション",
+      "relationshipsLabel_other": "リレーション"
+    },
+    "image": {
+      "annotationsTab": "アノテーション",
+      "relationshipsTab": "リレーション",
+      "metadataTab": "メタデータ",
+      "dimensions": "{{width}} x {{height}} px"
+    },
+    "folder": {
+      "imageCount_other": "{{count}} 件の画像",
+      "subFolderCount_other": "{{count}} 件のサブフォルダ",
+      "open": "開く"
+    },
+    "metadata": {
+      "save": "保存",
+      "iiifTab": "IIIF",
+      "myTab": "マイ"
+    }
+  }
+}

--- a/src/pages/knowledgegraph/GraphControls/GraphControls.tsx
+++ b/src/pages/knowledgegraph/GraphControls/GraphControls.tsx
@@ -1,4 +1,5 @@
 import { Fullscreen, PinOff, Search, Settings } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { TooltippedButton } from '@/components/TooltippedButton';
 
 interface GraphControlsProps {
@@ -23,6 +24,8 @@ interface GraphControlsProps {
 
 export const GraphControls = (props: GraphControlsProps) => {
 
+  const { t } = useTranslation('knowledgegraph');
+
   return (
     <>
       <div className="absolute top-6 right-6 flex gap-2.5">
@@ -32,7 +35,7 @@ export const GraphControls = (props: GraphControlsProps) => {
           className={props.isFullScreen 
             ? 'rounded-full bg-black'
             : 'rounded-full bg-white/70 backdrop-blur-xs'}
-          tooltip="Toggle fullscreen"
+          tooltip={t('graphControls.toggleFullscreen')}
           onClick={props.onToggleFullscreen}>
           <Fullscreen className="h-5 w-5" />
         </TooltippedButton>
@@ -43,7 +46,7 @@ export const GraphControls = (props: GraphControlsProps) => {
           <TooltippedButton
             size="icon"
             className="rounded-full"
-            tooltip="Un-pin all pinned nodes"
+            tooltip={t('graphControls.unpinAllNodes')}
             onClick={props.onUnpinAllNodes}>
             <PinOff className="h-5 w-5" />
           </TooltippedButton>
@@ -55,7 +58,7 @@ export const GraphControls = (props: GraphControlsProps) => {
           className={props.isSearchOpen 
             ? 'rounded-full bg-black'
             : 'rounded-full bg-white/70 backdrop-blur-xs'}
-          tooltip="Graph search"
+          tooltip={t('graphControls.graphSearch')}
           onClick={props.onToggleSearch}>
           <Search className="h-5 w-5" />
         </TooltippedButton>
@@ -65,9 +68,9 @@ export const GraphControls = (props: GraphControlsProps) => {
           className={props.isSettingsOpen 
             ? 'gap-2 pl-3.5 pr-4 rounded-full border'
             : 'gap-2 pl-3.5 pr-4 rounded-full bg-white/70 backdrop-blur-xs'}
-          tooltip="Graph settings"
+          tooltip={t('graphControls.graphSettings')}
           onClick={props.onToggleSettings}>
-          <Settings className="h-5 w-5" /> Settings
+          <Settings className="h-5 w-5" /> {t('graphControls.settings')}
         </TooltippedButton>
       </div>
     </>

--- a/src/pages/knowledgegraph/GraphSearch/GraphSearch.tsx
+++ b/src/pages/knowledgegraph/GraphSearch/GraphSearch.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { createPortal } from 'react-dom';
 import { W3CAnnotation } from '@annotorious/react';
 import { useDraggable } from '@neodrag/react';
@@ -48,6 +49,8 @@ interface GraphSearchProps {
 const EMPTY_CONDITION: Condition = { operator: 'AND', sentence: {} };
 
 export const GraphSearch = (props: GraphSearchProps) => {
+
+  const { t } = useTranslation('knowledgegraph');
 
   const el = useRef<HTMLDivElement>(null);
 
@@ -168,7 +171,7 @@ export const GraphSearch = (props: GraphSearchProps) => {
       <div className="flex justify-between items-center pl-2 pr-1 py-1 border-b cursor-move mb-4 text-xs font-medium text-muted-foreground">
         <div className="flex items-center gap-1.5">
           <Grip className="w-4 h-4 mb-0.5" />
-          <span>Graph Search</span>
+          <span>{t('graphSearch.title')}</span>
         </div>
 
         <Button 
@@ -183,7 +186,7 @@ export const GraphSearch = (props: GraphSearchProps) => {
       <div className="px-3 pr-5 pb-2">
         <div className="text-xs flex items-center gap-2">
           <span className="w-14 text-right">
-            Find
+            {t('graphSearch.find')}
           </span>
           
           <Select 
@@ -191,7 +194,7 @@ export const GraphSearch = (props: GraphSearchProps) => {
             onValueChange={onSelectObjectType}>
             <SelectTrigger className="rounded-none px-2 py-1 h-auto bg-white shadow-none">
               <span className="text-xs">
-                <SelectValue placeholder="select node type..." />
+                <SelectValue placeholder={t('graphSearch.selectNodeType')} />
               </span>
             </SelectTrigger>
 
@@ -199,18 +202,18 @@ export const GraphSearch = (props: GraphSearchProps) => {
               {props.settings.graphMode === 'RELATIONS' && (
                 <SelectItem
                   className="text-xs" 
-                  value="ENTITY_TYPE">entity classes</SelectItem>
+                  value="ENTITY_TYPE">{t('graphSearch.objectTypes.entityClasses')}</SelectItem>
               )}
 
               {props.settings.includeFolders && (
                 <SelectItem
                   className="text-xs" 
-                  value="FOLDER">sub-folders</SelectItem>
+                  value="FOLDER">{t('graphSearch.objectTypes.subFolders')}</SelectItem>
               )}
 
               <SelectItem
                 className="text-xs" 
-                value="IMAGE">images</SelectItem>
+                value="IMAGE">{t('graphSearch.objectTypes.images')}</SelectItem>
             </SelectContent>
           </Select>
         </div>
@@ -236,11 +239,11 @@ export const GraphSearch = (props: GraphSearchProps) => {
                   <SelectContent>
                     <SelectItem
                       className="text-xs" 
-                      value="AND">and</SelectItem>
+                      value="AND">{t('graphSearch.operators.and')}</SelectItem>
 
                     <SelectItem
-                      className="text-xs" 
-                      value="OR">or</SelectItem>
+                      className="text-xs"
+                      value="OR">{t('graphSearch.operators.or')}</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
@@ -266,7 +269,7 @@ export const GraphSearch = (props: GraphSearchProps) => {
                 size="sm"
                 className="flex items-center text-xs py-0 px-0 font-normal"
                 onClick={() => setConditions(conditions => ([...conditions, {...EMPTY_CONDITION}]))}>
-                <CirclePlus className="h-3.5 w-3.5 ml-0.5 mr-1 mb-0.5" /> Add Condition
+                <CirclePlus className="h-3.5 w-3.5 ml-0.5 mr-1 mb-0.5" /> {t('graphSearch.addCondition')}
               </Button>
 
               <Button 
@@ -274,7 +277,7 @@ export const GraphSearch = (props: GraphSearchProps) => {
                 size="sm"
                 className="flex items-center text-xs py-0 px-0 font-normal"
                 onClick={onClearAll}>
-                <Trash2 className="h-3.5 w-3.5 mr-1 mb-px" /> Clear All
+                <Trash2 className="h-3.5 w-3.5 mr-1 mb-px" /> {t('graphSearch.clearAll')}
               </Button>
             </div>
 
@@ -298,7 +301,7 @@ export const GraphSearch = (props: GraphSearchProps) => {
                   </TooltipTrigger>
 
                   <TooltipContent>
-                    Open in workspace
+                    {t('graphSearch.openInWorkspace')}
                   </TooltipContent>
                 </Tooltip>
               </div>

--- a/src/pages/knowledgegraph/GraphSearch/GraphSearchConditionBuilder.tsx
+++ b/src/pages/knowledgegraph/GraphSearch/GraphSearchConditionBuilder.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { CirclePlus, Trash2 } from 'lucide-react';
 import { W3CAnnotation } from '@annotorious/react';
 import { Combobox } from '@/components/Combobox';
@@ -46,6 +47,8 @@ interface GraphSearchConditionBuilderProps {
 
 export const GraphSearchConditionBuilder = (props: GraphSearchConditionBuilderProps) => {
 
+  const { t } = useTranslation('knowledgegraph');
+
   const {
     attributeOptions,
     comparatorOptions,
@@ -59,21 +62,21 @@ export const GraphSearchConditionBuilder = (props: GraphSearchConditionBuilderPr
     props.onChange(sentence, matches);
   }, [sentence, matches]);
 
-  const conditionTypes = useMemo(() => 
+  const conditionTypes = useMemo(() =>
     props.objectType === 'IMAGE' ? [
-      { label: 'where', value: 'WHERE' },
-      (props.settings.graphMode === 'RELATIONS' ? { label: 'with relationship', value: 'WITH_RELATIONSHIP' } : undefined),
-      { label: 'with entity', value: 'WITH_ENTITY' },
-      { label: 'with note', value: 'WITH_NOTE' },
-      { label: 'with IIIF metadata', value: 'WITH_IIIF_METADATA' }
-    ].filter(Boolean) : 
+      { label: t('graphSearch.conditionTypes.where'), value: 'WHERE' },
+      (props.settings.graphMode === 'RELATIONS' ? { label: t('graphSearch.conditionTypes.withRelationship'), value: 'WITH_RELATIONSHIP' } : undefined),
+      { label: t('graphSearch.conditionTypes.withEntity'), value: 'WITH_ENTITY' },
+      { label: t('graphSearch.conditionTypes.withNote'), value: 'WITH_NOTE' },
+      { label: t('graphSearch.conditionTypes.withIiifMetadata'), value: 'WITH_IIIF_METADATA' }
+    ].filter(Boolean) :
     props.objectType === 'ENTITY_TYPE' ? [
-      { label: 'with relationship', value: 'WITH_RELATIONSHIP' }
+      { label: t('graphSearch.conditionTypes.withRelationship'), value: 'WITH_RELATIONSHIP' }
     ] : [
       // props.object type === 'FOLDER'
-      { label: 'where', value: 'WHERE' },
-      { label: 'with IIIF metadata', value: 'WITH_IIIF_METADATA' }
-    ], [props.objectType, props.settings]);
+      { label: t('graphSearch.conditionTypes.where'), value: 'WHERE' },
+      { label: t('graphSearch.conditionTypes.withIiifMetadata'), value: 'WITH_IIIF_METADATA' }
+    ], [props.objectType, props.settings, t]);
 
   const showAddSubCondition = sentence.ConditionType === 'WITH_ENTITY' && 'Value' in sentence;
 
@@ -119,7 +122,7 @@ export const GraphSearchConditionBuilder = (props: GraphSearchConditionBuilderPr
         ))}
 
         {(options.length === 0) && (
-          <div className="text-xs text-muted-foreground flex justify-center py-1">No matches</div>
+          <div className="text-xs text-muted-foreground flex justify-center py-1">{t('graphSearch.noMatches')}</div>
         )}
       </SelectContent>
     </Select>
@@ -206,7 +209,7 @@ export const GraphSearchConditionBuilder = (props: GraphSearchConditionBuilderPr
           <button 
             className="flex items-center text-[11.5px] text-muted-foreground hover:text-black gap-1 pl-2"
             onClick={onAddSubcondition}>
-            <CirclePlus className="h-3 w-3" /> Sub-Condition
+            <CirclePlus className="h-3 w-3" /> {t('graphSearch.subCondition')}
           </button>
         )}
       </div>

--- a/src/pages/knowledgegraph/GraphSearch/GraphSearchSubConditionBuilder.tsx
+++ b/src/pages/knowledgegraph/GraphSearch/GraphSearchSubConditionBuilder.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Trash2 } from 'lucide-react';
 import { W3CAnnotation } from '@annotorious/react';
 import { Combobox } from '@/components/Combobox';
@@ -29,6 +30,8 @@ interface GraphSearchSubConditionBuilderProps {
 
 export const GraphSearchSubConditionBuilder = (props: GraphSearchSubConditionBuilderProps) => {
 
+  const { t } = useTranslation('knowledgegraph');
+
   const { subcondition } = props;
 
   const annotations = useMemo(() => (
@@ -52,7 +55,7 @@ export const GraphSearchSubConditionBuilder = (props: GraphSearchSubConditionBui
   
   return (
     <div className="flex pt-2">
-      <div className="w-32 text-right px-2 py-1">where</div>
+      <div className="w-32 text-right px-2 py-1">{t('graphSearch.where')}</div>
 
       <Combobox 
         className={`${selectStyle} border-l`}
@@ -80,7 +83,7 @@ export const GraphSearchSubConditionBuilder = (props: GraphSearchSubConditionBui
           ))}
 
           {(comparatorOptions.length === 0) && (
-            <div className="text-xs text-muted-foreground flex justify-center py-1">No matches</div>
+            <div className="text-xs text-muted-foreground flex justify-center py-1">{t('graphSearch.noMatches')}</div>
           )}
         </SelectContent>
       </Select>

--- a/src/pages/knowledgegraph/GraphSearch/export/ExportSelector.tsx
+++ b/src/pages/knowledgegraph/GraphSearch/export/ExportSelector.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/ui/Button';
 import { ChevronDown, Download, FileBarChart2, Table2 } from 'lucide-react';
 import { useStore, useExcelAnnotationExport, useExcelRelationshipExport } from '@/store';
@@ -23,6 +24,8 @@ interface ExportSelectorProps {
 }
 
 export const ExportSelector = (props: ExportSelectorProps) => {
+
+  const { t } = useTranslation('knowledgegraph');
 
   const store = useStore();
 
@@ -85,8 +88,8 @@ export const ExportSelector = (props: ExportSelectorProps) => {
             variant="link"
             size="sm"
             className="flex items-center text-xs py-0 px-0 font-normal">
-            <Download className="h-3.5 w-3.5 mr-1.5 mb-px" /> 
-            Export 
+            <Download className="h-3.5 w-3.5 mr-1.5 mb-px" />
+            {t('graphSearch.export.export')}
             <ChevronDown className="h-3.5 w-3.5 ml-0.5" />
           </Button>
         </DropdownMenuTrigger>
@@ -95,15 +98,15 @@ export const ExportSelector = (props: ExportSelectorProps) => {
           align="end"
           sideOffset={-5}>
           <DropdownMenuItem className="text-xs flex items-center" onSelect={onExportMetadata}>
-            <FileBarChart2 className="w-3.5 h-3.5 mr-1.5 mb-0.5" />  Export metadata
+            <FileBarChart2 className="w-3.5 h-3.5 mr-1.5 mb-0.5" />  {t('graphSearch.export.metadata')}
           </DropdownMenuItem>
 
           <DropdownMenuItem className="text-xs flex items-center" onSelect={onExportAnnotations}>
-            <FileBarChart2 className="w-3.5 h-3.5 mr-1.5 mb-0.5" /> Export annotations
+            <FileBarChart2 className="w-3.5 h-3.5 mr-1.5 mb-0.5" /> {t('graphSearch.export.annotations')}
           </DropdownMenuItem>
 
           <DropdownMenuItem className="text-xs flex items-center" onSelect={onExportRelationships}>
-            <FileBarChart2 className="w-3.5 h-3.5 mr-1.5 mb-0.5" /> Export relationships
+            <FileBarChart2 className="w-3.5 h-3.5 mr-1.5 mb-0.5" /> {t('graphSearch.export.relationships')}
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
@@ -111,7 +114,7 @@ export const ExportSelector = (props: ExportSelectorProps) => {
       <ProgressDialog 
         icon={<Table2 className="h-5 w-5" />}
         open={busy}
-        message="Exporting XLSX. This may take a while."
+        message={t('graphSearch.export.exporting')}
         progress={progress} />
     </>
   )

--- a/src/pages/knowledgegraph/GraphSearch/iiif/IIIFMetadataSearch.tsx
+++ b/src/pages/knowledgegraph/GraphSearch/iiif/IIIFMetadataSearch.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ChevronDown, Search } from 'lucide-react';
 import { Command, CommandEmpty, CommandItem, CommandList } from '@/ui/Command';
 import { Spinner } from '@/components/Spinner';
@@ -18,6 +19,8 @@ interface IIIFMetadataSearchProps {
 }
 
 export const IIIFMetadataSearch = (props: IIIFMetadataSearchProps) => {
+
+  const { t } = useTranslation('knowledgegraph');
 
   const { loading, search } = useManifestMetadataSearch(props.objectType);
 
@@ -66,7 +69,7 @@ export const IIIFMetadataSearch = (props: IIIFMetadataSearchProps) => {
             <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
             <input 
               className="flex h-auto w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
-              placeholder="Search..." 
+              placeholder={t('graphSearch.searchPlaceholder')}
               value={query}
               onChange={evt => setQuery(evt.target.value)} />
           </div>
@@ -74,7 +77,7 @@ export const IIIFMetadataSearch = (props: IIIFMetadataSearchProps) => {
           <CommandList className="p-1">
             <CommandEmpty 
               className="text-xs font-normal flex justify-center py-2 text-muted-foreground">
-              No matches
+              {t('graphSearch.noMatches')}
             </CommandEmpty>
 
             {options.map(option => (

--- a/src/pages/knowledgegraph/GraphSearch/useGraphSearch.ts
+++ b/src/pages/knowledgegraph/GraphSearch/useGraphSearch.ts
@@ -1,5 +1,6 @@
 import { useStore } from '@/store';
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { W3CAnnotation } from '@annotorious/react';
 import { IIIFManifestResource } from '@/model';
 import { IIIFMetadataIndexRecord } from './iiif';
@@ -27,19 +28,21 @@ import {
   PropertyCondition
 } from './searchUtils';
 
-const ComparatorOptions = [
-  { label: 'is', value: 'IS' }, 
-  { label: 'is empty', value: 'IS_EMPTY' },
-  { label: 'is not empty', value: 'IS_NOT_EMPTY'}
-];
-
 export const useGraphSearch = (
   annotations: { sourceId: string, annotations: W3CAnnotation[] }[],
-  graph: Graph, 
-  objectType: GraphNodeType, 
+  graph: Graph,
+  objectType: GraphNodeType,
   initialValue?: Partial<Sentence>
 ) => {
   const store = useStore();
+
+  const { t } = useTranslation('knowledgegraph');
+
+  const ComparatorOptions = [
+    { label: t('graphSearch.comparators.is'), value: 'IS' },
+    { label: t('graphSearch.comparators.isEmpty'), value: 'IS_EMPTY' },
+    { label: t('graphSearch.comparators.isNotEmpty'), value: 'IS_NOT_EMPTY' }
+  ];
 
   const [sentence, setSentence] = useState<Partial<Sentence>>(initialValue || {});
 
@@ -79,11 +82,19 @@ export const useGraphSearch = (
           ? listFolderMetadataProperties(store) : listAllMetadataProperties(store);
 
         setAttributeOptions(properties.map(p => {
-          const value = p.builtIn 
+          const value = p.builtIn
             ? p.propertyName
             : `${p.type === 'FOLDER' ? 'folder' : 'image'}:${p.propertyName}`;
-            
-          return { label: value, value, builtIn: p.builtIn }
+
+          const label = p.builtIn
+            ? (p.propertyName === 'folder name'
+                ? t('graphSearch.builtInAttributes.folderName')
+                : p.propertyName === 'image filename'
+                  ? t('graphSearch.builtInAttributes.imageFilename')
+                  : p.propertyName)
+            : `${p.type === 'FOLDER' ? t('graphSearch.attributePrefix.folder') : t('graphSearch.attributePrefix.image')}:${p.propertyName}`;
+
+          return { label, value, builtIn: p.builtIn }
         }));
       } else if (!s.Comparator) {
         setComparatorOptions(ComparatorOptions);

--- a/src/pages/knowledgegraph/GraphSearch/useSubConditions.ts
+++ b/src/pages/knowledgegraph/GraphSearch/useSubConditions.ts
@@ -1,21 +1,24 @@
 import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useDataModel } from '@/store';
 import { W3CAnnotation, W3CAnnotationBody } from '@annotorious/react';
 import { serializePropertyValue } from '@/utils/serialize';
 import { DropdownOption } from '../Types';
 
-const comparatorOptions = [
-  { label: 'is', value: 'IS' }, 
-  { label: 'is empty', value: 'IS_EMPTY' },
-  { label: 'is not empty', value: 'IS_NOT_EMPTY'}
-];
-
 export const useSubConditions = (
   annotations: W3CAnnotation[],
-  subjectId: string, 
+  subjectId: string,
   attribute?: DropdownOption,
 ) => {
   const model = useDataModel();
+
+  const { t } = useTranslation('knowledgegraph');
+
+  const comparatorOptions = useMemo(() => ([
+    { label: t('graphSearch.comparators.is'), value: 'IS' },
+    { label: t('graphSearch.comparators.isEmpty'), value: 'IS_EMPTY' },
+    { label: t('graphSearch.comparators.isNotEmpty'), value: 'IS_NOT_EMPTY' }
+  ]), [t]);
 
   const type = useMemo(() => model.getEntityType(subjectId, true), [subjectId]);
 

--- a/src/pages/knowledgegraph/GraphView/GraphView.tsx
+++ b/src/pages/knowledgegraph/GraphView/GraphView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import ForceGraph2D, { LinkObject, NodeObject, ForceGraphMethods } from 'react-force-graph-2d';
 import { useDataModel } from '@/store';
 import { usePrevious } from '@/utils/usePrevious';
@@ -41,6 +42,8 @@ const MIN_LINK_WIDTH = 1;
 let globalScale = 1;
 
 export const GraphView = (props: GraphViewProps) => {
+
+  const { t } = useTranslation('knowledgegraph');
 
   const { graph, settings } = props;
 
@@ -310,24 +313,24 @@ export const GraphView = (props: GraphViewProps) => {
 
     if (types.length > 1) return;
 
-    const t = types[0];
+    const type = types[0];
 
-    if (t === 'FOLDER_CONTAINS_SUBFOLDER') {
-      return 'Sub-Folder';
-    } else if (t === 'FOLDER_CONTAINS_IMAGE') {
-      return 'Image is in Sub-Folder';
-    } else if (t === 'IS_PARENT_TYPE_OF') {
-      return 'Entity Class Hierarchy';
-    } else if (t === 'HAS_ENTITY_ANNOTATION') {
-      return `Image has ${link.weight} entity annotation${link.weight ===  1 ? '' : 's'}`;
-    } else if (t === 'HAS_RELATED_ANNOTATION_IN') {
-      return link.source === link.target 
-        ? `${link.weight} Relationship${link.weight ===  1 ? '' : 's'} inside this image (${[...relations].join(', ')})`
-        : `${link.weight} Relationship${link.weight === 1 ? '' : 's'} between these images (${[...relations].join(', ')})`;
-    } else if (t === 'IS_RELATED_VIA_ANNOTATION') {
+    if (type === 'FOLDER_CONTAINS_SUBFOLDER') {
+      return t('graphView.linkLabels.subFolder');
+    } else if (type === 'FOLDER_CONTAINS_IMAGE') {
+      return t('graphView.linkLabels.imageInSubFolder');
+    } else if (type === 'IS_PARENT_TYPE_OF') {
+      return t('graphView.linkLabels.entityClassHierarchy');
+    } else if (type === 'HAS_ENTITY_ANNOTATION') {
+      return t('graphView.linkLabels.hasEntityAnnotations', { count: link.weight });
+    } else if (type === 'HAS_RELATED_ANNOTATION_IN') {
       return link.source === link.target
-        ? `${link.weight} Relationship${link.weight === 1 ? '' : 's'} between entities of this class (${[...relations].join(', ')})`
-        : `Connected via ${link.weight} Relationship${link.weight === 1 ? '' : 's'} (${[...relations].join(', ')})`
+        ? t('graphView.linkLabels.relationshipsInsideImage', { count: link.weight, relations: [...relations].join(', ') })
+        : t('graphView.linkLabels.relationshipsBetweenImages', { count: link.weight, relations: [...relations].join(', ') });
+    } else if (type === 'IS_RELATED_VIA_ANNOTATION') {
+      return link.source === link.target
+        ? t('graphView.linkLabels.relationshipsBetweenEntities', { count: link.weight, relations: [...relations].join(', ') })
+        : t('graphView.linkLabels.connectedViaRelationships', { count: link.weight, relations: [...relations].join(', ') });
     }
   }
 

--- a/src/pages/knowledgegraph/KnowledgeGraph.tsx
+++ b/src/pages/knowledgegraph/KnowledgeGraph.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useTransition, animated, easings } from '@react-spring/web';
 import { NodeObject } from 'react-force-graph-2d';
 import { AppNavigationSidebar } from '@/components/AppNavigationSidebar';
@@ -15,6 +16,8 @@ import { GraphSearch } from './GraphSearch';
 import { TooltipProvider } from '@/ui/Tooltip';
 
 export const KnowledgeGraph = () => {
+
+  const { t } = useTranslation('knowledgegraph');
 
   const { selectedNodes, setSelectedNodes } = useSelectedNodes();
 
@@ -85,13 +88,12 @@ export const KnowledgeGraph = () => {
             className="absolute top-4 left-6 z-10">
             <h1 className="text-xl font-semibold tracking-tight mb-1">
               <span className="bg-white/80 backdrop-blur-xs rounded px-1 py-0.5">
-                Knowledge Graph
+                {t('knowledgeGraph.title')}
               </span>
             </h1>
             <p className="text-sm text-muted-foreground max-w-lg leading-6">
               <span className="bg-white/80 backdrop-blur-xs box-decoration-clone px-1 py-0.5 rounded">
-                Explore connections between images and entities. Zoom and pan the graph with your mouse.
-                Grab and pull a node to re-arrange the graph. Click a node to see more information.
+                {t('knowledgeGraph.description')}
               </span>
             </p>
           </animated.div>

--- a/src/pages/knowledgegraph/Legend/Legend.tsx
+++ b/src/pages/knowledgegraph/Legend/Legend.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Maximize2, Minimize2 } from 'lucide-react';
 import { useSpring, animated } from '@react-spring/web';
 import { Button } from '@/ui/Button';
@@ -6,6 +7,8 @@ import { NODE_COLORS, LINK_COLORS } from '../Styles';
 import { useKnowledgeGraphSettings } from '../KnowledgeGraphState';
 
 export const Legend = () => {
+
+  const { t } = useTranslation('knowledgegraph');
 
   const { settings, setSettings } = useKnowledgeGraphSettings();
 
@@ -76,14 +79,14 @@ export const Legend = () => {
       </Button>
 
       <div>
-        {expanded && (<h3 className="font-medium pb-1.5">Nodes</h3>)}
+        {expanded && (<h3 className="font-medium pb-1.5">{t('legend.nodes')}</h3>)}
 
         <ul className="flex gap-6 text-muted-foreground text-xs">
           <li className="flex gap-2 items-center">
             <span 
               style={{ backgroundColor: NODE_COLORS['ENTITY_TYPE']}} 
               className="block w-[12px] h-[12px] rounded-full" />
-            <span>Entity Class</span>
+            <span>{t('legend.entityClass')}</span>
           </li>
 
           {settings.includeFolders && (
@@ -91,7 +94,7 @@ export const Legend = () => {
               <span 
                 style={{ backgroundColor: NODE_COLORS['FOLDER']}} 
                 className="block w-[12px] h-[12px] rounded-full" />
-              <span>Sub-Folder</span>
+              <span>{t('legend.subFolder')}</span>
             </li>
           )}
 
@@ -99,7 +102,7 @@ export const Legend = () => {
             <span 
               style={{ backgroundColor: NODE_COLORS['IMAGE']}} 
               className="block w-[12px] h-[12px] rounded-full"/>
-            <span>Image</span>
+            <span>{t('legend.image')}</span>
           </li>
         </ul>
       </div>
@@ -107,7 +110,7 @@ export const Legend = () => {
       <animated.div style={edgeLegendSpring}>
         <div ref={edgeLegendEl}>
           <div className="pt-8">
-            <h3 className="font-medium py-0.5">Edges</h3>
+            <h3 className="font-medium py-0.5">{t('legend.edges')}</h3>
             <ul>
               {settings.graphMode === 'RELATIONS' && (
                 <li className="flex gap-3 items-start py-2">
@@ -117,11 +120,11 @@ export const Legend = () => {
 
                   <div>
                     <h4 className="font-medium">
-                      Relationship
+                      {t('legend.relationship.title')}
                     </h4>
 
                     <p className="text-muted-foreground text-xs">
-                      Connections based on Relationships between your annotations.
+                      {t('legend.relationship.description')}
                     </p>
                   </div>
                 </li>
@@ -134,11 +137,11 @@ export const Legend = () => {
 
                 <div>
                   <h4 className="font-medium">
-                    Entity class hierarchy
+                    {t('legend.entityClassHierarchy.title')}
                   </h4>
 
                   <p className="text-muted-foreground text-xs">
-                    Links between parent- and child Entity Classes in your data model.
+                    {t('legend.entityClassHierarchy.description')}
                   </p>
                 </div>
               </li>
@@ -150,10 +153,9 @@ export const Legend = () => {
                     style={{ borderColor: LINK_COLORS.FOLDER_CONTAINS_SUBFOLDER }} />
 
                   <div>
-                    <h4 className="font-medium">Folder structure</h4>
+                    <h4 className="font-medium">{t('legend.folderStructure.title')}</h4>
                     <p className="text-muted-foreground text-xs">
-                      File structure of sub-folders and image files in your 
-                      project directory.
+                      {t('legend.folderStructure.description')}
                     </p>
                   </div>
                 </li>
@@ -165,10 +167,9 @@ export const Legend = () => {
                   style={{ borderColor: LINK_COLORS.HAS_ENTITY_ANNOTATION }} />
 
                 <div>
-                  <h4 className="font-medium">Entity Annotations</h4>
+                  <h4 className="font-medium">{t('legend.entityAnnotations.title')}</h4>
                   <p className="text-muted-foreground text-xs">
-                    Connections between images and Entity Classes, based on 
-                    the tags in your annotations.
+                    {t('legend.entityAnnotations.description')}
                   </p>
                 </div>
               </li>

--- a/src/pages/knowledgegraph/SelectionDetailsDrawer/AnnotationViewLink.tsx
+++ b/src/pages/knowledgegraph/SelectionDetailsDrawer/AnnotationViewLink.tsx
@@ -1,4 +1,5 @@
 import { PanelsTopLeft, SquareArrowOutUpRight } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { useOpenInAnnotationView } from '@/pages/annotate';
 import { Button } from '@/ui/Button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ui/Tooltip';
@@ -16,7 +17,9 @@ interface AnnotationViewLinkProps {
 }
 
 export const AnnotationViewLink = (props: AnnotationViewLinkProps) => {
-  
+
+  const { t } = useTranslation('knowledgegraph');
+
   const { imageIds, openInAnnotationView, addToAnnotationView } = useOpenInAnnotationView();
 
   const isOpen = imageIds.includes(props.id);
@@ -30,7 +33,7 @@ export const AnnotationViewLink = (props: AnnotationViewLinkProps) => {
       </TooltipTrigger>
 
       <TooltipContent>
-        Currently open in workspace
+        {t('selectionDetails.annotationViewLink.currentlyOpen')}
       </TooltipContent>
     </Tooltip>
   ) : (
@@ -46,11 +49,11 @@ export const AnnotationViewLink = (props: AnnotationViewLinkProps) => {
 
       <DropdownMenuContent>
         <DropdownMenuItem onSelect={() => openInAnnotationView(props.id)}>
-          Open image
+          {t('selectionDetails.annotationViewLink.openImage')}
         </DropdownMenuItem>
 
         <DropdownMenuItem onSelect={() => addToAnnotationView(props.id)}>
-          Add to workspace
+          {t('selectionDetails.annotationViewLink.addToWorkspace')}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/pages/knowledgegraph/SelectionDetailsDrawer/ImageTitle.tsx
+++ b/src/pages/knowledgegraph/SelectionDetailsDrawer/ImageTitle.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Clipboard, ClipboardCheck, Image } from 'lucide-react';
 import { LoadedImage } from '@/model';
 import { cn } from '@/ui/utils';
@@ -46,6 +47,8 @@ interface CopyManifestURLButtonProps {
 
 export const CopyManifestURLButton = (props: CopyManifestURLButtonProps) => {
 
+  const { t } = useTranslation('knowledgegraph');
+
   const [copied, setCopied] = useState(false);
   
   const onCopyManifestURL = (evt: React.MouseEvent) => {
@@ -74,7 +77,7 @@ export const CopyManifestURLButton = (props: CopyManifestURLButtonProps) => {
       </TooltipTrigger>
       
       <TooltipContent>
-        Copy manifest URL to clipboard
+        {t('selectionDetails.copyManifestUrl')}
       </TooltipContent>
     </Tooltip>
   )

--- a/src/pages/knowledgegraph/SelectionDetailsDrawer/SelectedEntityType/SelectedEntityType.tsx
+++ b/src/pages/knowledgegraph/SelectionDetailsDrawer/SelectedEntityType/SelectedEntityType.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Cuboid, MessagesSquare, Spline, X} from 'lucide-react';
 import { EntityType } from '@/model';
 import { Button } from '@/ui/Button';
@@ -20,6 +21,8 @@ interface SelectedEntityTypeProps {
 }
 
 export const SelectedEntityType = (props: SelectedEntityTypeProps) => {
+
+  const { t } = useTranslation('knowledgegraph');
 
   const { entityTypes } = useDataModel();
 
@@ -83,7 +86,7 @@ export const SelectedEntityType = (props: SelectedEntityTypeProps) => {
               </p>
             ) : (
               <p className="font-light mt-3 text-xs text-muted-foreground/50 py-6 px-1">
-                No description
+                {t('selectionDetails.entityType.noDescription')}
               </p>
             )}
           </div>
@@ -98,7 +101,7 @@ export const SelectedEntityType = (props: SelectedEntityTypeProps) => {
                 <span>
                   {annotations} {tab === 'annotations' && (
                     <>
-                      Annotation{annotations === 0 || annotations > 1 ? 's' : ''}
+                      {t('selectionDetails.entityType.annotationsLabel', { count: annotations })}
                     </>
                   )}
                 </span>
@@ -112,7 +115,7 @@ export const SelectedEntityType = (props: SelectedEntityTypeProps) => {
                 <span>
                   {entityRelationships.length} {tab === 'relations' && (
                     <>
-                      Relationship{entityRelationships.length === 0 || entityRelationships.length > 1 ? 's' : ''}
+                      {t('selectionDetails.entityType.relationshipsLabel', { count: entityRelationships.length })}
                     </>
                   )}
                 </span>

--- a/src/pages/knowledgegraph/SelectionDetailsDrawer/SelectedFolder/SelectedFolder.tsx
+++ b/src/pages/knowledgegraph/SelectionDetailsDrawer/SelectedFolder/SelectedFolder.tsx
@@ -1,4 +1,5 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import murmur from 'murmurhash';
 import { Link } from 'react-router-dom';
 import { Braces, FolderIcon, FolderOpen, ImageIcon, NotebookPen, X } from 'lucide-react';
@@ -33,6 +34,8 @@ interface MetadataProps {
 
 const Metadata = (props: MetadataProps) => {
 
+  const { t } = useTranslation('knowledgegraph');
+
   const [formState, setFormState] = useState<W3CAnnotationBody | undefined>();
 
   useEffect(() => {
@@ -59,7 +62,7 @@ const Metadata = (props: MetadataProps) => {
             disabled={!hasChanges(props.metadata, formState)} 
             className="w-full mb-2"
             type="submit">
-            Save
+            {t('selectionDetails.metadata.save')}
           </Button>
         </div>
       </form>
@@ -82,6 +85,8 @@ const SelectedFolderMetadata = ({ folder }: { folder: Folder }) => {
 
 const SelectedManifestMetadata = ({ manifest }: { manifest: IIIFManifestResource }) => {
 
+  const { t } = useTranslation('knowledgegraph');
+
   const cozyManifest = useIIIFResource(manifest.id);
 
   const { metadata, updateMetadata } = useManifestMetadata(manifest.id);
@@ -94,13 +99,13 @@ const SelectedManifestMetadata = ({ manifest }: { manifest: IIIFManifestResource
           <TabsTrigger 
             value="iiif"
             className="text-xs py-1 flex gap-1.5">
-            <Braces className="size-3.5" /> IIIF
+            <Braces className="size-3.5" /> {t('selectionDetails.metadata.iiifTab')}
           </TabsTrigger>
 
-          <TabsTrigger 
+          <TabsTrigger
             value="my"
             className="text-xs py-1 px-2 flex gap-1.5">
-            <NotebookPen className="size-3.5" /> My
+            <NotebookPen className="size-3.5" /> {t('selectionDetails.metadata.myTab')}
           </TabsTrigger>
         </TabsList>
 
@@ -121,6 +126,8 @@ const SelectedManifestMetadata = ({ manifest }: { manifest: IIIFManifestResource
 }
 
 export const SelectedFolder = (props: SelectedFolderProps) => {
+
+  const { t } = useTranslation('knowledgegraph');
 
   const store = useStore();
 
@@ -198,13 +205,13 @@ export const SelectedFolder = (props: SelectedFolderProps) => {
             <div className="text-muted-foreground flex gap-4">
               {imageCount > 0 && (
                 <div className="flex gap-1 items-center">
-                  <ImageIcon className="h-3.5 w-3.5" /> {imageCount} Images
+                  <ImageIcon className="h-3.5 w-3.5" /> {t('selectionDetails.folder.imageCount', { count: imageCount })}
                 </div>
               )}
 
               {folderCount > 0 && (
                 <div className="flex gap-1 items-center">
-                  <FolderIcon className="h-3.5 w-3.5" /> {folderCount} Sub-Folders
+                  <FolderIcon className="h-3.5 w-3.5" /> {t('selectionDetails.folder.subFolderCount', { count: folderCount })}
                 </div>
               )}
             </div>
@@ -212,7 +219,7 @@ export const SelectedFolder = (props: SelectedFolderProps) => {
             <Link 
               to={`/images/${folderId}`}
               className="bg-primary hover:bg-primary/90 text-white rounded-full px-4 py-1.5">
-              Open
+              {t('selectionDetails.folder.open')}
             </Link>
           </div>
         </div>

--- a/src/pages/knowledgegraph/SelectionDetailsDrawer/SelectedImage/Metadata/Metadata.tsx
+++ b/src/pages/knowledgegraph/SelectionDetailsDrawer/SelectedImage/Metadata/Metadata.tsx
@@ -1,4 +1,5 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Braces, NotebookPen } from 'lucide-react';
 import { W3CAnnotationBody } from '@annotorious/react';
 import { IIIFMetadataList } from '@/components/IIIFMetadataList';
@@ -16,6 +17,8 @@ interface MetadataProps {
 }
 
 const MyMetadata = (props: MetadataProps) => {
+
+  const { t } = useTranslation('knowledgegraph');
 
   const { metadata, updateMetadata } = useImageMetadata(props.imageId);
 
@@ -44,7 +47,7 @@ const MyMetadata = (props: MetadataProps) => {
             disabled={!hasChanges(metadata, formState)} 
             className="w-full mb-2"
             type="submit">
-            Save
+            {t('selectionDetails.metadata.save')}
           </Button>
         </div>
       </form>
@@ -70,6 +73,8 @@ const IIIFMetadata = (props: MetadataProps) => {
 
 export const Metadata = (props: MetadataProps) => {
 
+  const { t } = useTranslation('knowledgegraph');
+
   return  props.imageId.startsWith('iiif:') ? (
     <div className="bg-white shadow-xs rounded border px-4 py-3">
       <Tabs 
@@ -78,13 +83,13 @@ export const Metadata = (props: MetadataProps) => {
           <TabsTrigger 
             value="iiif"
             className="text-xs py-1 flex gap-1.5">
-            <Braces className="size-3.5" /> IIIF
+            <Braces className="size-3.5" /> {t('selectionDetails.metadata.iiifTab')}
           </TabsTrigger>
 
-          <TabsTrigger 
+          <TabsTrigger
             value="my"
             className="text-xs py-1 px-2 flex gap-1.5">
-            <NotebookPen className="size-3.5" /> My
+            <NotebookPen className="size-3.5" /> {t('selectionDetails.metadata.myTab')}
           </TabsTrigger>
         </TabsList>
 

--- a/src/pages/knowledgegraph/SelectionDetailsDrawer/SelectedImage/SelectedImage.tsx
+++ b/src/pages/knowledgegraph/SelectionDetailsDrawer/SelectedImage/SelectedImage.tsx
@@ -1,4 +1,5 @@
 import { memo, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { MessagesSquare, MoveDiagonal, NotebookPen, Spline, X } from 'lucide-react';
 import { W3CImageAnnotation } from '@annotorious/react';
 import { W3CRelationLinkAnnotation, W3CRelationMetaAnnotation } from '@annotorious/plugin-wires-react';
@@ -25,6 +26,8 @@ interface SelectedImageProps {
 }
 
 const SelectedImageComponent = (props: SelectedImageProps) => {
+
+  const { t } = useTranslation('knowledgegraph');
 
   const { image } = props;
 
@@ -112,7 +115,7 @@ const SelectedImageComponent = (props: SelectedImageProps) => {
                 <div 
                   className="flex items-center leading-relaxed text-muted-foreground gap-1 text-xs">
                   <MoveDiagonal className="h-3.5 w-3.5" />
-                  <span>{dimensions[0].toLocaleString()} x {dimensions[1].toLocaleString()} px</span>
+                  <span>{t('selectionDetails.image.dimensions', { width: dimensions[0].toLocaleString(), height: dimensions[1].toLocaleString() })}</span>
                 </div>
               )}
             </div>
@@ -128,7 +131,7 @@ const SelectedImageComponent = (props: SelectedImageProps) => {
                 <MessagesSquare size={15} className="mr-1.5" /> 
                 {annotations.length} 
                 {tab === 'annotations' && (
-                  <span className="ml-1">Annotations</span>
+                  <span className="ml-1">{t('selectionDetails.image.annotationsTab')}</span>
                 )}
               </TabsTrigger>
 
@@ -138,7 +141,7 @@ const SelectedImageComponent = (props: SelectedImageProps) => {
                 <Spline size={15} className="mr-1.5" /> 
                 {relationships.length} 
                 {tab === 'relationships' && (
-                  <span className="ml-1">Relationships</span>
+                  <span className="ml-1">{t('selectionDetails.image.relationshipsTab')}</span>
                 )}
               </TabsTrigger>
 
@@ -147,7 +150,7 @@ const SelectedImageComponent = (props: SelectedImageProps) => {
                 className={`transition-none pl-2 ${tab === 'metadata' ? 'pr-3' : 'pr-2'} py-1.5 border font-normal bg-muted/50 text-xs rounded-full data-[state=active]:bg-black data-[state=active]:border-black data-[state=active]:font-normal data-[state=active]:text-white`}>
                 <NotebookPen size={15} className="mx-1" />
                 {tab === 'metadata' && (
-                  <span className="ml-1">Metadata</span>
+                  <span className="ml-1">{t('selectionDetails.image.metadataTab')}</span>
                 )}
               </TabsTrigger>
             </TabsList>

--- a/src/pages/knowledgegraph/SettingsPanel/SettingPanel.tsx
+++ b/src/pages/knowledgegraph/SettingsPanel/SettingPanel.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useTransition, animated } from '@react-spring/web';
 import { ChevronDown, ChevronRight, X } from 'lucide-react';
 import { Button } from '@/ui/Button';
@@ -23,7 +24,9 @@ interface SettingsPanelProps {
 
 export const SettingsPanel = (props: SettingsPanelProps) => {
 
-  const { settings } = props;  
+  const { t } = useTranslation('knowledgegraph');
+
+  const { settings } = props;
 
   const transition = useTransition([props.open], {
     from: {  transform: 'translateY(50%)', opacity: 0 },
@@ -120,9 +123,9 @@ export const SettingsPanel = (props: SettingsPanelProps) => {
       <fieldset className="p-3">
         <div className="pb-3">
           <legend>
-            <div className="font-medium">Graph Type</div> 
+            <div className="font-medium">{t('settingsPanel.graphType.title')}</div>
             <p className="text-muted-foreground text-xs mt-0.5">
-              Select how you want to visualize your data. 
+              {t('settingsPanel.graphType.description')}
             </p>
           </legend>
         </div>
@@ -137,9 +140,9 @@ export const SettingsPanel = (props: SettingsPanelProps) => {
               id="HIERARCHY" />
 
             <div>
-              <Label htmlFor="HIERARCHY">Hierarchy & Annotations</Label>
+              <Label htmlFor="HIERARCHY">{t('settingsPanel.graphType.hierarchy')}</Label>
               <p className="text-xs text-muted-foreground">
-                Visualize the data model hierarchy, folder structure and entity annotations.
+                {t('settingsPanel.graphType.hierarchyDescription')}
               </p>
             </div>
           </div>
@@ -151,9 +154,9 @@ export const SettingsPanel = (props: SettingsPanelProps) => {
               id="RELATIONS" />
 
             <div>
-              <Label htmlFor="RELATIONS">Relationships</Label>
+              <Label htmlFor="RELATIONS">{t('settingsPanel.graphType.relations')}</Label>
               <p className="text-xs text-muted-foreground">
-                Visualize the Relationships between annotations. Data model hierarchy and entity annotations are shown on hover.
+                {t('settingsPanel.graphType.relationsDescription')}
               </p>
             </div>
           </div>
@@ -165,7 +168,7 @@ export const SettingsPanel = (props: SettingsPanelProps) => {
       <fieldset className="p-3">
         <div className="flex items-center gap-2 justify-between">
           <Label htmlFor="hide-labels">
-            Hide labels
+            {t('settingsPanel.hideLabels')}
           </Label>
 
           <Switch 
@@ -175,8 +178,7 @@ export const SettingsPanel = (props: SettingsPanelProps) => {
         </div>
 
         <p className="text-muted-foreground text-xs mt-1 pr-12">
-          Don't show text labels for graph nodes. A hover tooltip
-          will be used instead.
+          {t('settingsPanel.hideLabelsDescription')}
         </p>
 
         <Collapsible onOpenChange={open => setTypeLabelsOpen(open)}>
@@ -185,7 +187,7 @@ export const SettingsPanel = (props: SettingsPanelProps) => {
               <ChevronDown className="w-3.5 h-3.5" />
             ) : (
               <ChevronRight className="w-3.5 h-3.5" />
-            )} Hide for specific node types
+            )} {t('settingsPanel.hideForSpecificNodeTypes')}
           </CollapsibleTrigger>
 
           <CollapsibleContent className="pl-4">
@@ -193,7 +195,7 @@ export const SettingsPanel = (props: SettingsPanelProps) => {
               <Label 
                 className="text-xs font-normal"
                 htmlFor="hide-image-labels">
-                Image labels
+                {t('settingsPanel.imageLabels')}
               </Label>
 
               <Switch 
@@ -207,7 +209,7 @@ export const SettingsPanel = (props: SettingsPanelProps) => {
                 <Label 
                   className="text-xs font-normal"
                   htmlFor="hide-folder-labels">
-                  Sub-folder labels
+                  {t('settingsPanel.subFolderLabels')}
                 </Label>
 
                 <Switch 
@@ -221,7 +223,7 @@ export const SettingsPanel = (props: SettingsPanelProps) => {
               <Label 
                 className="text-xs font-normal"
                 htmlFor="hide-entity-labels">
-                Entity class labels
+                {t('settingsPanel.entityClassLabels')}
               </Label>
 
               <Switch 
@@ -236,7 +238,7 @@ export const SettingsPanel = (props: SettingsPanelProps) => {
       <fieldset className="p-3">
         <div className="flex items-center gap-2 justify-between">
           <Label htmlFor="include-folders">
-            Show sub-folders as nodes
+            {t('settingsPanel.showSubFolders')}
           </Label>
 
           <Switch 
@@ -247,14 +249,14 @@ export const SettingsPanel = (props: SettingsPanelProps) => {
         </div>
 
         <p className="text-muted-foreground text-xs mt-1 pr-12">
-          Include sub-folders inside your workfolder as nodes in the graph.
+          {t('settingsPanel.showSubFoldersDescription')}
         </p>
       </fieldset>
 
       <fieldset className={`p-3 ${settings.graphMode === 'RELATIONS' ? 'group is-disabled' : ''}`.trim()}>
         <div className="flex items-center gap-2 justify-between group-[.is-disabled]:text-muted-foreground/50">
           <Label htmlFor="hide-isolated">
-            Hide unconnected nodes
+            {t('settingsPanel.hideUnconnectedNodes')}
           </Label>
 
           <Switch 
@@ -267,7 +269,7 @@ export const SettingsPanel = (props: SettingsPanelProps) => {
 
         <p 
           className="text-xs mt-1 pr-12 text-muted-foreground group-[.is-disabled]:text-muted-foreground/50">
-          Remove nodes without any connections from the graph.
+          {t('settingsPanel.hideUnconnectedNodesDescription')}
         </p>
       </fieldset>
     </animated.div>


### PR DESCRIPTION
Knowledge graph translation, part of the page-by-page series (after #322, #323; alongside #325).

## What's in this one
- **`knowledgegraph` namespace**, wired into `src/i18n/index.ts`
- Translates `src/pages/knowledgegraph`: title/intro, graph controls & tooltips, settings panel, legend, graph search dialog, selection-details drawer
- `e2e/knowledgegraph.spec.ts` (both languages)

## Notes
- Builds on the shared `common` namespace from #323. Verified against current `main` (no upstream divergence in this page).
- Independent of the other in-flight page PRs except for the `src/i18n/index.ts` namespace list — I'll keep it rebased as siblings merge so you never see a conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)