### PR TITLE
i18n (4/5): images overview page

### DIFF
--- a/e2e/images.spec.ts
+++ b/e2e/images.spec.ts
@@ -1,0 +1,129 @@
+import { Page, expect, test } from '@playwright/test';
+import { findRawTranslationKeys, mockWorkFolder, openWorkFolder, setLanguage } from './helpers';
+
+/**
+ * E2E i18n checks for the images overview (src/pages/images, namespace
+ * `images`, plus shared nav strings from `common`).
+ */
+
+/** Collects uncaught page errors; assert the array is empty at the end. */
+const collectPageErrors = (page: Page): string[] => {
+  const errors: string[] = [];
+  page.on('pageerror', error => errors.push(String(error)));
+  return errors;
+};
+
+/** Boots the app in the given language and lands on the images overview. */
+const openImagesOverview = async (page: Page, lang: 'en' | 'ja') => {
+  await setLanguage(page, lang);
+  await mockWorkFolder(page);
+  await page.goto('/');
+  await openWorkFolder(page);
+};
+
+test.describe('images overview i18n', () => {
+
+  test('ja: renders translated sidebar and header controls', async ({ page }) => {
+    const errors = collectPageErrors(page);
+    await openImagesOverview(page, 'ja');
+
+    // Navigation sidebar (common.appNavigationSidebar)
+    await expect(page.getByRole('link', { name: '画像' })).toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole('link', { name: 'ワークスペース' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'ナレッジグラフ' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'データモデル' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'エクスポート' })).toBeVisible();
+    await expect(page.getByRole('link', { name: '設定' })).toBeVisible();
+    await expect(page.getByRole('button', { name: '終了' })).toBeVisible();
+
+    // Folder header (images.folderHeader / images.common / images.headerControls)
+    await expect(page.getByText('フォルダ', { exact: true })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'メタデータ' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'IIIF をインポート' })).toBeVisible();
+    await expect(page.getByRole('button', { name: '未アノテーションを非表示' })).toBeVisible();
+    // The layout select trigger has no aria-label; グリッド is its content
+    await expect(page.getByRole('combobox').filter({ hasText: 'グリッド' })).toBeVisible();
+    // Default (unsorted) grid sorting label
+    await expect(page.getByText('マニフェスト順')).toBeVisible();
+
+    expect(await findRawTranslationKeys(page)).toEqual([]);
+    expect(errors).toEqual([]);
+  });
+
+  test('ja: grid sorting menu shows translated options', async ({ page }) => {
+    const errors = collectPageErrors(page);
+    await openImagesOverview(page, 'ja');
+
+    await expect(page.getByText('マニフェスト順')).toBeVisible({ timeout: 15000 });
+    await page.getByText('マニフェスト順').click();
+
+    await expect(page.getByRole('menuitemradio', { name: '名前' })).toBeVisible();
+    await expect(page.getByRole('menuitemradio', { name: 'アノテーション' })).toBeVisible();
+    await expect(page.getByRole('menuitemradio', { name: '昇順' })).toBeVisible();
+    await expect(page.getByRole('menuitemradio', { name: '降順' })).toBeVisible();
+
+    expect(await findRawTranslationKeys(page)).toEqual([]);
+
+    await page.keyboard.press('Escape');
+    expect(errors).toEqual([]);
+  });
+
+  test('ja: switching to table layout shows translated column headers', async ({ page }) => {
+    const errors = collectPageErrors(page);
+    await openImagesOverview(page, 'ja');
+
+    // Layout select (images.headerControls.grid / .table)
+    const layoutSelect = page.getByRole('combobox').filter({ hasText: 'グリッド' });
+    await expect(layoutSelect).toBeVisible({ timeout: 15000 });
+    await layoutSelect.click();
+    await page.getByRole('option', { name: 'テーブル' }).click();
+
+    // Table column headers (images.table)
+    await expect(page.getByRole('columnheader', { name: '種類' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: '名前' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: '寸法' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: '最終編集' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'アノテーション' })).toBeVisible();
+
+    // The seeded sample image is listed as a row
+    await expect(page.getByRole('row', { name: /sample\.png/ })).toBeVisible();
+
+    expect(await findRawTranslationKeys(page)).toEqual([]);
+    expect(errors).toEqual([]);
+  });
+
+  test('ja: image item context menu shows translated actions', async ({ page }) => {
+    const errors = collectPageErrors(page);
+    await openImagesOverview(page, 'ja');
+
+    const imageItem = page.locator('.item-grid li', { hasText: 'sample.png' });
+    await expect(imageItem).toBeVisible({ timeout: 15000 });
+    await imageItem.hover();
+    await imageItem.locator('.item-actions-trigger').click();
+
+    // images.common strings in the dropdown
+    await expect(page.getByRole('menuitem', { name: 'メタデータ' })).toBeVisible();
+    await expect(page.getByRole('menuitem', { name: '画像を開く' })).toBeVisible();
+    await expect(page.getByRole('menuitem', { name: 'ワークスペースに追加' })).toBeVisible();
+
+    expect(await findRawTranslationKeys(page)).toEqual([]);
+
+    await page.keyboard.press('Escape');
+    expect(errors).toEqual([]);
+  });
+
+  test('en: spot-checks translated overview strings', async ({ page }) => {
+    const errors = collectPageErrors(page);
+    await openImagesOverview(page, 'en');
+
+    await expect(page.getByRole('link', { name: 'Images' })).toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole('link', { name: 'Knowledge Graph' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Hide unannotated' })).toBeVisible();
+    await expect(page.getByRole('combobox').filter({ hasText: 'Grid' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Import IIIF' })).toBeVisible();
+
+    expect(await findRawTranslationKeys(page)).toEqual([]);
+    expect(errors).toEqual([]);
+  });
+
+});

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -4,6 +4,7 @@ import { initReactI18next } from 'react-i18next';
 
 import enAnnotate from '../locales/en/annotate.json';
 import enCommon from '../locales/en/common.json';
+import enImages from '../locales/en/images.json';
 import enKnowledgegraph from '../locales/en/knowledgegraph.json';
 import enSmartTools from '../locales/en/smartTools.json';
 import enStart from '../locales/en/start.json';
@@ -11,6 +12,7 @@ import enUi from '../locales/en/ui.json';
 
 import jaAnnotate from '../locales/ja/annotate.json';
 import jaCommon from '../locales/ja/common.json';
+import jaImages from '../locales/ja/images.json';
 import jaKnowledgegraph from '../locales/ja/knowledgegraph.json';
 import jaSmartTools from '../locales/ja/smartTools.json';
 import jaStart from '../locales/ja/start.json';
@@ -29,6 +31,7 @@ i18n
       en: {
         annotate: enAnnotate,
         common: enCommon,
+        images: enImages,
         knowledgegraph: enKnowledgegraph,
         smartTools: enSmartTools,
         start: enStart,
@@ -37,6 +40,7 @@ i18n
       ja: {
         annotate: jaAnnotate,
         common: jaCommon,
+        images: jaImages,
         knowledgegraph: jaKnowledgegraph,
         smartTools: jaSmartTools,
         start: jaStart,

--- a/src/locales/en/images.json
+++ b/src/locales/en/images.json
@@ -1,0 +1,105 @@
+{
+  "common": {
+    "metadata": "Metadata",
+    "openFolder": "Open folder",
+    "openImage": "Open image",
+    "openCanvas": "Open canvas",
+    "openManifest": "Open manifest",
+    "manifestMetadata": "Manifest metadata",
+    "canvasMetadata": "Canvas metadata",
+    "addToWorkspace": "Add to workspace",
+    "otherIIIFViewers": "Other IIIF Viewers",
+    "breadcrumbs": "Breadcrumbs",
+    "delete": "Delete",
+    "cancel": "Cancel",
+    "save": "Save",
+    "close": "Close",
+    "confirmDeleteManifest": "This will remove the manifest and will permanently delete all its annotations from your computer."
+  },
+  "folderHeader": {
+    "folder": "Folder"
+  },
+  "headerControls": {
+    "showUnannotated": "Show unannotated",
+    "hideUnannotated": "Hide unannotated",
+    "grid": "Grid",
+    "table": "Table",
+    "sorting": {
+      "name": "Name",
+      "annotations": "Annotations",
+      "manifestOrder": "Manifest order",
+      "ascending": "Ascending",
+      "descending": "Descending"
+    }
+  },
+  "folderItem": {
+    "empty": "Empty",
+    "imageCount_one": "{{count}} Image",
+    "imageCount_other": "{{count}} Images",
+    "iiifCount": "{{count}} IIIF",
+    "subfolderCount_one": "{{count}} Subfolder",
+    "subfolderCount_other": "{{count}} Subfolders"
+  },
+  "manifestItem": {
+    "canvasCount_one": "{{count}} Canvas",
+    "canvasCount_other": "{{count}} Canvases"
+  },
+  "workspaceIndicator": {
+    "currentlyOpen": "Currently open in workspace"
+  },
+  "table": {
+    "type": "Type",
+    "name": "Name",
+    "dimensions": "Dimensions",
+    "lastEdit": "Last Edit",
+    "annotations": "Annotations",
+    "noData": "No data"
+  },
+  "metadataPanel": {
+    "iiifTab": "IIIF",
+    "myTab": "My"
+  },
+  "iiifImporter": {
+    "importIIIF": "Import IIIF",
+    "title": "Import IIIF Manifest",
+    "description": "Paste the URL to a <strong1>IIIF Presentation Manifest</strong1>. The following links will <strong2>not</strong2> work:",
+    "linkTypeViewerPages": "viewer pages – e.g. pages that embed Mirador or Universal Viewer.",
+    "linkTypeImageFiles": "links to image files – <code1>jpg</code1>, <code2>png</code2>, etc.",
+    "linkTypeImageApi": "IIIF Image API endpoints – ending with <code1>info.json</code1>.",
+    "urlPlaceholder": "IIIF Presentation API URL",
+    "fetching": "Fetching...",
+    "alreadyImportedTitle": "Already Imported",
+    "alreadyImportedMessage": "This manifest already exists in the current subfolder. IMMARKUS allows you to import the same manifest multiple times, but each import must be placed in a different subfolder. To proceed, please select another subfolder and import the manifest there.",
+    "presentationApiFallback": "Presentation API v{{version}}",
+    "annotationCount_one": "{{count}} annotation",
+    "annotationCount_other": "{{count}} annotations",
+    "canvasAnnotationCount_one": "{{count}} non-region annotation (canvas metadata)",
+    "canvasAnnotationCount_other": "{{count}} non-region annotations (canvas metadata)",
+    "failedAnnotationCount_one": "Failed to parse {{count}} annotation - skipping",
+    "failedAnnotationCount_other": "Failed to parse {{count}} annotations - skipping",
+    "noAnnotations": "Manifest includes no annotations",
+    "resolvingAnnotations": "Resolving annotations",
+    "mayTakeAWhile": "(this may take a while)",
+    "collectionDetected": "This is a IIIF Collection Manifest with multiple items. <selectButton>Select items to import</selectButton>.",
+    "import": "Import",
+    "errors": {
+      "fetchFailed": "Failed to fetch. Server may restrict access.",
+      "fetchFailedWithMessage": "Failed to fetch. {{message}}",
+      "imageApiUnsupported": "Image API URLs are currently unsupported",
+      "invalidUrlWebPage": "Invalid URL: web page",
+      "invalidUrlImageFile": "Invalid URL: image file",
+      "help": "IMMARKUS could not import from this URL. See our <troubleshootingLink>troubleshooting guide</troubleshootingLink> for information on common import problems and possible solutions."
+    }
+  },
+  "importFromCollection": {
+    "title": "Import from IIIF Collection",
+    "description": "This collection contains multiple presentation manifests. Choose which items to import into your workspace.",
+    "selectAll": "Select All",
+    "importWithCount": "Import ({{count}})",
+    "importingTitle": "Importing",
+    "importingMessage_one": "Importing {{count}} IIIF manifest",
+    "importingMessage_other": "Importing {{count}} IIIF manifests",
+    "importErrorTitle": "Import Error",
+    "alreadyExists": "{{name}} already exists in the current subfolder. IMMARKUS allows multiple imports of the same manifest, but each one must be placed in a different subfolder. To continue, please remove this manifest from the list or choose a different subfolder."
+  }
+}

--- a/src/locales/ja/images.json
+++ b/src/locales/ja/images.json
@@ -1,0 +1,98 @@
+{
+  "common": {
+    "metadata": "メタデータ",
+    "openFolder": "フォルダを開く",
+    "openImage": "画像を開く",
+    "openCanvas": "キャンバスを開く",
+    "openManifest": "マニフェストを開く",
+    "manifestMetadata": "マニフェストのメタデータ",
+    "canvasMetadata": "キャンバスのメタデータ",
+    "addToWorkspace": "ワークスペースに追加",
+    "otherIIIFViewers": "その他の IIIF ビューア",
+    "breadcrumbs": "パンくずリスト",
+    "delete": "削除",
+    "cancel": "キャンセル",
+    "save": "保存",
+    "close": "閉じる",
+    "confirmDeleteManifest": "マニフェストを削除し、そのすべてのアノテーションをコンピュータから完全に削除します。"
+  },
+  "folderHeader": {
+    "folder": "フォルダ"
+  },
+  "headerControls": {
+    "showUnannotated": "未アノテーションを表示",
+    "hideUnannotated": "未アノテーションを非表示",
+    "grid": "グリッド",
+    "table": "テーブル",
+    "sorting": {
+      "name": "名前",
+      "annotations": "アノテーション",
+      "manifestOrder": "マニフェスト順",
+      "ascending": "昇順",
+      "descending": "降順"
+    }
+  },
+  "folderItem": {
+    "empty": "空",
+    "imageCount_other": "画像 {{count}} 件",
+    "iiifCount": "IIIF {{count}} 件",
+    "subfolderCount_other": "サブフォルダ {{count}} 件"
+  },
+  "manifestItem": {
+    "canvasCount_other": "キャンバス {{count}} 件"
+  },
+  "workspaceIndicator": {
+    "currentlyOpen": "現在ワークスペースで開いています"
+  },
+  "table": {
+    "type": "種類",
+    "name": "名前",
+    "dimensions": "寸法",
+    "lastEdit": "最終編集",
+    "annotations": "アノテーション",
+    "noData": "データがありません"
+  },
+  "metadataPanel": {
+    "iiifTab": "IIIF",
+    "myTab": "マイ"
+  },
+  "iiifImporter": {
+    "importIIIF": "IIIF をインポート",
+    "title": "IIIF マニフェストをインポート",
+    "description": "<strong1>IIIF プレゼンテーションマニフェスト</strong1>の URL を貼り付けてください。次のリンクは<strong2>機能しません</strong2>:",
+    "linkTypeViewerPages": "ビューアページ – Mirador や Universal Viewer を埋め込んだページなど。",
+    "linkTypeImageFiles": "画像ファイルへのリンク – <code1>jpg</code1>、<code2>png</code2> など。",
+    "linkTypeImageApi": "IIIF Image API エンドポイント – <code1>info.json</code1> で終わる URL。",
+    "urlPlaceholder": "IIIF Presentation API の URL",
+    "fetching": "取得中...",
+    "alreadyImportedTitle": "インポート済み",
+    "alreadyImportedMessage": "このマニフェストは現在のサブフォルダに既に存在します。IMMARKUS では同じマニフェストを複数回インポートできますが、それぞれ別のサブフォルダに配置する必要があります。続行するには、別のサブフォルダを選択してそこにインポートしてください。",
+    "presentationApiFallback": "Presentation API v{{version}}",
+    "annotationCount_other": "アノテーション {{count}} 件",
+    "canvasAnnotationCount_other": "非領域アノテーション {{count}} 件 (キャンバスメタデータ)",
+    "failedAnnotationCount_other": "アノテーション {{count}} 件を解析できませんでした - スキップします",
+    "noAnnotations": "マニフェストにアノテーションは含まれていません",
+    "resolvingAnnotations": "アノテーションを解決しています",
+    "mayTakeAWhile": "(時間がかかる場合があります)",
+    "collectionDetected": "これは複数のアイテムを含む IIIF コレクションマニフェストです。<selectButton>インポートするアイテムを選択</selectButton>",
+    "import": "インポート",
+    "errors": {
+      "fetchFailed": "取得に失敗しました。サーバーがアクセスを制限している可能性があります。",
+      "fetchFailedWithMessage": "取得に失敗しました。{{message}}",
+      "imageApiUnsupported": "Image API の URL は現在サポートされていません",
+      "invalidUrlWebPage": "無効な URL: ウェブページ",
+      "invalidUrlImageFile": "無効な URL: 画像ファイル",
+      "help": "IMMARKUS はこの URL からインポートできませんでした。一般的なインポートの問題と解決策については<troubleshootingLink>トラブルシューティングガイド</troubleshootingLink>をご覧ください。"
+    }
+  },
+  "importFromCollection": {
+    "title": "IIIF コレクションからインポート",
+    "description": "このコレクションには複数のプレゼンテーションマニフェストが含まれています。ワークスペースにインポートするアイテムを選択してください。",
+    "selectAll": "すべて選択",
+    "importWithCount": "インポート ({{count}})",
+    "importingTitle": "インポート中",
+    "importingMessage_other": "IIIF マニフェスト {{count}} 件をインポートしています",
+    "importErrorTitle": "インポートエラー",
+    "alreadyExists": "{{name}} は現在のサブフォルダに既に存在します。IMMARKUS では同じマニフェストを複数回インポートできますが、それぞれ別のサブフォルダに配置する必要があります。続行するには、このマニフェストをリストから削除するか、別のサブフォルダを選択してください。"
+  }
+}

--- a/src/pages/images/HeaderControls/FilterByAnnotations/FilterByAnnotations.tsx
+++ b/src/pages/images/HeaderControls/FilterByAnnotations/FilterByAnnotations.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
 import { MessageCircle, MessageCircleOff } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { Toggle } from '@/ui/Toggle';
 
 interface FilterByAnnotationsProps {
@@ -12,6 +13,8 @@ interface FilterByAnnotationsProps {
 
 export const FilterByAnnotations = (props: FilterByAnnotationsProps) => {
 
+  const { t } = useTranslation('images');
+
   const { hideUnannotated } = props;
 
   return (
@@ -22,11 +25,11 @@ export const FilterByAnnotations = (props: FilterByAnnotationsProps) => {
 
       {hideUnannotated ? (
         <>
-          <MessageCircle className="size-4" /> Show unannotated
+          <MessageCircle className="size-4" /> {t('headerControls.showUnannotated')}
         </>
       ) : (
         <>
-          <MessageCircleOff className="size-4" /> Hide unannotated
+          <MessageCircleOff className="size-4" /> {t('headerControls.hideUnannotated')}
         </>
       )}
     </Toggle> 

--- a/src/pages/images/HeaderControls/GridSorting/GridSorting.tsx
+++ b/src/pages/images/HeaderControls/GridSorting/GridSorting.tsx
@@ -1,4 +1,5 @@
 import { ArrowDownNarrowWide, ArrowUpNarrowWide, ChevronDown } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { SortOrder } from 'primereact/datatable';
 import { Sorting } from '@/utils/useImageSorting';
 import { 
@@ -20,17 +21,19 @@ interface GridSortingProps {
 
 }
 
-const LABELS = {
-  'name': 'Name',
-  'annotations': 'Annotations',
-  undefined: 'Manifest Order'
-};
-
 const UNSORTED = 'unsorted';
 
 export const GridSorting = (props: GridSortingProps) => {
   const { allowUnsorted, sorting, onChange } = props;
-  
+
+  const { t } = useTranslation('images');
+
+  const LABELS = {
+    'name': t('headerControls.sorting.name'),
+    'annotations': t('headerControls.sorting.annotations'),
+    undefined: t('headerControls.sorting.manifestOrder')
+  };
+
   const isUnsorted = !(sorting?.sortField && sorting?.sortOrder);
 
   const onSortFieldChange = (sortField: string) => {
@@ -61,16 +64,16 @@ export const GridSorting = (props: GridSortingProps) => {
           onValueChange={onSortFieldChange}>
           {allowUnsorted && (
             <DropdownMenuRadioItem value={UNSORTED}>
-              Manifest order
+              {t('headerControls.sorting.manifestOrder')}
             </DropdownMenuRadioItem>
           )}
 
           <DropdownMenuRadioItem value="name">
-            Name
+            {t('headerControls.sorting.name')}
           </DropdownMenuRadioItem>
 
           <DropdownMenuRadioItem value="annotations">
-            Annotations
+            {t('headerControls.sorting.annotations')}
           </DropdownMenuRadioItem>
         </DropdownMenuRadioGroup>
 
@@ -83,14 +86,14 @@ export const GridSorting = (props: GridSortingProps) => {
             value="1"
             className="gap-1.5"
             disabled={isUnsorted}>
-            <ArrowDownNarrowWide className="size-4" /> Ascending
+            <ArrowDownNarrowWide className="size-4" /> {t('headerControls.sorting.ascending')}
           </DropdownMenuRadioItem>
 
           <DropdownMenuRadioItem 
             value="-1"
             className="gap-1.5"
             disabled={isUnsorted}>
-            <ArrowUpNarrowWide className="size-4" /> Descending
+            <ArrowUpNarrowWide className="size-4" /> {t('headerControls.sorting.descending')}
           </DropdownMenuRadioItem>
         </DropdownMenuRadioGroup>
       </DropdownMenuContent>

--- a/src/pages/images/HeaderControls/IIIFOpenOtherViewer/IIIFOpenOtherViewer.tsx
+++ b/src/pages/images/HeaderControls/IIIFOpenOtherViewer/IIIFOpenOtherViewer.tsx
@@ -1,4 +1,5 @@
 import { MouseEvent, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ChevronDown, Share2 } from 'lucide-react';
 import { CopyManifestURL } from '@/components/CopyManifestURL';
 import { IIIFManifestResource } from '@/model';
@@ -19,6 +20,8 @@ interface IIIFOpenOtherViewerProps {
 
 export const IIIFOpenOtherViewer = (props: IIIFOpenOtherViewerProps) => {
 
+  const { t } = useTranslation('images');
+
   const [copied, setCopied] = useState(false);
 
   const onCopyManifestURL = (evt: MouseEvent) => {
@@ -36,7 +39,7 @@ export const IIIFOpenOtherViewer = (props: IIIFOpenOtherViewerProps) => {
         <Button 
           variant="link"
           className="text-muted-foreground flex items-center gap-1.5 p-0 h-auto font-normal">
-          <Share2 className="size-4" strokeWidth={2.2}/> Other IIIF Viewers <ChevronDown className="size-4 opacity-50" />
+          <Share2 className="size-4" strokeWidth={2.2}/> {t('common.otherIIIFViewers')} <ChevronDown className="size-4 opacity-50" />
         </Button>
       </DropdownMenuTrigger>
 

--- a/src/pages/images/HeaderControls/ToggleLayout/ToggleLayout.tsx
+++ b/src/pages/images/HeaderControls/ToggleLayout/ToggleLayout.tsx
@@ -1,4 +1,5 @@
 import { LayoutGrid, Rows3 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { OverviewLayout } from '../../Types';
 import { 
   Select, 
@@ -17,6 +18,8 @@ interface ToggleLayoutProps {
 
 export const ToggleLayout = (props: ToggleLayoutProps) => {
 
+  const { t } = useTranslation('images');
+
   return (
     <Select 
       value={props.layout}
@@ -24,15 +27,15 @@ export const ToggleLayout = (props: ToggleLayoutProps) => {
       <SelectTrigger
         className="text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring ring-offset-2 rounded hover:underline underline-offset-4 bg-transparent border-0 shadow-none flex items-center gap-1.5 p-0 h-auto font-normal">
         {props.layout === 'grid' ? (
-          <><LayoutGrid className="size-4" /> Grid</>
+          <><LayoutGrid className="size-4" /> {t('headerControls.grid')}</>
         ) : (
-          <><Rows3 className="size-4" /> Table</>
+          <><Rows3 className="size-4" /> {t('headerControls.table')}</>
         )}
       </SelectTrigger>
-      
+
       <SelectContent>
-        <SelectItem value="grid">Grid</SelectItem>
-        <SelectItem value="table">Table</SelectItem>
+        <SelectItem value="grid">{t('headerControls.grid')}</SelectItem>
+        <SelectItem value="table">{t('headerControls.table')}</SelectItem>
       </SelectContent>
     </Select>
   );

--- a/src/pages/images/IIIFImporter/ErrorAlert.tsx
+++ b/src/pages/images/IIIFImporter/ErrorAlert.tsx
@@ -1,7 +1,8 @@
 import { Ban } from 'lucide-react';
+import { Trans } from 'react-i18next';
 
 interface ErrorAlertProps {
-  
+
   message: string;
 
 }
@@ -14,11 +15,17 @@ export const ErrorAlert = (props: ErrorAlertProps) => {
       </div>
 
       <div>
-        IMMARKUS could not import from this URL. See our <a 
-          className="underline"
-          href="https://github.com/rsimon/immarkus/wiki/Troubleshooting-IIIF-Manifest-Imports" 
-          target="_blank">troubleshooting 
-        guide</a> for information on common import problems and possible solutions.
+        <Trans
+          ns="images"
+          i18nKey="iiifImporter.errors.help"
+          components={{
+            troubleshootingLink: (
+              <a
+                className="underline"
+                href="https://github.com/rsimon/immarkus/wiki/Troubleshooting-IIIF-Manifest-Imports"
+                target="_blank" />
+            )
+          }} />
       </div>
     </div>
   )

--- a/src/pages/images/IIIFImporter/IIIFImporter.tsx
+++ b/src/pages/images/IIIFImporter/IIIFImporter.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
 import murmur from 'murmurhash';
 import { type CozyParseResult, Cozy } from 'cozy-iiif';
 import { Ban, Check, CloudDownload, Loader2, MessageSquareX, MessagesSquare, SquareLibrary } from 'lucide-react';
@@ -24,6 +25,8 @@ interface IIIFImporterProps {
 export type ImportableIIIFResource = Omit<IIIFResource, 'path' | 'folder'>;
 
 export const IIIFImporter = (props: IIIFImporterProps) => {
+
+  const { t } = useTranslation('images');
 
   const store = useStore();
 
@@ -146,137 +149,161 @@ export const IIIFImporter = (props: IIIFImporterProps) => {
         <Button
           variant="link"
           className="text-muted-foreground flex items-center gap-1.5 p-0 h-auto font-normal ring-offset-2 rounded">
-          <CloudDownload className="size-4.5 pt-px" /> Import IIIF
+          <CloudDownload className="size-4.5 pt-px" /> {t('iiifImporter.importIIIF')}
         </Button>
       </DialogTrigger>
 
       <DialogContent className="max-w-2xl">
         <DialogTitle>
-          Import IIIF Manifest
+          {t('iiifImporter.title')}
         </DialogTitle>
-        
-        <DialogDescription asChild> 
+
+        <DialogDescription asChild>
           <div className="leading-relaxed space-y-1 mb-2">
             <p>
-            Paste the URL to a <strong className="font-semibold">IIIF Presentation Manifest</strong>. The 
-            following links will <strong className="font-semibold">not</strong> work:
+              <Trans
+                ns="images"
+                i18nKey="iiifImporter.description"
+                components={{
+                  strong1: <strong className="font-semibold" />,
+                  strong2: <strong className="font-semibold" />
+                }} />
             </p>
 
             <ul className="list-disc pl-5">
-              <li>viewer pages – e.g. pages that embed Mirador or Universal Viewer.</li>
-              <li>links to image files – <code className="text-xs">jpg</code>, <code className="text-xs">png</code>, etc.</li>
-              <li>IIIF Image API endpoints – ending with <code className="text-xs">info.json</code>.</li>
+              <li>{t('iiifImporter.linkTypeViewerPages')}</li>
+              <li>
+                <Trans
+                  ns="images"
+                  i18nKey="iiifImporter.linkTypeImageFiles"
+                  components={{
+                    code1: <code className="text-xs" />,
+                    code2: <code className="text-xs" />
+                  }} />
+              </li>
+              <li>
+                <Trans
+                  ns="images"
+                  i18nKey="iiifImporter.linkTypeImageApi"
+                  components={{
+                    code1: <code className="text-xs" />
+                  }} />
+              </li>
             </ul>
           </div>
         </DialogDescription>
 
-        <form 
+        <form
           className="text-xs space-y-2"
           onSubmit={onSubmit}>
-          <Input 
+          <Input
             autoFocus
             value={uri}
-            placeholder="IIIF Presentation API URL"
+            placeholder={t('iiifImporter.urlPlaceholder')}
             onChange={evt => setURI(evt.target.value)} />
 
           {busy ? (
             <div className="flex items-center gap-1.5 pl-0.5">
-              <Loader2 className="animate-spin size-3.5 mb-px" /> Fetching...
+              <Loader2 className="animate-spin size-3.5 mb-px" /> {t('iiifImporter.fetching')}
             </div>
           ) : alreadyImported ? (
-            <div 
+            <div
               className="p-3 mt-6 items-start leading-relaxed
                 rounded text-destructive border border-destructive">
               <div className="font-semibold mb-2 flex gap-1.5">
-                <Ban className="size-3.5 mt-0.75" /> Already Imported
+                <Ban className="size-3.5 mt-0.75" /> {t('iiifImporter.alreadyImportedTitle')}
               </div>
 
               <div>
-                This manifest already exists in the current subfolder. IMMARKUS allows you to import the 
-                same manifest multiple times, but each import must be placed in a different subfolder.
-                To proceed, please select another subfolder and import the manifest there.
+                {t('iiifImporter.alreadyImportedMessage')}
               </div>
             </div>
           ) : parseResult?.type === 'error' ? (
-            <div 
+            <div
               className="p-3 mt-6 items-start leading-relaxed
                 rounded text-destructive border border-destructive">
 
               {parseResult.code === 'FETCH_ERROR' ? (
-                <ErrorAlert message="Failed to fetch. Server may restrict access." />
+                <ErrorAlert message={t('iiifImporter.errors.fetchFailed')} />
               ) : parseResult.code === 'INVALID_HTTP_RESPONSE' ? (
-                <ErrorAlert message={`Failed to fetch. ${parseResult.message}`} />
+                <ErrorAlert message={t('iiifImporter.errors.fetchFailedWithMessage', { message: parseResult.message })} />
               ) : (
                 <ErrorAlert message={parseResult.message} />
               )}
             </div>
           ) : parseResult?.type === 'iiif-image' ? (
             <div className="flex items-center gap-1.5 pl-0.5 text-red-600">
-              <Ban className="size-3.5 mb-px" /> Image API URLs are currently unsupported
+              <Ban className="size-3.5 mb-px" /> {t('iiifImporter.errors.imageApiUnsupported')}
             </div>
           ) : parseResult?.type === 'manifest' ? (
             <>
               <div className="flex items-center gap-1.5 pl-0.5 text-green-600">
-                <Check className="size-4" /> {parseResult.resource.getLabel() || `Presentation API v${parseResult.resource.majorVersion}`}
+                <Check className="size-4" /> {parseResult.resource.getLabel() || t('iiifImporter.presentationApiFallback', { version: parseResult.resource.majorVersion })}
               </div>
 
               {validationResult && validationResult.total > 0 ? (
                 <>
                   {validationResult.shapeAnnotations > 0 && (
                     <div className="flex items-center gap-1.5 pl-0.5 text-green-600">
-                      <MessagesSquare className="size-4" /> 
-                      {validationResult.shapeAnnotations} annotation{validationResult.shapeAnnotations > 1 ? 's' : ''}
+                      <MessagesSquare className="size-4" />
+                      {t('iiifImporter.annotationCount', { count: validationResult.shapeAnnotations })}
                     </div>
                   )}
 
                   {validationResult.canvasAnnotations > 0 && (
                     <div className="flex items-center gap-1.5 pl-0.5 text-green-600">
-                      <MessagesSquare className="size-4" /> 
-                      {validationResult.canvasAnnotations} non-region annotation{validationResult.canvasAnnotations > 1 ? 's' : ''} (canvas metadata)
+                      <MessagesSquare className="size-4" />
+                      {t('iiifImporter.canvasAnnotationCount', { count: validationResult.canvasAnnotations })}
                     </div>
                   )}
 
                   {validationResult.failed > 0 && (
                     <div className="flex items-center gap-1.5 pl-0.5 text-red-600">
-                      <MessageSquareX className="size-4" /> 
-                      Failed to parse {validationResult.failed} annotation{validationResult.failed > 1 ? 's' : ''} - skipping
+                      <MessageSquareX className="size-4" />
+                      {t('iiifImporter.failedAnnotationCount', { count: validationResult.failed })}
                     </div>
                   )}
                 </>
               ) :validationResult ? (
                   <div className="flex items-center gap-1.5 pl-0.5 text-gray-600">
-                    <MessagesSquare className="size-4" /> 
-                    Manifest includes no annotations
+                    <MessagesSquare className="size-4" />
+                    {t('iiifImporter.noAnnotations')}
                   </div>
               ) : validatingAnnotations && (
                 <div className="flex items-center gap-1.5 pl-0.5 text-gray-600">
-                  <Spinner className="size-4" /> 
-                  Resolving annotations {validatingSlow && (<span>(this may take a while)</span>)}
+                  <Spinner className="size-4" />
+                  {t('iiifImporter.resolvingAnnotations')} {validatingSlow && (<span>{t('iiifImporter.mayTakeAWhile')}</span>)}
                 </div>
               )}
             </>
           ) : parseResult?.type === 'webpage' ? (
-            <div 
+            <div
               className="p-3 mt-6 items-start leading-relaxed
                 rounded text-destructive border border-destructive">
-              <ErrorAlert message="Invalid URL: web page" />
+              <ErrorAlert message={t('iiifImporter.errors.invalidUrlWebPage')} />
             </div>
           ) : parseResult?.type === 'collection' ? (
             <div className="flex items-center gap-1 pl-0.5 mt-1 text-amber-600">
-              <SquareLibrary className="size-4.5 mb-0.5" /> 
+              <SquareLibrary className="size-4.5 mb-0.5" />
               <div>
-                This is a IIIF Collection Manifest with multiple items. 
-                <Button 
-                  variant="link"
-                  className="ml-1 p-0 h-auto text-xs text-amber-600 underline"
-                  onClick={() => setShowCollectionImporter(true)}>Select items to import</Button>.
+                <Trans
+                  ns="images"
+                  i18nKey="iiifImporter.collectionDetected"
+                  components={{
+                    selectButton: (
+                      <Button
+                        variant="link"
+                        className="ml-1 p-0 h-auto text-xs text-amber-600 underline"
+                        onClick={() => setShowCollectionImporter(true)} />
+                    )
+                  }} />
               </div>
             </div>
           ) : parseResult?.type === 'plain-image' ? (
-            <div 
+            <div
               className="p-3 mt-6 items-start leading-relaxed
                 rounded text-destructive border border-destructive">
-              <ErrorAlert message="Invalid URL: image file" />
+              <ErrorAlert message={t('iiifImporter.errors.invalidUrlImageFile')} />
             </div>
           ) : (
             <div className="flex items-center gap-1.5 pl-0.5">{'\u00A0'}</div>
@@ -291,16 +318,16 @@ export const IIIFImporter = (props: IIIFImporterProps) => {
 
           <div className="flex justify-end gap-2 pt-4">
             <DialogClose asChild>
-              <Button 
+              <Button
                 type="button"
                 variant="ghost">
-                Cancel
+                {t('common.cancel')}
               </Button>
             </DialogClose>
 
             <Button
               disabled={!parseResult || parseResult?.type !== 'manifest'}>
-              Import
+              {t('iiifImporter.import')}
             </Button>
           </div>
         </form>

--- a/src/pages/images/IIIFImporter/ImportFromCollection.tsx
+++ b/src/pages/images/IIIFImporter/ImportFromCollection.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import murmur from 'murmurhash';
 import { FileX, LibrarySquare } from 'lucide-react';
 import { Cozy, CozyCollection, CozyCollectionItem, CozyParseResult } from 'cozy-iiif';
@@ -46,6 +47,8 @@ interface ImportFromCollectionProps {
 type ParseResult = { id: string, parsed: CozyParseResult };
 
 export const ImportFromCollection = (props: ImportFromCollectionProps) => {
+
+  const { t } = useTranslation('images');
 
   const store = useStore();
 
@@ -96,7 +99,7 @@ export const ImportFromCollection = (props: ImportFromCollectionProps) => {
       return generateShortId(idSeed).then(id => {
         const exists = Boolean(store.getIIIFResource(id));
         if (exists) {
-          return Promise.reject(new Error(`${manifest.getLabel()} already exists in the current subfolder. IMMARKUS allows multiple imports of the same manifest, but each one must be placed in a different subfolder. To continue, please remove this manifest from the list or choose a different subfolder.`));
+          return Promise.reject(new Error(t('importFromCollection.alreadyExists', { name: manifest.getLabel() })));
         } else {
           return Cozy.parseURL(manifest.id).then(parsed => ({ id, parsed }));
         }
@@ -162,11 +165,10 @@ export const ImportFromCollection = (props: ImportFromCollectionProps) => {
         onOpenChange={open => !open && props.onCancel()}>
         <DialogContent>
           <DialogTitle>
-            Import from IIIF Collection
+            {t('importFromCollection.title')}
           </DialogTitle>
           <DialogDescription className="leading-relaxed">
-            This collection contains multiple presentation manifests. Choose 
-            which items to import into your workspace.
+            {t('importFromCollection.description')}
           </DialogDescription>
 
           <div className="mt-4 mb-4 overflow-hidden">
@@ -175,7 +177,7 @@ export const ImportFromCollection = (props: ImportFromCollectionProps) => {
                 checked={isIndeterminate ? 'indeterminate' : isAllSelected}
                 onCheckedChange={onSelectAll} />
               <span className="text-xs">
-                Select All
+                {t('importFromCollection.selectAll')}
               </span>
             </div>
 
@@ -201,7 +203,7 @@ export const ImportFromCollection = (props: ImportFromCollectionProps) => {
             <Button
               variant="ghost" 
               onClick={props.onCancel}>
-              Cancel
+              {t('common.cancel')}
             </Button>
 
             <Button 
@@ -211,7 +213,7 @@ export const ImportFromCollection = (props: ImportFromCollectionProps) => {
               {importing ? (
                 <Spinner className="size-4" />
               ) : (
-                <span>Import ({selected.length})</span>
+                <span>{t('importFromCollection.importWithCount', { count: selected.length })}</span>
               )}
             </Button>
           </DialogFooter>
@@ -221,8 +223,8 @@ export const ImportFromCollection = (props: ImportFromCollectionProps) => {
       <ProgressDialog
         icon={<LibrarySquare className="h-5 w-5" />}
         open={importing}
-        title="Importing"
-        message={`Importing ${selected.length} IIIF manifests`}
+        title={t('importFromCollection.importingTitle')}
+        message={t('importFromCollection.importingMessage', { count: selected.length })}
         progress={importProgress} />
 
       <AlertDialog 
@@ -233,7 +235,7 @@ export const ImportFromCollection = (props: ImportFromCollectionProps) => {
           <AlertDialogHeader>
             <AlertDialogTitle
               className="flex gap-2 items-center text-destructive">
-              <FileX className="size-5 -ml-0.5" />  Import Error
+              <FileX className="size-5 -ml-0.5" />  {t('importFromCollection.importErrorTitle')}
             </AlertDialogTitle>
             <AlertDialogDescription
               className="my-2 leading-relaxed text-primary">
@@ -244,7 +246,7 @@ export const ImportFromCollection = (props: ImportFromCollectionProps) => {
           <AlertDialogFooter>
             <AlertDialogCancel
               className="bg-destructive border-destructive text-destructive-foreground hover:text-destructive-foreground hover:bg-destructive/90">
-              Close
+              {t('common.close')}
             </AlertDialogCancel>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/pages/images/IIIFManifestOverview/IIIFManifestGrid/IIIFCanvasItemActions.tsx
+++ b/src/pages/images/IIIFManifestOverview/IIIFManifestGrid/IIIFCanvasItemActions.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Image, Images, MoreVertical, NotebookPen } from 'lucide-react';
 import { CanvasInformation } from '@/model';
 import { CozyCanvas } from 'cozy-iiif';
@@ -25,6 +26,8 @@ interface IIIFCanvasItemActionsProps {
 
 export const IIIFCanvasItemActions = (props: IIIFCanvasItemActionsProps) => {
 
+  const { t } = useTranslation('images');
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -36,15 +39,15 @@ export const IIIFCanvasItemActions = (props: IIIFCanvasItemActionsProps) => {
 
       <DropdownMenuContent align="start">
         <DropdownMenuItem onSelect={props.onSelect}>
-          <NotebookPen className="h-4 w-4 text-muted-foreground mr-2" /> Metadata
+          <NotebookPen className="h-4 w-4 text-muted-foreground mr-2" /> {t('common.metadata')}
         </DropdownMenuItem>
 
         <DropdownMenuItem onSelect={props.onOpen}>
-          <Image className="size-4 text-muted-foreground mr-2" /> Open canvas
+          <Image className="size-4 text-muted-foreground mr-2" /> {t('common.openCanvas')}
         </DropdownMenuItem>
 
         <DropdownMenuItem onSelect={props.onAddToWorkspace}>
-          <Images className="size-4 text-muted-foreground mr-2" /> Add to workspace
+          <Images className="size-4 text-muted-foreground mr-2" /> {t('common.addToWorkspace')}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/pages/images/IIIFManifestOverview/IIIFManifestHeader.tsx
+++ b/src/pages/images/IIIFManifestOverview/IIIFManifestHeader.tsx
@@ -1,5 +1,6 @@
 import { Fragment } from 'react';
 import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import murmur from 'murmurhash';
 import { CozyTOCNode } from 'cozy-iiif';
 import { ChevronRight, NotebookPen } from 'lucide-react';
@@ -40,6 +41,8 @@ interface IIIFManifestHeaderProps {
 
 export const IIIFManifestHeader = (props: IIIFManifestHeaderProps) => {
 
+  const { t } = useTranslation('images');
+
   const { manifest, breadcrumbs } = props;
 
   const store = useStore();
@@ -63,7 +66,7 @@ export const IIIFManifestHeader = (props: IIIFManifestHeaderProps) => {
   return (
     <div className="space-y-1 grow">
       <h1 className="text-sm text-muted-foreground tracking-tight">
-        <nav className="breadcrumbs" aria-label="Breadcrumbs">
+        <nav className="breadcrumbs" aria-label={t('common.breadcrumbs')}>
           <ol className="flex items-center gap-0.5">
             <li>
               <Link className="hover:underline" to={`/images`}>{store.getRootFolder().name}</Link>
@@ -101,7 +104,7 @@ export const IIIFManifestHeader = (props: IIIFManifestHeaderProps) => {
           variant="link"
           className="text-muted-foreground flex items-center gap-1.5 p-0 h-auto font-normal"
           onClick={props.onShowMetadata}>
-          <NotebookPen className="size-4" /> Metadata
+          <NotebookPen className="size-4" /> {t('common.metadata')}
         </Button>
 
         <span>·</span> 

--- a/src/pages/images/IIIFManifestOverview/IIIFManifestTable/IIIFManifestTable.tsx
+++ b/src/pages/images/IIIFManifestOverview/IIIFManifestTable/IIIFManifestTable.tsx
@@ -1,4 +1,5 @@
 import { memo, useEffect, useLayoutEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
 import murmur from 'murmurhash';
 import { DataTable, DataTableRowClickEvent } from 'primereact/datatable';
@@ -65,6 +66,8 @@ const canvasToRow = (
 }
 
 export const IIIFManifestTable = memo((props: IIIFManifestOverviewLayoutProps) => {
+
+  const { t } = useTranslation('images');
 
   const { annotations, canvases, folders, hideUnannotated } = props;
 
@@ -153,39 +156,39 @@ export const IIIFManifestTable = memo((props: IIIFManifestOverviewLayoutProps) =
         sortIcon={sortIcon}
         emptyMessage={props.loading ? TABLE_SKELETON : TABLE_EMPTY_MESSAGE}>
         <Column
-          field="type" 
-          header="Type" 
+          field="type"
+          header={t('table.type')}
           headerClassName={TABLE_HEADER_CLASS}
           body={typeTemplate} />
 
-        <Column 
+        <Column
           sortable
           sortFunction={sortByName}
-          field="name" 
-          header="Name" 
-          headerClassName={TABLE_HEADER_CLASS} 
+          field="name"
+          header={t('table.name')}
+          headerClassName={TABLE_HEADER_CLASS}
           body={NAME_COLUMN_TEMPLATE} />
 
         <Column
           field="dimensions"
-          header="Dimensions"
+          header={t('table.dimensions')}
           headerClassName={TABLE_HEADER_CLASS}
           body={DIMENSIONS_COLUMN_TEMPLATE} />
 
         <Column
           sortable
           sortFunction={sortByLastEdit}
-          field="lastEdit" 
-          header="Last Edit" 
+          field="lastEdit"
+          header={t('table.lastEdit')}
           headerClassName={TABLE_HEADER_CLASS}
           body={LAST_EDIT_COLUMN_TEMPLATE} />
 
         <Column
           sortable
           sortFunction={sortByAnnotations}
-          field="annotations" 
-          header="Annotations" 
-          headerClassName={TABLE_HEADER_CLASS} 
+          field="annotations"
+          header={t('table.annotations')}
+          headerClassName={TABLE_HEADER_CLASS}
           body={ANNOTATIONS_COLUMN_TEMPLATE} />
 
         <Column 

--- a/src/pages/images/IIIFManifestOverview/IIIFManifestTable/IIIFManifestTableRowActions.tsx
+++ b/src/pages/images/IIIFManifestOverview/IIIFManifestTable/IIIFManifestTableRowActions.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import murmur from 'murmurhash';
 import { FolderOpen, ImageIcon, Images, MoreHorizontal, NotebookPen } from 'lucide-react';
 import { CozyRange } from 'cozy-iiif';
@@ -29,6 +30,8 @@ interface IIIFManifestTableRowActionsProps {
 
 export const IIIFManifestTableRowActions = (props: IIIFManifestTableRowActionsProps) => {
 
+  const { t } = useTranslation('images');
+
   const isCanvas = 'type' in props.data && props.data.type === 'canvas';
 
   const rangeURL = useMemo(() => {
@@ -57,24 +60,24 @@ export const IIIFManifestTableRowActions = (props: IIIFManifestTableRowActionsPr
         onClick={evt => evt.stopPropagation()}>
         {isCanvas && (
           <DropdownMenuItem onSelect={() => props.onSelectCanvas(props.data as CanvasItem)}>
-            <NotebookPen className="size-4 text-muted-foreground mr-2" /> Metadata
+            <NotebookPen className="size-4 text-muted-foreground mr-2" /> {t('common.metadata')}
           </DropdownMenuItem>
         )}
 
         {isCanvas ? (
           <>
             <DropdownMenuItem onSelect={() => props.onOpenCanvas(props.data as CanvasItem)}>
-              <ImageIcon className="size-4 text-muted-foreground mr-2" /> Open canvas
+              <ImageIcon className="size-4 text-muted-foreground mr-2" /> {t('common.openCanvas')}
             </DropdownMenuItem>
 
             <DropdownMenuItem onSelect={() => props.onAddToWorkspace(props.data as CanvasItem)}>
-              <Images className="size-4 text-muted-foreground mr-2" /> Add to workspace
+              <Images className="size-4 text-muted-foreground mr-2" /> {t('common.addToWorkspace')}
             </DropdownMenuItem>
           </>
         ) : (
           <DropdownMenuItem asChild>
             <Link to={rangeURL}>
-              <FolderOpen className="size-4 text-muted-foreground mr-2" /> Open folder
+              <FolderOpen className="size-4 text-muted-foreground mr-2" /> {t('common.openFolder')}
             </Link>
           </DropdownMenuItem>
         )}

--- a/src/pages/images/ImagesUtils.tsx
+++ b/src/pages/images/ImagesUtils.tsx
@@ -1,5 +1,7 @@
 import murmur from 'murmurhash';
+import { useTranslation } from 'react-i18next';
 import { formatDistanceToNow } from 'date-fns';
+import { getDateLocale } from '@/i18n/dateLocale';
 import { CozyRange } from 'cozy-iiif';
 import { W3CAnnotation } from '@annotorious/react';
 import { ColumnSortEvent } from 'primereact/column';
@@ -15,10 +17,18 @@ import {
 
 export const TABLE_HEADER_CLASS = 'pl-3 pr-2 whitespace-nowrap text-xs text-muted-foreground font-semibold text-left';
 
+const TableEmptyMessage = () => {
+  const { t } = useTranslation('images');
+
+  return (
+    <div className="flex justify-center p-5 text-muted-foreground/60">
+      {t('table.noData')}
+    </div>
+  );
+}
+
 export const TABLE_EMPTY_MESSAGE = (
-  <div className="flex justify-center p-5 text-muted-foreground/60">
-    No data
-  </div>
+  <TableEmptyMessage />
 );
 
 export const TABLE_SKELETON = (
@@ -80,7 +90,7 @@ export const DIMENSIONS_COLUMN_TEMPLATE = (row: ItemTableRow) =>
 export const LAST_EDIT_COLUMN_TEMPLATE = (row: ItemTableRow) => 
   row.lastEdit ? (
     <div className="text-muted-foreground">
-      {formatDistanceToNow(row.lastEdit, { addSuffix: true })}
+      {formatDistanceToNow(row.lastEdit, { addSuffix: true, locale: getDateLocale() })}
     </div>
   ) : null;
 

--- a/src/pages/images/IsInWorkspaceIndicator.tsx
+++ b/src/pages/images/IsInWorkspaceIndicator.tsx
@@ -1,4 +1,5 @@
 import { PanelsTopLeft } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { useAnnotationViewState } from '@/pages/annotate';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ui/Tooltip';
 
@@ -9,6 +10,8 @@ interface IsInWorkspaceIndicatorPipProps {
 }
 
 export const IsInWorkspaceIndicatorPip = (props: IsInWorkspaceIndicatorPipProps) => {
+
+  const { t } = useTranslation('images');
 
   const {imageIds } = useAnnotationViewState();
   
@@ -21,7 +24,7 @@ export const IsInWorkspaceIndicatorPip = (props: IsInWorkspaceIndicatorPipProps)
       </TooltipTrigger>
 
       <TooltipContent>
-        Currently open in workspace
+        {t('workspaceIndicator.currentlyOpen')}
       </TooltipContent>
     </Tooltip>
   ) : null;
@@ -36,6 +39,8 @@ interface IsInWorkspaceIndicatorBadgeProps {
 
 export const IsInWorkspaceIndicatorBadge = (props: IsInWorkspaceIndicatorBadgeProps) => {
 
+  const { t } = useTranslation('images');
+
   const {imageIds } = useAnnotationViewState();
   
   const isInWorkspace = imageIds.includes(props.imageId);
@@ -49,7 +54,7 @@ export const IsInWorkspaceIndicatorBadge = (props: IsInWorkspaceIndicatorBadgePr
       </TooltipTrigger>
 
       <TooltipContent>
-        Currently open in workspace
+        {t('workspaceIndicator.currentlyOpen')}
       </TooltipContent>
     </Tooltip>
   ) : null;

--- a/src/pages/images/ItemOverview/FolderHeader/FolderHeader.tsx
+++ b/src/pages/images/ItemOverview/FolderHeader/FolderHeader.tsx
@@ -1,5 +1,6 @@
 import { Fragment } from 'react';
 import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { ChevronRight, NotebookPen } from 'lucide-react';
 import { Folder, RootFolder } from '@/model';
 import { useStore } from '@/store';
@@ -31,6 +32,8 @@ interface FolderHeaderProps {
 
 export const FolderHeader = (props: FolderHeaderProps) => {
 
+  const { t } = useTranslation('images');
+
   const { folder } = props;
 
   const store = useStore();
@@ -39,9 +42,9 @@ export const FolderHeader = (props: FolderHeaderProps) => {
     <div className="space-y-1 grow">
       <h1 className="text-sm text-muted-foreground tracking-tight">
         {isRootFolder(folder) ? (
-          <span>Folder</span>
+          <span>{t('folderHeader.folder')}</span>
         ) : (
-          <nav className="breadcrumbs" aria-label="Breadcrumbs">
+          <nav className="breadcrumbs" aria-label={t('common.breadcrumbs')}>
             <ol className="flex items-center gap-0.5">
               <li>
                 <Link className="hover:underline" to={`/images`}>{store.getRootFolder().name}</Link>
@@ -72,7 +75,7 @@ export const FolderHeader = (props: FolderHeaderProps) => {
           variant="link"
           className="text-muted-foreground flex items-center gap-1.5 p-0 h-auto font-normal ring-offset-2 rounded"
           onClick={props.onShowMetadata}>
-          <NotebookPen className="size-4" /> Metadata
+          <NotebookPen className="size-4" /> {t('common.metadata')}
         </Button>
 
         <IIIFImporter 

--- a/src/pages/images/ItemOverview/IIIFOpenInViewerAction.tsx
+++ b/src/pages/images/ItemOverview/IIIFOpenInViewerAction.tsx
@@ -1,4 +1,5 @@
 import { Share2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { IIIFManifestResource } from '@/model';
 import { 
   DropdownMenuItem,
@@ -18,10 +19,12 @@ interface IIIFOpenInViewerActionProps {
 
 export const IIIFOpenInViewerAction = (props: IIIFOpenInViewerActionProps) => {
 
+  const { t } = useTranslation('images');
+
   return (
     <DropdownMenuSub>
       <DropdownMenuSubTrigger>
-        <Share2 className="size-4 text-muted-foreground mr-2"  /> Other IIIF Viewers
+        <Share2 className="size-4 text-muted-foreground mr-2"  /> {t('common.otherIIIFViewers')}
       </DropdownMenuSubTrigger>
       <DropdownMenuPortal>
         <DropdownMenuSubContent>

--- a/src/pages/images/ItemOverview/ItemGrid/FolderItem/FolderItem.tsx
+++ b/src/pages/images/ItemOverview/ItemGrid/FolderItem/FolderItem.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { MessagesSquare } from 'lucide-react';
 import { Folder } from '@/model';
 import { useStore } from '@/store';
@@ -20,6 +21,8 @@ interface FolderItemProps {
 
 export const FolderItem = (props: FolderItemProps) => {
 
+  const { t } = useTranslation('images');
+
   const store = useStore();
 
   const { images, folders, iiifResources } = store.getFolderContents(props.folder.handle);
@@ -30,17 +33,17 @@ export const FolderItem = (props: FolderItemProps) => {
     const m = iiifResources.length;
 
     if ((i + f + m) === 0) {
-      return 'Empty';
+      return t('folderItem.empty');
     } else {
       const tokens = [
-        i > 0 ? `${i} Image${i > 1 ? 's' : ''}` : undefined,
-        m > 0 ? `${m} IIIF` : undefined,
-        f > 0 ? `${f} Subfolder${f > 1 ? 's' : ''}` : undefined,
+        i > 0 ? t('folderItem.imageCount', { count: i }) : undefined,
+        m > 0 ? t('folderItem.iiifCount', { count: m }) : undefined,
+        f > 0 ? t('folderItem.subfolderCount', { count: f }) : undefined,
       ].filter(Boolean);
 
       return tokens.join(' · ')
     }
-  }, [images.length, folders.length, iiifResources.length]);
+  }, [images.length, folders.length, iiifResources.length, t]);
 
   return (
     <div>

--- a/src/pages/images/ItemOverview/ItemGrid/FolderItem/FolderItemActions.tsx
+++ b/src/pages/images/ItemOverview/ItemGrid/FolderItem/FolderItemActions.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { Folder } from '@/model';
 import { FolderOpen, MoreVertical, NotebookPen } from 'lucide-react';
 import {
@@ -20,6 +21,8 @@ interface FolderItemActionProps {
 
 export const FolderItemActions = (props: FolderItemActionProps) => {
 
+  const { t } = useTranslation('images');
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -31,12 +34,12 @@ export const FolderItemActions = (props: FolderItemActionProps) => {
 
       <DropdownMenuContent align="start">
         <DropdownMenuItem onSelect={props.onSelect}>
-          <NotebookPen className="h-4 w-4 text-muted-foreground mr-2" /> Metadata
+          <NotebookPen className="h-4 w-4 text-muted-foreground mr-2" /> {t('common.metadata')}
         </DropdownMenuItem>
 
         <DropdownMenuItem asChild>
           <Link to={`/images/${props.folder.id}`}>
-            <FolderOpen className="h-4 w-4 text-muted-foreground mr-2" /> Open folder
+            <FolderOpen className="h-4 w-4 text-muted-foreground mr-2" /> {t('common.openFolder')}
           </Link>
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/src/pages/images/ItemOverview/ItemGrid/IIIFManifestItem/IIIFManifestItem.tsx
+++ b/src/pages/images/ItemOverview/ItemGrid/IIIFManifestItem/IIIFManifestItem.tsx
@@ -1,4 +1,5 @@
 import { MessagesSquare } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { FolderIcon } from '@/components/FolderIcon';
 import { IIIFIcon } from '@/components/IIIFIcon';
 import { TruncatedLabel } from '@/components/TruncatedLabel';
@@ -22,6 +23,8 @@ interface IIIFManifestItemProps {
 }
 
 export const IIIFManifestItem = (props: IIIFManifestItemProps) => {
+
+  const { t } = useTranslation('images');
 
   const resource = props.resource as IIIFManifestResource;
 
@@ -70,7 +73,7 @@ export const IIIFManifestItem = (props: IIIFManifestItemProps) => {
         <div className="text-sm ml-1 max-w-47.5 overflow-hidden">
           <TruncatedLabel value={resource.name} />
           <p className="pt-1 text-xs text-muted-foreground">
-            {`${resource.canvases.length.toLocaleString()} Canvas${resource.canvases.length === 1 ? '' : 'es'}`}
+            {t('manifestItem.canvasCount', { count: resource.canvases.length })}
           </p>
         </div>
       </div>

--- a/src/pages/images/ItemOverview/ItemGrid/IIIFManifestItem/IIIFManifestItemActions.tsx
+++ b/src/pages/images/ItemOverview/ItemGrid/IIIFManifestItem/IIIFManifestItemActions.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { Images, MoreVertical, NotebookPen, Trash2 } from 'lucide-react';
 import { IIIFManifestResource, IIIFResource } from '@/model';
 import { ConfirmedDelete } from '@/components/ConfirmedDelete';
@@ -23,6 +24,8 @@ interface IIIFManifestItemActionsProps {
 
 export const IIIFManifestItemActions = (props: IIIFManifestItemActionsProps) => {
 
+  const { t } = useTranslation('images');
+
   const [confirmDelete, setConfirmDelete] = useState(false);
 
   return (
@@ -37,12 +40,12 @@ export const IIIFManifestItemActions = (props: IIIFManifestItemActionsProps) => 
 
         <DropdownMenuContent align="start">
           <DropdownMenuItem onSelect={props.onSelect}>
-            <NotebookPen className="h-4 w-4 text-muted-foreground mr-2" /> Metadata
+            <NotebookPen className="h-4 w-4 text-muted-foreground mr-2" /> {t('common.metadata')}
           </DropdownMenuItem>
 
           <DropdownMenuItem asChild>
             <Link to={`/images/${props.resource.id}`}>
-              <Images className="size-4 text-muted-foreground mr-2" /> Open Manifest
+              <Images className="size-4 text-muted-foreground mr-2" /> {t('common.openManifest')}
             </Link>
           </DropdownMenuItem>
 
@@ -50,14 +53,14 @@ export const IIIFManifestItemActions = (props: IIIFManifestItemActionsProps) => 
 
           <DropdownMenuItem onSelect={() => setConfirmDelete(true)}>          
             <Trash2 className="size-4 mr-2 mb-px text-red-700/70" />
-            <span className="text-red-700 hover:text-red-700">Delete</span>
+            <span className="text-red-700 hover:text-red-700">{t('common.delete')}</span>
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
 
       <ConfirmedDelete
         open={confirmDelete}
-        message="This will remove the manifest and will permanently delete all its annotations from your computer."
+        message={t('common.confirmDeleteManifest')}
         onConfirm={props.onDelete}
         onOpenChange={setConfirmDelete} />
     </>

--- a/src/pages/images/ItemOverview/ItemGrid/IIIFManifestItem/SingleCanvasManifestItem/SingleCanvasManifestItemActions.tsx
+++ b/src/pages/images/ItemOverview/ItemGrid/IIIFManifestItem/SingleCanvasManifestItem/SingleCanvasManifestItemActions.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Image, Images, MoreVertical, NotebookPen, Trash2 } from 'lucide-react';
 import { ConfirmedDelete } from '@/components/ConfirmedDelete';
 import { VisualSearchDebugAction } from '@/components/VisualSearchDebugAction';
@@ -33,6 +34,8 @@ interface SingleCanvasManifestItemActionsProps {
 }
 
 export const SingleCanvasManifestItemActions = (props: SingleCanvasManifestItemActionsProps) => {
+  const { t } = useTranslation('images');
+
   const [confirmDelete, setConfirmDelete] = useState(false);
   
   const id = `iiif:${props.canvas.manifestId}:${props.canvas.id}`;
@@ -50,25 +53,25 @@ export const SingleCanvasManifestItemActions = (props: SingleCanvasManifestItemA
         <DropdownMenuContent align="start">
           <DropdownMenuSub>
             <DropdownMenuSubTrigger>
-              <NotebookPen className="h-4 w-4 text-muted-foreground mr-2" /> Metadata
+              <NotebookPen className="h-4 w-4 text-muted-foreground mr-2" /> {t('common.metadata')}
             </DropdownMenuSubTrigger>
             <DropdownMenuSubContent>
               <DropdownMenuItem onSelect={props.onSelectManifest}>
-                <Images className="size-4 text-muted-foreground mr-2" /> Manifest metadata
+                <Images className="size-4 text-muted-foreground mr-2" /> {t('common.manifestMetadata')}
               </DropdownMenuItem>
 
               <DropdownMenuItem onSelect={props.onSelectCanvas}>
-                <Image className="size-4 text-muted-foreground mr-2" /> Canvas metadata
+                <Image className="size-4 text-muted-foreground mr-2" /> {t('common.canvasMetadata')}
               </DropdownMenuItem>
             </DropdownMenuSubContent>
           </DropdownMenuSub>
 
           <DropdownMenuItem onSelect={props.onOpen}>
-            <Image className="size-4 text-muted-foreground mr-2" /> Open canvas
+            <Image className="size-4 text-muted-foreground mr-2" /> {t('common.openCanvas')}
           </DropdownMenuItem>
 
           <DropdownMenuItem onSelect={props.onAddToWorkspace}>
-            <Images className="size-4 text-muted-foreground mr-2" /> Add to workspace
+            <Images className="size-4 text-muted-foreground mr-2" /> {t('common.addToWorkspace')}
           </DropdownMenuItem>
 
           <IIIFOpenInViewerAction manifest={props.manifest} />
@@ -79,14 +82,14 @@ export const SingleCanvasManifestItemActions = (props: SingleCanvasManifestItemA
 
           <DropdownMenuItem onSelect={() => setConfirmDelete(true)}>          
               <Trash2 className="size-4 mr-2 mb-px text-red-700/70" />
-              <span className="text-red-700 hover:text-red-700">Delete</span>
+              <span className="text-red-700 hover:text-red-700">{t('common.delete')}</span>
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
 
       <ConfirmedDelete
         open={confirmDelete}
-        message="This will remove the manifest and will permanently delete all annotations from your computer."
+        message={t('common.confirmDeleteManifest')}
         onConfirm={props.onDelete}
         onOpenChange={setConfirmDelete} />
     </>

--- a/src/pages/images/ItemOverview/ItemGrid/ImageItem/ImageItemActions.tsx
+++ b/src/pages/images/ItemOverview/ItemGrid/ImageItem/ImageItemActions.tsx
@@ -1,4 +1,5 @@
 import { ImageIcon, Images, MoreVertical, NotebookPen } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { VisualSearchDebugAction } from '@/components/VisualSearchDebugAction';
 import { LoadedImage } from '@/model';
 import {
@@ -24,6 +25,8 @@ interface ImageItemActionProps {
 
 export const ImageItemActions = (props: ImageItemActionProps) => {
 
+  const { t } = useTranslation('images');
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -35,15 +38,15 @@ export const ImageItemActions = (props: ImageItemActionProps) => {
 
       <DropdownMenuContent align="start">
         <DropdownMenuItem onSelect={props.onSelect}>
-          <NotebookPen className="size-4 text-muted-foreground mr-2" /> Metadata
+          <NotebookPen className="size-4 text-muted-foreground mr-2" /> {t('common.metadata')}
         </DropdownMenuItem>
 
         <DropdownMenuItem onSelect={props.onOpen}>
-          <ImageIcon className="size-4 text-muted-foreground mr-2" /> Open image
+          <ImageIcon className="size-4 text-muted-foreground mr-2" /> {t('common.openImage')}
         </DropdownMenuItem>
 
         <DropdownMenuItem onSelect={props.onAddToWorkspace}>
-          <Images className="size-4 text-muted-foreground mr-2" /> Add to workspace
+          <Images className="size-4 text-muted-foreground mr-2" /> {t('common.addToWorkspace')}
         </DropdownMenuItem>
 
         <VisualSearchDebugAction 

--- a/src/pages/images/ItemOverview/ItemTable/ItemTable.tsx
+++ b/src/pages/images/ItemOverview/ItemTable/ItemTable.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { DataTable, DataTableRowClickEvent } from 'primereact/datatable';
 import { Column } from 'primereact/column';
 import { FolderIcon } from '@/components/FolderIcon';
@@ -69,6 +70,8 @@ const imageToRow = (
 });
 
 export const ItemTable = (props: ItemOverviewLayoutProps) => {
+
+  const { t } = useTranslation('images');
 
   const [rows, setRows] = useState<ItemTableRow[]>([]);
 
@@ -155,39 +158,39 @@ export const ItemTable = (props: ItemOverviewLayoutProps) => {
         onSort={onSort}
         emptyMessage={TABLE_EMPTY_MESSAGE}>
         <Column
-          field="type" 
-          header="Type" 
+          field="type"
+          header={t('table.type')}
           headerClassName={TABLE_HEADER_CLASS}
           body={typeTemplate} />
 
-        <Column 
+        <Column
           sortable
           sortFunction={sortByName}
-          field="name" 
-          header="Name" 
-          headerClassName={TABLE_HEADER_CLASS} 
+          field="name"
+          header={t('table.name')}
+          headerClassName={TABLE_HEADER_CLASS}
           body={NAME_COLUMN_TEMPLATE} />
 
         <Column
           field="dimensions"
-          header="Dimensions"
+          header={t('table.dimensions')}
           headerClassName={TABLE_HEADER_CLASS}
           body={DIMENSIONS_COLUMN_TEMPLATE} />
 
         <Column
           sortable
           sortFunction={sortByLastEdit}
-          field="lastEdit" 
-          header="Last Edit" 
+          field="lastEdit"
+          header={t('table.lastEdit')}
           headerClassName={TABLE_HEADER_CLASS}
           body={LAST_EDIT_COLUMN_TEMPLATE} />
 
         <Column
           sortable
           sortFunction={sortByAnnotations}
-          field="annotations" 
-          header="Annotations" 
-          headerClassName={TABLE_HEADER_CLASS} 
+          field="annotations"
+          header={t('table.annotations')}
+          headerClassName={TABLE_HEADER_CLASS}
           body={ANNOTATIONS_COLUMN_TEMPLATE} />
 
         <Column 

--- a/src/pages/images/ItemOverview/ItemTable/ItemTableRowActions.tsx
+++ b/src/pages/images/ItemOverview/ItemTable/ItemTableRowActions.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { FolderOpen, ImageIcon, Images, MoreHorizontal, NotebookPen, Trash2 } from 'lucide-react';
 import { Button } from '@/ui/Button';
 import { ConfirmedDelete } from '@/components/ConfirmedDelete';
@@ -41,6 +42,8 @@ interface ItemTableRowActions {
 
 const SingleCanvasMetadataMenu = (props: ItemTableRowActions) => {
 
+  const { t } = useTranslation('images');
+
   const info = (props.data as IIIFManifestResource).canvases[0];
 
   const id = `iiif:${info.manifestId}:${info.id}`;
@@ -56,17 +59,17 @@ const SingleCanvasMetadataMenu = (props: ItemTableRowActions) => {
   return (
     <DropdownMenuSub>
       <DropdownMenuSubTrigger>
-        <NotebookPen className="h-4 w-4 text-muted-foreground mr-2" /> Metadata
+        <NotebookPen className="h-4 w-4 text-muted-foreground mr-2" /> {t('common.metadata')}
       </DropdownMenuSubTrigger>
 
       <DropdownMenuSubContent>
         <DropdownMenuItem onSelect={onSelectManifest}>
-          <Images className="size-4 text-muted-foreground mr-2" /> Manifest Metadata
+          <Images className="size-4 text-muted-foreground mr-2" /> {t('common.manifestMetadata')}
         </DropdownMenuItem>
 
         {canvas && (
           <DropdownMenuItem onSelect={onSelectCanvas}>
-            <ImageIcon className="size-4 text-muted-foreground mr-2" /> Canvas Metadata
+            <ImageIcon className="size-4 text-muted-foreground mr-2" /> {t('common.canvasMetadata')}
           </DropdownMenuItem>
         )}
       </DropdownMenuSubContent>
@@ -76,6 +79,8 @@ const SingleCanvasMetadataMenu = (props: ItemTableRowActions) => {
 }
 
 export const ItemTableRowActions = (props: ItemTableRowActions) => {
+
+  const { t } = useTranslation('images');
 
   const store = useStore();
 
@@ -137,38 +142,38 @@ export const ItemTableRowActions = (props: ItemTableRowActions) => {
             <SingleCanvasMetadataMenu {...props} />
           ) : (
             <DropdownMenuItem onSelect={onSelect}>
-              <NotebookPen className="h-4 w-4 text-muted-foreground mr-2" /> Metadata
+              <NotebookPen className="h-4 w-4 text-muted-foreground mr-2" /> {t('common.metadata')}
             </DropdownMenuItem>
           )}
 
           {isImage ? (
             <>
               <DropdownMenuItem onSelect={() => props.onOpenImage(imageId)}>
-                <ImageIcon className="size-4 text-muted-foreground mr-2" /> Open image
+                <ImageIcon className="size-4 text-muted-foreground mr-2" /> {t('common.openImage')}
               </DropdownMenuItem>
 
               <DropdownMenuItem onSelect={() => props.onAddToWorkspace(imageId)}>
-                <Images className="size-4 text-muted-foreground mr-2" /> Add to workspace
+                <Images className="size-4 text-muted-foreground mr-2" /> {t('common.addToWorkspace')}
               </DropdownMenuItem>
 
-              <VisualSearchDebugAction 
+              <VisualSearchDebugAction
                 imageId={imageId}
                 title={props.data.name} />
             </>
           ) : isFolder ? (
             <DropdownMenuItem asChild>
               <Link to={`/images/${props.data.id}`}>
-                <FolderOpen className="h-4 w-4 text-muted-foreground mr-2" /> Open folder
+                <FolderOpen className="h-4 w-4 text-muted-foreground mr-2" /> {t('common.openFolder')}
               </Link>
             </DropdownMenuItem>
           ) : isSingleCanvas ? (
             <>
               <DropdownMenuItem onSelect={() => props.onOpenImage(imageId)}>
-                <ImageIcon className="size-4 text-muted-foreground mr-2" /> Open canvas
+                <ImageIcon className="size-4 text-muted-foreground mr-2" /> {t('common.openCanvas')}
               </DropdownMenuItem>
 
               <DropdownMenuItem onSelect={() => props.onAddToWorkspace(imageId)}>
-                <Images className="size-4 text-muted-foreground mr-2" /> Add to workspace
+                <Images className="size-4 text-muted-foreground mr-2" /> {t('common.addToWorkspace')}
               </DropdownMenuItem>
 
               <IIIFOpenInViewerAction manifest={props.data as IIIFManifestResource} />
@@ -181,7 +186,7 @@ export const ItemTableRowActions = (props: ItemTableRowActions) => {
             <>
               <DropdownMenuItem asChild>
                 <Link to={`/images/${props.data.id}`}>
-                  <Images className="size-4 text-muted-foreground mr-2" /> Open manifest
+                  <Images className="size-4 text-muted-foreground mr-2" /> {t('common.openManifest')}
                 </Link>
               </DropdownMenuItem>
 
@@ -193,7 +198,7 @@ export const ItemTableRowActions = (props: ItemTableRowActions) => {
             <>
               <DropdownMenuItem onSelect={() => setConfirmDelete(true)}>          
                 <Trash2 className="size-4 mr-2 mb-px text-red-700/70" />
-                <span className="text-red-700 hover:text-red-700">Delete</span>
+                <span className="text-red-700 hover:text-red-700">{t('common.delete')}</span>
               </DropdownMenuItem>
               
               {/* <FixRelocatedManifest manifest={props.data as IIIFManifestResource}/> */}
@@ -205,7 +210,7 @@ export const ItemTableRowActions = (props: ItemTableRowActions) => {
 
       <ConfirmedDelete
         open={confirmDelete}
-        message="This will remove the manifest and will permanently delete all its annotations from your computer."
+        message={t('common.confirmDeleteManifest')}
         onConfirm={onDeleteManifest}
         onOpenChange={setConfirmDelete} />
     </>

--- a/src/pages/images/MetadataDrawer/FolderMetadataPanel.tsx
+++ b/src/pages/images/MetadataDrawer/FolderMetadataPanel.tsx
@@ -1,4 +1,5 @@
 import { FormEvent, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { W3CAnnotationBody } from '@annotorious/react';
 import { useFolderMetadata } from '@/store';
 import { PropertyValidation } from '@/components/PropertyFields';
@@ -13,6 +14,8 @@ interface FolderMetadataPanelProps {
 }
 
 export const FolderMetadataPanel = (props: FolderMetadataPanelProps) => {
+
+  const { t } = useTranslation('images');
 
   const { metadata, updateMetadata } = useFolderMetadata(props.folder);
 
@@ -47,7 +50,7 @@ export const FolderMetadataPanel = (props: FolderMetadataPanelProps) => {
             disabled={!hasChanges(metadata, formState)} 
             className="w-full mb-2"
             type="submit">
-            Save
+            {t('common.save')}
           </Button>
         </div>
       </form>

--- a/src/pages/images/MetadataDrawer/IIIFMetadataPanel.tsx
+++ b/src/pages/images/MetadataDrawer/IIIFMetadataPanel.tsx
@@ -1,4 +1,5 @@
 import { SubmitEvent, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Braces, ImagePlus, NotebookPen, PanelTop } from 'lucide-react';
 import { W3CAnnotationBody } from '@annotorious/react';
 import { PropertyValidation } from '@/components/PropertyFields';
@@ -34,6 +35,8 @@ interface MetadataListProps {
 
 const MetadataList = (props: MetadataListProps) => {
 
+  const { t } = useTranslation('images');
+
   const { customMetadata, iiifMetadata } = props;
 
   const [tab, setTab] = useState<string>('embedded'); 
@@ -58,13 +61,13 @@ const MetadataList = (props: MetadataListProps) => {
         <TabsTrigger 
           value="embedded"
           className="text-xs py-1 px-2 flex gap-1.5"> 
-          <Braces className="size-3.5" />IIIF
+          <Braces className="size-3.5" />{t('metadataPanel.iiifTab')}
         </TabsTrigger>
 
-        <TabsTrigger 
-          value="custom" 
+        <TabsTrigger
+          value="custom"
           className="text-xs py-1 px-2 flex gap-1.5">
-          <NotebookPen className="size-3.5" /> My
+          <NotebookPen className="size-3.5" /> {t('metadataPanel.myTab')}
         </TabsTrigger>
       </TabsList>
 
@@ -102,7 +105,7 @@ const MetadataList = (props: MetadataListProps) => {
                 disabled={!hasChanges(customMetadata, formState)} 
                 className="w-full"
                 type="submit">
-                Save
+                {t('common.save')}
               </Button>
 
               <Button 
@@ -110,7 +113,7 @@ const MetadataList = (props: MetadataListProps) => {
                 className="w-full"
                 type="button"
                 onClick={props.onOpen}>
-                <PanelTop className="size-4 mr-2" /> Open Image
+                <PanelTop className="size-4 mr-2" /> {t('common.openImage')}
               </Button>
 
               <Button 
@@ -118,7 +121,7 @@ const MetadataList = (props: MetadataListProps) => {
                 className="w-full"
                 type="button"
                 onClick={props.onAddToWorkspace}>
-                <ImagePlus className="size-4 mr-2" /> Add to Workspace
+                <ImagePlus className="size-4 mr-2" /> {t('common.addToWorkspace')}
               </Button>
             </div>
           </form>

--- a/src/pages/images/MetadataDrawer/ImageMetadataPanel.tsx
+++ b/src/pages/images/MetadataDrawer/ImageMetadataPanel.tsx
@@ -1,4 +1,5 @@
 import { SubmitEvent, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useImageMetadata } from '@/store';
 import { PropertyValidation } from '@/components/PropertyFields';
 import { Button } from '@/ui/Button';
@@ -15,6 +16,8 @@ interface ImageMetadataPanelProps {
 }
 
 export const ImageMetadataPanel = (props: ImageMetadataPanelProps) => {
+
+  const { t } = useTranslation('images');
 
   const { metadata, updateMetadata } = useImageMetadata(props.image?.id);
 
@@ -51,7 +54,7 @@ export const ImageMetadataPanel = (props: ImageMetadataPanelProps) => {
             disabled={!hasChanges(metadata, formState)} 
             className="w-full"
             type="submit">
-            Save
+            {t('common.save')}
           </Button>
 
           <Button 
@@ -59,7 +62,7 @@ export const ImageMetadataPanel = (props: ImageMetadataPanelProps) => {
             className="w-full"
             type="button"
             onClick={() => openInAnnotationView(props.image.id)}>
-            <PanelTop className="size-4 mr-2" /> Open Image
+            <PanelTop className="size-4 mr-2" /> {t('common.openImage')}
           </Button>
 
           <Button 
@@ -67,7 +70,7 @@ export const ImageMetadataPanel = (props: ImageMetadataPanelProps) => {
             className="w-full"
             type="button"
             onClick={() => addToAnnotationView(props.image.id)}>
-            <ImagePlus className="size-4 mr-2" /> Add to Workspace
+            <ImagePlus className="size-4 mr-2" /> {t('common.addToWorkspace')}
           </Button>
         </div>
       </form>


### PR DESCRIPTION
Images overview translation, part of the page-by-page series (after #322, #323; alongside #325, #326).

## What's in this one
- **`images` namespace**, wired into `src/i18n/index.ts`
- Translates `src/pages/images`: header controls (filter by annotations, layout toggle, grid sorting), IIIF importer + manifest overview, item grid/table + row actions, metadata drawer
- `e2e/images.spec.ts` — grid/table layouts, sorting menu, context menus, in both languages
- Adds `src/i18n/dateLocale.ts` for the locale-aware "last edit" timestamps

## Notes
- `dateLocale.ts` is also introduced by the annotate PR (#325). Whichever merges first wins; I'll drop the duplicate from the other on rebase so there's no add/add conflict for you.
- Builds on the shared `common` namespace from #323. Verified against current `main` (no upstream divergence in this page).
- i18next plurals replace hand-rolled `+ 's'`; `<Trans>` for strings with inline links/markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)