### PR TITLE
i18n: ServiceRegistry strings (services namespace)

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -11,6 +11,7 @@ import enExport from '../locales/en/export.json';
 import enImages from '../locales/en/images.json';
 import enKnowledgegraph from '../locales/en/knowledgegraph.json';
 import enMarkus from '../locales/en/markus.json';
+import enServices from '../locales/en/services.json';
 import enSettings from '../locales/en/settings.json';
 import enSmartTools from '../locales/en/smartTools.json';
 import enStart from '../locales/en/start.json';
@@ -25,6 +26,7 @@ import jaExport from '../locales/ja/export.json';
 import jaImages from '../locales/ja/images.json';
 import jaKnowledgegraph from '../locales/ja/knowledgegraph.json';
 import jaMarkus from '../locales/ja/markus.json';
+import jaServices from '../locales/ja/services.json';
 import jaSettings from '../locales/ja/settings.json';
 import jaSmartTools from '../locales/ja/smartTools.json';
 import jaStart from '../locales/ja/start.json';
@@ -50,6 +52,7 @@ i18n
         images: enImages,
         knowledgegraph: enKnowledgegraph,
         markus: enMarkus,
+        services: enServices,
         settings: enSettings,
         smartTools: enSmartTools,
         start: enStart,
@@ -65,6 +68,7 @@ i18n
         images: jaImages,
         knowledgegraph: jaKnowledgegraph,
         markus: jaMarkus,
+        services: jaServices,
         settings: jaSettings,
         smartTools: jaSmartTools,
         start: jaStart,

--- a/src/locales/en/services.json
+++ b/src/locales/en/services.json
@@ -1,0 +1,143 @@
+{
+  "anthropic-claude": {
+    "description": "Full-text transcription via Anthropic Claude",
+    "params": {
+      "api-key": {
+        "displayName": "Your API Key"
+      },
+      "model": {
+        "displayName": "Model"
+      }
+    }
+  },
+  "google-gemini": {
+    "description": "Full-text transcription via Google Gemini",
+    "keyInstructions": "You need an API key to use Google Gemini. To get your own key:\n\n- Go to <https://aistudio.google.com/>\n- Select **Get an API key** from the popup",
+    "params": {
+      "api-key": {
+        "displayName": "Your API Key"
+      },
+      "model": {
+        "displayName": "Model"
+      }
+    }
+  },
+  "google-vision": {
+    "description": "OCR via the Google Cloud Vision API",
+    "keyInstructions": "You need an API key to use Google Vision. Note that Google Vision is a **paid service**!\n\nTo get your own key:\n- [Start here](https://cloud.google.com/vision/docs/before-you-begin) and create a new project\n- Choose **Billing** from the sidebar\n- Choose **Enable billing account** and fill your payment information\n- Go to **APIs & Services** > **Enabled APIs & Services** and enable the Google Cloud Vision API\n- Go to **APIs & Services** > **Credentials** \n- Choose **Create Credentials** > **API key** from the menu to create a key",
+    "params": {
+      "api-key": {
+        "displayName": "Your API Key"
+      },
+      "merge-annotations": {
+        "displayName": "Merge Annotations",
+        "options": {
+          "dont_merge": "Don't merge",
+          "paragraph": "Merge paragraphs",
+          "block": "Merge blocks"
+        }
+      }
+    }
+  },
+  "huggingface-inference": {
+    "description": "Transcription via HuggingFace's Inference Providers",
+    "keyInstructions": "You need an Access Token to use HuggingFace Inference Providers.\n\nTo get your own key:\n- [Start here](https://huggingface.co/) to create a HuggingFace account\n- After you are logged in, click your Avatar in the top-left corner to **open your account menu**\n- Choose **Settings**\n- In the sidebar, choose **Access Tokens**\n- Click **Create new token**\n- Give the new token a name of your choice (e.g. \"IMMARKUS\")\n- Under **User Permissions**, check **Make calls to Inference Providers**\n- Click **Create Token**",
+    "params": {
+      "access-token": {
+        "displayName": "HuggingFace Access Token"
+      },
+      "model": {
+        "displayName": "Model"
+      }
+    }
+  },
+  "huggingface-spaces": {
+    "description": "Use your own model on HuggingFace Spaces",
+    "params": {
+      "endpoint": {
+        "displayName": "Endpoint"
+      },
+      "access-token": {
+        "displayName": "Access Token (Optional)"
+      },
+      "image_fieldname": {
+        "displayName": "API Fieldname: Image"
+      },
+      "prompt_fieldname": {
+        "displayName": "API Fieldname: Prompt"
+      },
+      "optional_args": {
+        "displayName": "Additional Arguments (JSON, Optional)"
+      }
+    }
+  },
+  "ocr-space": {
+    "description": "Free OCR service provided by OCR.space",
+    "params": {
+      "language": {
+        "displayName": "Content Language",
+        "options": {
+          "ara": "Arabic",
+          "bul": "Bulgarian",
+          "chs": "Chinese (Simplified)",
+          "cht": "Chinese (Traditional)",
+          "hrv": "Croatian",
+          "cze": "Czech",
+          "dan": "Danish",
+          "dut": "Dutch",
+          "eng": "English",
+          "fin": "Finnish",
+          "fre": "French",
+          "ger": "German",
+          "gre": "Greek",
+          "hun": "Hungarian",
+          "kor": "Korean",
+          "ita": "Italian",
+          "jpn": "Japanese",
+          "pol": "Polish",
+          "por": "Portuguese",
+          "rus": "Russian",
+          "slv": "Slovenian",
+          "spa": "Spanish",
+          "swe": "Swedish",
+          "tha": "Thai",
+          "tur": "Turkish",
+          "ukr": "Ukrainian",
+          "vnm": "Vietnamese"
+        }
+      },
+      "merge-lines": {
+        "displayName": "Merge Words",
+        "hint": "Create one annotation per detected text line instead of separate annotations for each word."
+      }
+    }
+  },
+  "open-ai-gpt": {
+    "description": "Full-text transcription via OpenAI GPT",
+    "keyInstructions": "You need an API key to use the OpenAI API. Note that OpenAI image analysis is a **paid service**! \n\nTo get your own key:\n\n- Go to <https://platform.openai.com/>\n- Choose **API keys** from the sidebar\n- Click **Create a new secret key**\n- Make sure that you have a payment method configured in your profile's billing settings",
+    "params": {
+      "api-key": {
+        "displayName": "Your API Key"
+      }
+    }
+  },
+  "sino-nom": {
+    "description": "Sino-Nom OCR by the Kim Hán Nôm project",
+    "params": {
+      "email": {
+        "displayName": "Account E-Mail"
+      },
+      "password": {
+        "displayName": "Password"
+      }
+    }
+  },
+  "volcano-engine": {
+    "description": "Doubao 1.5 Vision Pro via Volcano Engine",
+    "params": {
+      "api-key": {
+        "displayName": "Your Volcano Engine API Key"
+      }
+    }
+  }
+}

--- a/src/locales/ja/services.json
+++ b/src/locales/ja/services.json
@@ -1,0 +1,143 @@
+{
+  "anthropic-claude": {
+    "description": "Anthropic Claude による全文文字起こし",
+    "params": {
+      "api-key": {
+        "displayName": "API キー"
+      },
+      "model": {
+        "displayName": "モデル"
+      }
+    }
+  },
+  "google-gemini": {
+    "description": "Google Gemini による全文文字起こし",
+    "keyInstructions": "Google Gemini を使用するには API キーが必要です。API キーを取得するには:\n\n- <https://aistudio.google.com/> にアクセスします\n- ポップアップから **Get an API key** を選択します",
+    "params": {
+      "api-key": {
+        "displayName": "API キー"
+      },
+      "model": {
+        "displayName": "モデル"
+      }
+    }
+  },
+  "google-vision": {
+    "description": "Google Cloud Vision API による OCR",
+    "keyInstructions": "Google Vision を使用するには API キーが必要です。Google Vision は **有料サービス** であることにご注意ください。\n\nAPI キーを取得するには:\n- [こちら](https://cloud.google.com/vision/docs/before-you-begin) から開始し、新しいプロジェクトを作成します\n- サイドバーから **Billing** を選択します\n- **Enable billing account** を選択し、支払い情報を入力します\n- **APIs & Services** > **Enabled APIs & Services** に移動し、Google Cloud Vision API を有効にします\n- **APIs & Services** > **Credentials** に移動します\n- メニューから **Create Credentials** > **API key** を選択してキーを作成します",
+    "params": {
+      "api-key": {
+        "displayName": "API キー"
+      },
+      "merge-annotations": {
+        "displayName": "アノテーションの結合",
+        "options": {
+          "dont_merge": "結合しない",
+          "paragraph": "段落で結合",
+          "block": "ブロックで結合"
+        }
+      }
+    }
+  },
+  "huggingface-inference": {
+    "description": "HuggingFace の Inference Providers による文字起こし",
+    "keyInstructions": "HuggingFace Inference Providers を使用するにはアクセストークンが必要です。\n\nアクセストークンを取得するには:\n- [こちら](https://huggingface.co/) から HuggingFace アカウントを作成します\n- ログイン後、左上のアバターをクリックして **アカウントメニューを開きます**\n- **Settings** を選択します\n- サイドバーで **Access Tokens** を選択します\n- **Create new token** をクリックします\n- 新しいトークンに任意の名前を付けます(例:「IMMARKUS」)\n- **User Permissions** で **Make calls to Inference Providers** にチェックを入れます\n- **Create Token** をクリックします",
+    "params": {
+      "access-token": {
+        "displayName": "HuggingFace アクセストークン"
+      },
+      "model": {
+        "displayName": "モデル"
+      }
+    }
+  },
+  "huggingface-spaces": {
+    "description": "HuggingFace Spaces で独自のモデルを使用",
+    "params": {
+      "endpoint": {
+        "displayName": "エンドポイント"
+      },
+      "access-token": {
+        "displayName": "アクセストークン(任意)"
+      },
+      "image_fieldname": {
+        "displayName": "API フィールド名:画像"
+      },
+      "prompt_fieldname": {
+        "displayName": "API フィールド名:プロンプト"
+      },
+      "optional_args": {
+        "displayName": "追加の引数(JSON、任意)"
+      }
+    }
+  },
+  "ocr-space": {
+    "description": "OCR.space が提供する無料の OCR サービス",
+    "params": {
+      "language": {
+        "displayName": "コンテンツの言語",
+        "options": {
+          "ara": "アラビア語",
+          "bul": "ブルガリア語",
+          "chs": "中国語(簡体字)",
+          "cht": "中国語(繁体字)",
+          "hrv": "クロアチア語",
+          "cze": "チェコ語",
+          "dan": "デンマーク語",
+          "dut": "オランダ語",
+          "eng": "英語",
+          "fin": "フィンランド語",
+          "fre": "フランス語",
+          "ger": "ドイツ語",
+          "gre": "ギリシャ語",
+          "hun": "ハンガリー語",
+          "kor": "韓国語",
+          "ita": "イタリア語",
+          "jpn": "日本語",
+          "pol": "ポーランド語",
+          "por": "ポルトガル語",
+          "rus": "ロシア語",
+          "slv": "スロベニア語",
+          "spa": "スペイン語",
+          "swe": "スウェーデン語",
+          "tha": "タイ語",
+          "tur": "トルコ語",
+          "ukr": "ウクライナ語",
+          "vnm": "ベトナム語"
+        }
+      },
+      "merge-lines": {
+        "displayName": "単語の結合",
+        "hint": "単語ごとに個別のアノテーションを作成する代わりに、検出されたテキスト行ごとに 1 つのアノテーションを作成します。"
+      }
+    }
+  },
+  "open-ai-gpt": {
+    "description": "OpenAI GPT による全文文字起こし",
+    "keyInstructions": "OpenAI API を使用するには API キーが必要です。OpenAI の画像解析は **有料サービス** であることにご注意ください。\n\nAPI キーを取得するには:\n\n- <https://platform.openai.com/> にアクセスします\n- サイドバーから **API keys** を選択します\n- **Create a new secret key** をクリックします\n- プロフィールの請求設定に支払い方法が設定されていることを確認します",
+    "params": {
+      "api-key": {
+        "displayName": "API キー"
+      }
+    }
+  },
+  "sino-nom": {
+    "description": "Kim Hán Nôm プロジェクトによる Sino-Nom OCR",
+    "params": {
+      "email": {
+        "displayName": "アカウントのメールアドレス"
+      },
+      "password": {
+        "displayName": "パスワード"
+      }
+    }
+  },
+  "volcano-engine": {
+    "description": "Volcano Engine 経由の Doubao 1.5 Vision Pro",
+    "params": {
+      "api-key": {
+        "displayName": "Volcano Engine API キー"
+      }
+    }
+  }
+}

--- a/src/pages/annotate/SmartTools/Transcribe/TranscriptionDialog/TranscriptionControls/TranscriptionControls.tsx
+++ b/src/pages/annotate/SmartTools/Transcribe/TranscriptionDialog/TranscriptionControls/TranscriptionControls.tsx
@@ -46,6 +46,8 @@ export const TranscriptionControls = (props: TranscriptionControlsProps) => {
 
   const { t } = useTranslation('smartTools');
 
+  const { t: ts } = useTranslation('services');
+
   const { connectorId, serviceOptions } = props.options;
 
   const { connectorConfig, serviceConfig } = useMemo(() => {
@@ -95,23 +97,25 @@ export const TranscriptionControls = (props: TranscriptionControlsProps) => {
         value={value} 
         onValueChanged={onValueChanged} />
     ) : param.type === 'radio' ? (
-      <RadioParameterControl 
+      <RadioParameterControl
         key={param.id}
         param={param}
+        connectorId={connectorConfig.id}
         value={value}
         onValueChanged={onValueChanged} />
     ) : param.type === 'string' ? (
-      <StringParameterControl 
+      <StringParameterControl
         key={param.id}
-        param={param} 
-        connector={connectorConfig} 
-        value={value} 
+        param={param}
+        connector={connectorConfig}
+        value={value}
         onValueChanged={onValueChanged} />
     ) : param.type === 'switch' ? (
-      <SwitchParameterControl 
+      <SwitchParameterControl
         key={param.id}
-        param={param} 
-        checked={value} 
+        param={param}
+        connectorId={connectorConfig.id}
+        checked={value}
         onCheckedChange={onValueChanged} />
     ) : null;
   }
@@ -137,7 +141,7 @@ export const TranscriptionControls = (props: TranscriptionControlsProps) => {
                   )}
                 </h4>
                 <p className="text-xs leading-relaxed mt-0.5">
-                  {serviceConfig.description}
+                  {ts(`${connectorConfig.id}.description`, { defaultValue: serviceConfig.description })}
                 </p>
               </div>
             </SelectTrigger>
@@ -156,7 +160,7 @@ export const TranscriptionControls = (props: TranscriptionControlsProps) => {
                     )} 
                   </h4>
                   <p className="text-xs leading-relaxed mt-0.5">
-                    {c.services.find(s => s.type === 'TRANSCRIPTION')?.description}
+                    {ts(`${c.id}.description`, { defaultValue: c.services.find(s => s.type === 'TRANSCRIPTION')?.description })}
                   </p>
                 </SelectItem>
               ))}

--- a/src/pages/annotate/SmartTools/Transcribe/TranscriptionDialog/TranscriptionControls/parameters/CredentialParameterControl.tsx
+++ b/src/pages/annotate/SmartTools/Transcribe/TranscriptionDialog/TranscriptionControls/parameters/CredentialParameterControl.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import Markdown from 'react-markdown';
 import { ServiceConfigCredentialParameter, ServiceConnectorConfig } from '@/services';
 import { deobfuscate, obfuscate } from '@/utils/obfuscateString';
@@ -23,6 +24,8 @@ export const CredentialParameterControl = (props: CredentialParameterControlProp
 
   const { connector, param, value } = props;
 
+  const { t } = useTranslation('services');
+
   const key = `immarkus:services:${connector.id}:${param.id}`;
 
   useEffect(() => {
@@ -45,7 +48,7 @@ export const CredentialParameterControl = (props: CredentialParameterControlProp
   return (
     <fieldset className="space-y-2">
       <div className="flex gap-2 items-center">
-        <Label className="font-semibold">{param.displayName}</Label>
+        <Label className="font-semibold">{t(`${connector.id}.params.${param.id}.displayName`, { defaultValue: param.displayName })}</Label>
         {connector.keyInstructions && (
           <Popover>
             <PopoverTrigger>
@@ -59,7 +62,7 @@ export const CredentialParameterControl = (props: CredentialParameterControlProp
               alignOffset={-10}
               collisionPadding={10}
               className="text-xs shadow-2xl p-4 w-96 leading-relaxed prose prose-p:py-1 prose-p:m-0 prose-ul:my-2 prose-ul:px-4">
-              <Markdown>{connector.keyInstructions}</Markdown>
+              <Markdown>{t(`${connector.id}.keyInstructions`, { defaultValue: connector.keyInstructions })}</Markdown>
             </PopoverContent>
           </Popover>
         )}

--- a/src/pages/annotate/SmartTools/Transcribe/TranscriptionDialog/TranscriptionControls/parameters/RadioParameterControl.tsx
+++ b/src/pages/annotate/SmartTools/Transcribe/TranscriptionDialog/TranscriptionControls/parameters/RadioParameterControl.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { ServiceConfigRadioParameter } from '@/services';
 import { Label } from '@/ui/Label';
 import { RadioGroup, RadioGroupItem } from '@/ui/RadioGroup';
@@ -5,6 +6,8 @@ import { RadioGroup, RadioGroupItem } from '@/ui/RadioGroup';
 interface RadioParameterControlProps {
 
   param: ServiceConfigRadioParameter;
+
+  connectorId: string;
 
   value?: string;
 
@@ -14,25 +17,27 @@ interface RadioParameterControlProps {
 
 export const RadioParameterControl = (props: RadioParameterControlProps) => {
 
-  const { param, value, onValueChanged } = props;
+  const { connectorId, param, value, onValueChanged } = props;
+
+  const { t } = useTranslation('services');
 
   return (
     <fieldset className="space-y-2">
-      <Label className="font-semibold">{param.displayName}</Label>
+      <Label className="font-semibold">{t(`${connectorId}.params.${param.id}.displayName`, { defaultValue: param.displayName })}</Label>
 
       <RadioGroup
         className="mt-2 pl-1 space-y-1"
-        value={value || param.options[0][0]} 
+        value={value || param.options[0][0]}
         onValueChange={onValueChanged}>
         {param.options.map(([id, label]) => (
-          <div 
+          <div
             key={id}
             className="flex items-center gap-2.5">
             <RadioGroupItem
               value={id}
               id={id} />
 
-            <Label htmlFor={id}>{label}</Label>
+            <Label htmlFor={id}>{t(`${connectorId}.params.${param.id}.options.${id}`, { defaultValue: label })}</Label>
           </div>
         ))}
       </RadioGroup>

--- a/src/pages/annotate/SmartTools/Transcribe/TranscriptionDialog/TranscriptionControls/parameters/StringParameterControl.tsx
+++ b/src/pages/annotate/SmartTools/Transcribe/TranscriptionDialog/TranscriptionControls/parameters/StringParameterControl.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ServiceConfigStringParameter, ServiceConnectorConfig } from '@/services/Types';
 import { Input } from '@/ui/Input';
 import { Label } from '@/ui/Label';
@@ -26,6 +27,8 @@ interface StringParameterControlProps {
 export const StringParameterControl =  (props:StringParameterControlProps) => {
 
   const { connector, param, value } = props;
+
+  const { t } = useTranslation('services');
 
   const key = `immarkus:services:${connector.id}:${param.id}`;
 
@@ -56,7 +59,7 @@ export const StringParameterControl =  (props:StringParameterControlProps) => {
 
   return initialized ? (
     <fieldset className="space-y-2">
-      <Label className="font-semibold">{param.displayName}</Label>
+      <Label className="font-semibold">{t(`${connector.id}.params.${param.id}.displayName`, { defaultValue: param.displayName })}</Label>
 
       {param.options ? (
         <Select 
@@ -68,10 +71,10 @@ export const StringParameterControl =  (props:StringParameterControlProps) => {
 
           <SelectContent>
             {param.options.map(([key, value]) => (
-              <SelectItem 
+              <SelectItem
                 key={key}
                 value={key}>
-                {value}
+                {t(`${connector.id}.params.${param.id}.options.${key}`, { defaultValue: value })}
               </SelectItem>
             ))}
           </SelectContent>

--- a/src/pages/annotate/SmartTools/Transcribe/TranscriptionDialog/TranscriptionControls/parameters/SwitchParameterControl.tsx
+++ b/src/pages/annotate/SmartTools/Transcribe/TranscriptionDialog/TranscriptionControls/parameters/SwitchParameterControl.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { ServiceConfigSwitchParameter } from '@/services/Types';
 import { Label } from '@/ui/Label';
 import { Switch } from '@/ui/Switch';
@@ -5,6 +6,8 @@ import { Switch } from '@/ui/Switch';
 interface SwitchParameterControlProps {
 
   param: ServiceConfigSwitchParameter;
+
+  connectorId: string;
 
   checked?: boolean;
 
@@ -14,21 +17,23 @@ interface SwitchParameterControlProps {
 
 export const SwitchParameterControl =  (props:SwitchParameterControlProps) => {
 
-  const { param, checked, onCheckedChange } = props;
+  const { connectorId, param, checked, onCheckedChange } = props;
+
+  const { t } = useTranslation('services');
 
   return (
     <fieldset>
       <div className="flex gap-3 items-start mt-3">
-        <Switch 
-          id="merge-lines" 
-          className="mt-1" 
-          checked={Boolean(checked)} 
+        <Switch
+          id="merge-lines"
+          className="mt-1"
+          checked={Boolean(checked)}
           onCheckedChange={onCheckedChange} />
 
         <div className="leading-relaxed">
-          <Label htmlFor="merge-lines">{param.displayName}</Label>
+          <Label htmlFor="merge-lines">{t(`${connectorId}.params.${param.id}.displayName`, { defaultValue: param.displayName })}</Label>
           <p className="text-sm text-muted-foreground pr-4">
-            {param.hint}
+            {t(`${connectorId}.params.${param.id}.hint`, { defaultValue: param.hint })}
           </p>
         </div>
       </div>


### PR DESCRIPTION
## What

Internationalizes the user-facing strings in the **ServiceRegistry** (`src/services/connectors/*/config.ts`) — the last untranslated area of the app — by introducing a new `services` i18n namespace with English and Japanese resources. This was explicitly invited in #305.

## Approach (minimally invasive)

- **The connector `config.ts` files are left completely untouched.** They remain the English source and fallback.
- Strings are translated **at render time** in the components that display them. Each lookup resolves a derived key with the English config string passed as i18next `defaultValue`, e.g.:
  ```ts
  t(`${connectorId}.description`, { defaultValue: serviceConfig.description })
  ```
  So if a key is missing from the `services` namespace, the original English config string is shown.
- A new namespace ships **both** `src/locales/en/services.json` (English, mirrored from the configs — for key parity and as a translator reference) and `src/locales/ja/services.json` (Japanese), wired into `src/i18n/index.ts`.

## Key convention

```
services.<connectorId>.description
services.<connectorId>.keyInstructions
services.<connectorId>.params.<paramId>.displayName
services.<connectorId>.params.<paramId>.hint            (switch params)
services.<connectorId>.params.<paramId>.options.<value> (only human-readable, dot-free option values)
```

## What is / isn't translated

- **Translated:** every transcription `description`; every `keyInstructions` (markdown — prose translated, URLs / `**bold**` / structure / product names kept intact); every parameter `displayName`; switch `hint`s; and the human-readable option labels (google-vision `merge-annotations` and the 27 ocr-space language names).
- **Kept verbatim:** connector brand `displayName`s (Google Gemini, Anthropic Claude, OpenAI GPT, OCR.space, Volcano Engine, Kim Sino Nom, …), model identifiers (`gemini-2.0-flash`, `Qwen3-VL-8B-Instruct`, `Claude Opus 4`, …), and the `TranslationServiceConfig` model-variant displayNames ("HuggingFace (Qwen 7B)" etc.). These are identifiers, and several contain `.` which i18next reserves as a key separator anyway.

## Note on the locale parity test

These keys are **dynamic** (built from connector/param ids), so they are not covered by the static `t('literal')` key-resolution test in `locales.test.ts`. They **are** covered by that test's en↔ja parity / no-empty / no-orphan checks — en and ja `services.json` have identical key sets (63 keys each).

## Validation

- `npx tsc --noEmit`: no new errors (same 1 pre-existing TS2688 `wicg-file-system-access` line as `main`).
- `npm run build`: succeeds.
- `npm test` (vitest): the 3 new `services.json` parity checks pass. (The 1 unrelated pre-existing `settings.json` parity failure is present on `main` as well and is untouched here.)

Refs #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)