### PR TITLE
i18n: add missing Japanese settings strings

### DIFF
--- a/src/locales/ja/settings.json
+++ b/src/locales/ja/settings.json
@@ -1,6 +1,7 @@
 {
   "title": "設定",
   "description": "アプリケーション全体の設定です。",
+  "errors": "件のエラー",
   "nav": {
     "general": "一般",
     "visualSearch": "ビジュアル検索"
@@ -30,6 +31,7 @@
   },
   "indexReady": {
     "title": "画像を検索する準備ができました",
+    "errorsOccurred": "インデックス作成中に次のエラーが発生しました:",
     "description": "IMMARKUS による画像の解析が完了し、検索できるようになりました。<b><wsIcon /> ワークスペース</b>のスマートツールから<b>ビジュアル検索</b>を選ぶと、視覚的に類似した画像を検索できます。",
     "stats": "{{images}} 件の画像をインデックス済み · {{objects}} 件のオブジェクトを検出",
     "dangerZone": "危険な操作",


### PR DESCRIPTION
Two English labels added recently to the Settings / Visual Search index view had no Japanese counterpart yet, so the locale key-parity test (`src/locales/locales.test.ts`) was failing on `main`:

- `errors` — the failed-indexing count label (rendered as `{count} {t('errors')}`)
- `indexReady.errorsOccurred` — "The following errors occurred during indexing:"

This adds the Japanese translations (`件のエラー` / `インデックス作成中に次のエラーが発生しました:`), so `npm test` is green again (41 passed).

Related to the workflow question in #305 — this is exactly the "EN label added, JA pending" case the parity test is meant to surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)