### PR TITLE
test(i18n): report missing translations instead of failing CI

### DIFF
--- a/src/locales/locales.test.ts
+++ b/src/locales/locales.test.ts
@@ -39,15 +39,25 @@ describe('locale key parity (en vs ja)', () => {
     expect(ja.sort()).toEqual([...namespaceFiles].sort());
   });
 
-  it.each(namespaceFiles)('%s: every en key has a ja translation', file => {
-    const en = loadNamespace('en', file);
-    const ja = loadNamespace('ja', file);
+  // Missing translations are reported, not failed. With the "add the English
+  // label first, translate later" workflow (see #305), this surfaces the
+  // outstanding backlog in CI without breaking the build. Empty values,
+  // orphaned keys, mismatched namespace files, and unresolved referenced keys
+  // (below) all remain hard failures.
+  it('reports en keys still awaiting a ja translation (non-blocking)', () => {
+    const pending = namespaceFiles.flatMap(file => {
+      const en = loadNamespace('en', file);
+      const ja = loadNamespace('ja', file);
+      return [...en]
+        // ja only needs the _other variant of a plural pair
+        .filter(key => !ja.has(key) && !(key.endsWith('_one') && ja.has(key.replace(/_one$/, '_other'))))
+        .map(key => `${file}:${key}`);
+    });
 
-    const missing = [...en].filter(key =>
-      // ja only needs the _other variant of a plural pair
-      !ja.has(key) && !(key.endsWith('_one') && ja.has(key.replace(/_one$/, '_other'))));
+    if (pending.length > 0)
+      console.warn(`\n[i18n] ${pending.length} ja translation(s) pending:\n  ${pending.join('\n  ')}\n`);
 
-    expect(missing).toEqual([]);
+    expect(Array.isArray(pending)).toBe(true);
   });
 
   it.each(namespaceFiles)('%s: ja has no keys missing from en', file => {


### PR DESCRIPTION
Implements the workflow agreed in #305: new UI labels are added to the **EN locale file only**, and translations are filled in later. For that to work, a missing `ja` key should not break the build — it should be a visible to-do, not a red CI.

This changes the en→ja parity check in `src/locales/locales.test.ts` from a hard failure into a **non-blocking report** that lists the outstanding keys via `console.warn` (e.g. `[i18n] 2 ja translation(s) pending: settings.json:errors ...`).

Kept as hard failures (these indicate real mistakes, not pending work):
- empty `ja` values
- `ja` keys with no `en` counterpart (orphans / typos)
- mismatched namespace files between locales
- `t()` / `<Trans>` keys referenced in source that don't resolve in `en`

(The two currently-pending settings keys are translated in #331; with that merged, the report is empty.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)