### PR TITLE
i18n: lazy-load non-English locales

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "fuse.js": "^7.4.2",
         "i18next": "^26.3.1",
         "i18next-browser-languagedetector": "^8.2.1",
+        "i18next-resources-to-backend": "^1.2.1",
         "localforage": "^1.10.0",
         "lucide-react": "^1.18.0",
         "masonic": "^4.1.0",
@@ -6177,6 +6178,15 @@
         "@babel/runtime": "^7.23.2"
       }
     },
+    "node_modules/i18next-resources-to-backend": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/i18next-resources-to-backend/-/i18next-resources-to-backend-1.2.1.tgz",
+      "integrity": "sha512-okHbVA+HZ7n1/76MsfhPqDou0fptl2dAlhRDu2ideXloRRduzHsqDOznJBef+R3DFZnbvWoBW+KxJ7fnFjd6Yw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -10154,24 +10164,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/zip-stream": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "fuse.js": "^7.4.2",
     "i18next": "^26.3.1",
     "i18next-browser-languagedetector": "^8.2.1",
+    "i18next-resources-to-backend": "^1.2.1",
     "localforage": "^1.10.0",
     "lucide-react": "^1.18.0",
     "masonic": "^4.1.0",

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,80 +1,55 @@
 import i18n from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
+import resourcesToBackend from 'i18next-resources-to-backend';
 import { initReactI18next } from 'react-i18next';
-
-import enAbout from '../locales/en/about.json';
-import enAnnotate from '../locales/en/annotate.json';
-import enApp from '../locales/en/app.json';
-import enCommon from '../locales/en/common.json';
-import enDatamodel from '../locales/en/datamodel.json';
-import enExport from '../locales/en/export.json';
-import enImages from '../locales/en/images.json';
-import enKnowledgegraph from '../locales/en/knowledgegraph.json';
-import enMarkus from '../locales/en/markus.json';
-import enSettings from '../locales/en/settings.json';
-import enSmartTools from '../locales/en/smartTools.json';
-import enStart from '../locales/en/start.json';
-import enUi from '../locales/en/ui.json';
-
-import jaAbout from '../locales/ja/about.json';
-import jaAnnotate from '../locales/ja/annotate.json';
-import jaApp from '../locales/ja/app.json';
-import jaCommon from '../locales/ja/common.json';
-import jaDatamodel from '../locales/ja/datamodel.json';
-import jaExport from '../locales/ja/export.json';
-import jaImages from '../locales/ja/images.json';
-import jaKnowledgegraph from '../locales/ja/knowledgegraph.json';
-import jaMarkus from '../locales/ja/markus.json';
-import jaSettings from '../locales/ja/settings.json';
-import jaSmartTools from '../locales/ja/smartTools.json';
-import jaStart from '../locales/ja/start.json';
-import jaUi from '../locales/ja/ui.json';
 
 export const SUPPORTED_LANGUAGES = [
   { code: 'en', label: 'English' },
   { code: 'ja', label: '日本語' }
 ];
 
+// English ships in the main bundle and is the always-available fallback, so
+// the first paint never waits on a network/chunk load.
+const enModules = import.meta.glob('../locales/en/*.json', { eager: true });
+
+const en: Record<string, any> = {};
+for (const path in enModules) {
+  const ns = path.split('/').pop()!.replace('.json', '');
+  en[ns] = (enModules[path] as any).default;
+}
+
+// Each non-English locale file becomes its own lazy chunk, fetched on demand
+// (and cached) when the user selects that language, instead of being baked into
+// the main bundle. English is excluded here because it is bundled eagerly
+// above. Adding a language or namespace is just dropping the JSON file in — no
+// wiring needed here.
+const localeModules = import.meta.glob([
+  '../locales/*/*.json',
+  '!../locales/en/*.json'
+]);
+
 i18n
   .use(LanguageDetector)
+  .use(resourcesToBackend((language: string, namespace: string) => {
+    const load = localeModules[`../locales/${language}/${namespace}.json`];
+    if (!load) return Promise.reject(new Error(`Unknown locale resource: ${language}/${namespace}`));
+    return load().then((mod: any) => mod.default);
+  }))
   .use(initReactI18next)
   .init({
-    resources: {
-      en: {
-        about: enAbout,
-        annotate: enAnnotate,
-        app: enApp,
-        common: enCommon,
-        datamodel: enDatamodel,
-        export: enExport,
-        images: enImages,
-        knowledgegraph: enKnowledgegraph,
-        markus: enMarkus,
-        settings: enSettings,
-        smartTools: enSmartTools,
-        start: enStart,
-        ui: enUi
-      },
-      ja: {
-        about: jaAbout,
-        annotate: jaAnnotate,
-        app: jaApp,
-        common: jaCommon,
-        datamodel: jaDatamodel,
-        export: jaExport,
-        images: jaImages,
-        knowledgegraph: jaKnowledgegraph,
-        markus: jaMarkus,
-        settings: jaSettings,
-        smartTools: jaSmartTools,
-        start: jaStart,
-        ui: jaUi
-      }
-    },
+    // English is bundled; other languages come from the backend above.
+    resources: { en },
+    partialBundledLanguages: true,
+    ns: Object.keys(en),
     fallbackLng: 'en',
     interpolation: {
       // React already escapes interpolated values
       escapeValue: false
+    },
+    react: {
+      // No Suspense boundary in the tree: while a language loads, components
+      // render the English fallback and re-render once the chunk arrives.
+      useSuspense: false
     },
     detection: {
       order: ['localStorage', 'navigator'],


### PR DESCRIPTION
Follows up on the bundling question in #305. Right now every locale is baked into the main JS; this splits non-English languages into separate chunks so a user only downloads English (the default/fallback) plus their selected language.

## Approach
Vite-native code splitting rather than `i18next-http-backend`, so the locale chunks go through the normal build (hashing + cache-busting handled by Vite) with no raw JSON to serve from `public/` and no extra fetch layer to configure:
- English via an **eager** `import.meta.glob('../locales/en/*.json', { eager: true })` → bundled, always available as the fallback.
- Other languages via a **lazy** `import.meta.glob(['../locales/*/*.json', '!../locales/en/*.json'])` behind `i18next-resources-to-backend` → fetched on demand and cached.
- `react: { useSuspense: false }` so a language load never needs a Suspense boundary in the tree.

A nice side effect: namespaces are auto-discovered from the files, so `src/i18n/index.ts` no longer needs a manual import list (and page PRs no longer touch it).

## Effect
- Main bundle ~2,775 kB → ~2,732 kB, and — the real point — it stays flat as more languages are added (each new language is its own chunk).
- Build is clean (no new warnings); `tsc` shows no new errors; `npm test` (vitest) passes.

## Trade-off
For a returning non-English user, the detected language now loads as a chunk after first paint, so there's a brief English flash before it swaps in. This can be removed later with a Suspense boundary + fallback, or by awaiting the detected language in the bootstrap before render. Kept out of this PR to keep it focused — happy to add whichever you prefer.

## Note on tests
`npm run test:e2e`: 12 of 13 pass. The one failure (`start.spec.ts` › language switcher toggles and persists across reload) is **pre-existing on `main`** and unrelated to this change — it reproduces with the eager bundling too. It looks like the start-page language-switcher restyle changed what the test's selector matches; I'll fix that test separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)