### PR TITLE
fix(a11y): keep the start-page language switcher out of aria-hidden

### DIFF
--- a/src/pages/start/Start.tsx
+++ b/src/pages/start/Start.tsx
@@ -56,8 +56,8 @@ export const Start = (props: StartProps) => {
 
   return (
     <div>
-      <div className="absolute top-2 right-2 text-xs text-muted-foreground/50 flex gap-2" aria-hidden={true}>
-        <span>v{process.env.PACKAGE_VERSION}</span> · <span>Build {buildDate}</span> · <LanguageSwitcher />
+      <div className="absolute top-2 right-2 text-xs text-muted-foreground/50 flex gap-2">
+        <span aria-hidden={true}>v{process.env.PACKAGE_VERSION}</span> <span aria-hidden={true}>· Build {buildDate} ·</span> <LanguageSwitcher />
       </div>
 
       {!window.showDirectoryPicker ? (


### PR DESCRIPTION
Small accessibility fix on the start page.

The version/build line in the top-right corner is `aria-hidden` (correct — it's decorative). After the recent switcher restyle, the `<LanguageSwitcher>` ended up **inside** that same `aria-hidden` container, which removes it from the accessibility tree entirely:

- screen-reader / keyboard users relying on AT can't reach the language switcher
- role-based queries can't find it either — this is why the `start.spec.ts` "language switcher toggles and persists across reload" e2e is currently failing on `main` (it looks for `getByRole('combobox', { name: 'Language' })`)

This scopes `aria-hidden` to just the version and build text spans, so the switcher stays accessible. The visual layout is unchanged. With this, the start-page e2e passes again (4/4).

(Found while validating #333; unrelated to that change — it reproduces with the current bundling too.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)