### PR TITLE
IIIF Folder Export

### DIFF
--- a/src/pages/images/IIIFExporter/IIIFExportAction.tsx
+++ b/src/pages/images/IIIFExporter/IIIFExportAction.tsx
@@ -4,6 +4,8 @@ import { DropdownMenuItem } from '@/ui/DropdownMenu';
 
 interface IIIFExportActionProps {
 
+  disabled?: boolean;
+
   onSelect(): void;
 
 }
@@ -13,7 +15,9 @@ export const IIIFExportAction = (props: IIIFExportActionProps) => {
   const { t } = useTranslation('images');
 
   return (
-    <DropdownMenuItem onSelect={props.onSelect}>
+    <DropdownMenuItem 
+      disabled={props.disabled}
+      onSelect={props.onSelect}>
       <IIIFIcon 
         light
         className="size-4 text-muted-foreground mr-2" /> {t('common.exportIIIF')}

--- a/src/pages/images/IIIFExporter/IIIFExporterDialog.tsx
+++ b/src/pages/images/IIIFExporter/IIIFExporterDialog.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { IIIFIcon } from '@/components/IIIFIcon';
-import { IIIFManifestResource, IIIFResource, LoadedFileImage } from '@/model';
+import { Folder, IIIFManifestResource, IIIFResource, LoadedFileImage } from '@/model';
 import { Label } from '@/ui/Label';
 import { Input } from '@/ui/Input';
 import { Button } from '@/ui/Button';
@@ -9,6 +9,7 @@ import { Checkbox } from '@/ui/Checkbox';
 import { useStore } from '@/store';
 import { exportImageToIIIF } from '@/store/export/iiif/exportImageToIIIF';
 import { exportDerivativeResource } from '@/store/export/iiif/exportDerivativeResource';
+import { exportImageFolderToIIIF } from '@/store/export/iiif/exportImageFolderToIIIF';
 import { 
   Dialog, 
   DialogContent, 
@@ -20,7 +21,7 @@ import {
 
 interface IIIFExportDialogProps {
 
-  item: LoadedFileImage | IIIFResource;
+  item: LoadedFileImage | IIIFResource | Folder;
 
   open: boolean;
 
@@ -62,10 +63,15 @@ export const IIIFExportDialog = (props: IIIFExportDialogProps) => {
       return;
     }
 
-    if ('data' in props.item)
-      exportImageToIIIF(props.item, stripTrailingSlash(baseUrl), miradorSafe, store);
-    else 
-      exportDerivativeResource(props.item as IIIFManifestResource, stripTrailingSlash(baseUrl), miradorSafe, store);
+    const base = stripTrailingSlash(baseUrl);
+
+    if ('data' in props.item) {
+      exportImageToIIIF(props.item, base, miradorSafe, store);
+    } else if ('handle' in props.item) {
+      exportImageFolderToIIIF(props.item, base, miradorSafe, store);
+    } else {
+      exportDerivativeResource(props.item as IIIFManifestResource, base, miradorSafe, store);
+    }
 
     props.onOpenChange(false);
   }

--- a/src/pages/images/ItemOverview/ItemGrid/FolderItem/FolderItemActions.tsx
+++ b/src/pages/images/ItemOverview/ItemGrid/FolderItem/FolderItemActions.tsx
@@ -1,7 +1,11 @@
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Folder } from '@/model';
 import { FolderOpen, MoreVertical, NotebookPen } from 'lucide-react';
+import { Folder } from '@/model';
+import { useStore } from '@/store';
+import { canExportFolderAsIIIF } from '@/store/export/iiif/exportImageFolderToIIIF';
+import { IIIFExportAction, IIIFExportDialog } from '../../../IIIFExporter';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -23,27 +27,44 @@ export const FolderItemActions = (props: FolderItemActionProps) => {
 
   const { t } = useTranslation('images');
 
+  const store = useStore();
+
+  const canExportIIIF = canExportFolderAsIIIF(props.folder, store);
+
+  const [isIIIFExportOpen, setIIIFExportOpen] = useState(false);
+
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <button
-          className="item-actions-trigger absolute bottom-2 right-1">
-          <MoreVertical size={18} />
-        </button>
-      </DropdownMenuTrigger>
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            className="item-actions-trigger absolute bottom-2 right-1">
+            <MoreVertical size={18} />
+          </button>
+        </DropdownMenuTrigger>
 
-      <DropdownMenuContent align="start">
-        <DropdownMenuItem onSelect={props.onSelect}>
-          <NotebookPen className="h-4 w-4 text-muted-foreground mr-2" /> {t('common.metadata')}
-        </DropdownMenuItem>
+        <DropdownMenuContent align="start">
+          <DropdownMenuItem onSelect={props.onSelect}>
+            <NotebookPen className="h-4 w-4 text-muted-foreground mr-2" /> {t('common.metadata')}
+          </DropdownMenuItem>
 
-        <DropdownMenuItem asChild>
-          <Link to={`/images/${props.folder.id}`}>
-            <FolderOpen className="h-4 w-4 text-muted-foreground mr-2" /> {t('common.openFolder')}
-          </Link>
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+          <DropdownMenuItem asChild>
+            <Link to={`/images/${props.folder.id}`}>
+              <FolderOpen className="h-4 w-4 text-muted-foreground mr-2" /> {t('common.openFolder')}
+            </Link>
+          </DropdownMenuItem>
+
+          <IIIFExportAction 
+            disabled={!canExportIIIF}
+            onSelect={() => setIIIFExportOpen(true)} />
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <IIIFExportDialog 
+        open={isIIIFExportOpen} 
+        onOpenChange={setIIIFExportOpen} 
+        item={props.folder} />
+    </>
   )
 
 }

--- a/src/pages/knowledgegraph/GraphSearch/searchUtils.ts
+++ b/src/pages/knowledgegraph/GraphSearch/searchUtils.ts
@@ -1,7 +1,7 @@
 import { CanvasInformation, Folder, IIIFManifestResource, Image, MetadataSchema } from '@/model';
 import { DataModelStore, getManifestMetadata, Store } from '@/store';
 import { W3CAnnotation, W3CAnnotationBody } from '@annotorious/react';
-import { getParentFolders } from '@/utils/metadata';
+import { getSourceParents } from '@/utils/metadata';
 import { serializePropertyValue } from '@/utils/serialize';
 import {
   Graph, 
@@ -278,7 +278,7 @@ export const getAggregatedMetadata = (store: Store, imageId: string): Promise<Sc
     ];
   }
 
-  const folders = getParentFolders(store, imageId);
+  const folders = getSourceParents(store, imageId);
 
   // Go through folders from the top and aggregate metadata values
   const folderMetadata = folders.reduce<Promise<SchemaPropertyValue[]>>((promise, folder) => 

--- a/src/pages/knowledgegraph/GraphSearch/searchUtils.ts
+++ b/src/pages/knowledgegraph/GraphSearch/searchUtils.ts
@@ -278,7 +278,7 @@ export const getAggregatedMetadata = (store: Store, imageId: string): Promise<Sc
     ];
   }
 
-  const folders = getSourceParents(store, imageId);
+  const folders = getSourceParents(imageId, store);
 
   // Go through folders from the top and aggregate metadata values
   const folderMetadata = folders.reduce<Promise<SchemaPropertyValue[]>>((promise, folder) => 

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -68,7 +68,7 @@ export interface AnnotationStore {
 
   listImagesInFolder(folderId: string): Image[];
 
-  loadImage(id: string): Promise<LoadedImage>;
+  loadImage(id: string): Promise<LoadedFileImage>;
 
   removeIIIFResource(resource: IIIFResource): Promise<void>;
 

--- a/src/store/export/iiif/crosswalkMetadata.ts
+++ b/src/store/export/iiif/crosswalkMetadata.ts
@@ -1,7 +1,7 @@
 import { W3CAnnotationBody } from '@annotorious/react';
 import { getManifestMetadata, Store } from '@/store';
-import { getSourceParents } from '@/utils/metadata';
 import { serializePropertyValue } from '@/utils/serialize';
+import type { Folder, IIIFManifestResource, RootFolder } from '@/model';
 
 // Basic helper shape
 export interface IIIFMetadataField {
@@ -41,9 +41,10 @@ export const crosswalkMetadata = (
 }
 
 /** Collapses parent folder metadata for the given image or IIIF manifest **/
-export const getFlattenedParentFolderMetadata = (store: Store, sourceId: string): Promise<IIIFMetadataField[]> => {
-  const folders = getSourceParents(store, sourceId);
-
+export const getFlattenedParentFolderMetadata = (
+  folderHierarchy: (RootFolder | Folder | IIIFManifestResource)[], 
+  store: Store
+): Promise<IIIFMetadataField[]> => {
   // Merges two lists of IIIF metadata fields, with same-labeled fields in 'next' taking precedence
   const mergeIIIFMetadataFields = (
     current: IIIFMetadataField[],
@@ -53,7 +54,7 @@ export const getFlattenedParentFolderMetadata = (store: Store, sourceId: string)
     return [...current.filter(field => !nextLabels.has(field.label.en[0])), ...next];
   }
 
-  return folders.reduce<Promise<IIIFMetadataField[]>>((promise, folder) => promise.then(fields => {
+  return folderHierarchy.reduce<Promise<IIIFMetadataField[]>>((promise, folder) => promise.then(fields => {
     const body = 'uri' in folder
       ? getManifestMetadata(store, folder.id).then(({ metadata }) => metadata)
       : store.getFolderMetadata(folder.handle).then(annotation => {

--- a/src/store/export/iiif/crosswalkMetadata.ts
+++ b/src/store/export/iiif/crosswalkMetadata.ts
@@ -1,6 +1,6 @@
 import { W3CAnnotationBody } from '@annotorious/react';
 import { getManifestMetadata, Store } from '@/store';
-import { getParentFolders } from '@/utils/metadata';
+import { getSourceParents } from '@/utils/metadata';
 import { serializePropertyValue } from '@/utils/serialize';
 
 // Basic helper shape
@@ -42,7 +42,7 @@ export const crosswalkMetadata = (
 
 /** Collapses parent folder metadata for the given image or IIIF manifest **/
 export const getFlattenedParentFolderMetadata = (store: Store, sourceId: string): Promise<IIIFMetadataField[]> => {
-  const folders = getParentFolders(store, sourceId);
+  const folders = getSourceParents(store, sourceId);
 
   // Merges two lists of IIIF metadata fields, with same-labeled fields in 'next' taking precedence
   const mergeIIIFMetadataFields = (

--- a/src/store/export/iiif/exportImageFolderToIIIF.ts
+++ b/src/store/export/iiif/exportImageFolderToIIIF.ts
@@ -1,0 +1,25 @@
+import { Folder } from '@/model';
+import { Store } from '@/store';
+
+/**
+ * Exports a ready-to-deploy IIIF ZIP package for a folder that 
+ * contains ONLY IMAGES AND NO SUB-FOLDERS.
+ * 
+ * Zip contains:
+ * - The image files
+ * - A presentation API v3 manifest with one static image canvas for each image
+ * - One JSON-LD annotation list for each image
+ */
+export const exportImageFolderToIIIF = async (folder: Folder, baseUrl: string, miradorSafe: boolean, store: Store) => {
+  console.log('[TODO] exporting folder', folder);
+}
+
+/**
+ * A helper method to determine whether the folder meets
+ * the requirements and limitations of `exportImageFolderToIIIF`.
+ */
+export const canExportFolderAsIIIF = (folder: Folder, store: Store) => {
+  const { images, folders, iiifResources } = store.getFolderContents(folder.handle);
+  return folders.length === 0 && iiifResources.length === 0 && images.length > 0;
+}
+ 

--- a/src/store/export/iiif/exportImageFolderToIIIF.ts
+++ b/src/store/export/iiif/exportImageFolderToIIIF.ts
@@ -2,7 +2,8 @@ import JSZip from 'jszip';
 import { Folder, LoadedFileImage } from '@/model';
 import { getImageMetadata, Store } from '@/store';
 import { createAnnotationPage, createStaticImageCanvas, stripExtension } from './exportImageToIIIF';
-import { crosswalkMetadata, IIIFMetadataField } from './crosswalkMetadata';
+import { crosswalkMetadata, getFlattenedParentFolderMetadata, IIIFMetadataField } from './crosswalkMetadata';
+import { getParentFolderHierarchy } from '@/utils/metadata';
 
 /**
  * Creates a basic IIIF manifest for the list of image files, according to 
@@ -12,7 +13,8 @@ import { crosswalkMetadata, IIIFMetadataField } from './crosswalkMetadata';
  */
 const createStaticManifest = async (folder: Folder, images: LoadedFileImage[], base: string, store: Store) => {
   // Folder metadata -> manifest metadata
-  // const folderMetadata = await getFlattenedParentFolderMetadata(store, image.id);
+  const folders = getParentFolderHierarchy(folder, store);
+  const folderMetadata = await getFlattenedParentFolderMetadata(folders, store);
 
   const resolveImageMetadata = async (image: LoadedFileImage): Promise<IIIFMetadataField[]> => {
     const { metadata: imageMetaBody } = await getImageMetadata(store, image.id);
@@ -32,6 +34,9 @@ const createStaticManifest = async (folder: Folder, images: LoadedFileImage[], b
     id: `${base}/manifest.json`,
     type: 'Manifest',
     label: { en: [ folder.name ] },
+    ...(
+      folderMetadata.length > 0 ? { metadata: folderMetadata } : {}
+    ),
     items
   }
 }

--- a/src/store/export/iiif/exportImageFolderToIIIF.ts
+++ b/src/store/export/iiif/exportImageFolderToIIIF.ts
@@ -1,5 +1,41 @@
-import { Folder } from '@/model';
-import { Store } from '@/store';
+import JSZip from 'jszip';
+import { Folder, LoadedFileImage } from '@/model';
+import { getImageMetadata, Store } from '@/store';
+import { createAnnotationPage, createStaticImageCanvas, stripExtension } from './exportImageToIIIF';
+import { crosswalkMetadata, IIIFMetadataField } from './crosswalkMetadata';
+
+/**
+ * Creates a basic IIIF manifest for the list of image files, according to 
+ * IIIF cookbook recipe 1:
+ * 
+ * https://iiif.io/api/cookbook/recipe/0001-mvm-image/
+ */
+const createStaticManifest = async (folder: Folder, images: LoadedFileImage[], base: string, store: Store) => {
+  // Folder metadata -> manifest metadata
+  // const folderMetadata = await getFlattenedParentFolderMetadata(store, image.id);
+
+  const resolveImageMetadata = async (image: LoadedFileImage): Promise<IIIFMetadataField[]> => {
+    const { metadata: imageMetaBody } = await getImageMetadata(store, image.id);
+    return imageMetaBody && Object.keys(imageMetaBody).length > 0 
+      ? crosswalkMetadata(imageMetaBody, store, 'IMAGE') : [];
+  } 
+
+  const items = await Promise.all(
+    images.map(async image => {
+      const metadata = await resolveImageMetadata(image);
+      return createStaticImageCanvas(image, metadata, base);
+    })
+  );
+
+  return {
+    '@context': 'http://iiif.io/api/presentation/3/context.json',
+    id: `${base}/manifest.json`,
+    type: 'Manifest',
+    label: { en: [ folder.name ] },
+    // TODO folder + parent folder metadata 
+    items
+  }
+}
 
 /**
  * Exports a ready-to-deploy IIIF ZIP package for a folder that 
@@ -11,7 +47,35 @@ import { Store } from '@/store';
  * - One JSON-LD annotation list for each image
  */
 export const exportImageFolderToIIIF = async (folder: Folder, baseUrl: string, miradorSafe: boolean, store: Store) => {
-  console.log('[TODO] exporting folder', folder);
+  const base = `${baseUrl}/${folder.id}`;
+
+  const zip = new JSZip();
+
+  const { images } = store.getFolderContents(folder.handle);
+  const loadedImages = await Promise.all(images.map(i => store.loadImage(i.id)));
+
+  // Package image files
+  loadedImages.forEach(image => {
+    zip.file(`${folder.id}/${image.name}`, image.data, { binary: true });
+  });
+
+  // Package annotation lists
+  const annotationPages = await Promise.all(images.map(i => 
+    createAnnotationPage(i, base, miradorSafe, store)));
+
+  annotationPages.forEach((annotations, idx) =>
+    zip.file(`${folder.id}/${stripExtension(images[idx].name)}.json`, JSON.stringify(annotations, null, 2)));
+
+  // Package manifest
+  const manifest = await createStaticManifest(folder, loadedImages, base, store);
+  zip.file(`${folder.id}/manifest.json`, JSON.stringify(manifest, null, 2));
+
+  const blob = await zip.generateAsync({ type:'blob' });
+
+  const anchor = document.createElement('a');
+  anchor.href = URL.createObjectURL(blob);
+  anchor.download = `${folder.id}.zip`;
+  anchor.click();
 }
 
 /**

--- a/src/store/export/iiif/exportImageFolderToIIIF.ts
+++ b/src/store/export/iiif/exportImageFolderToIIIF.ts
@@ -21,9 +21,9 @@ const createStaticManifest = async (folder: Folder, images: LoadedFileImage[], b
   } 
 
   const items = await Promise.all(
-    images.map(async image => {
+    images.map(async (image, idx) => {
       const metadata = await resolveImageMetadata(image);
-      return createStaticImageCanvas(image, metadata, base);
+      return createStaticImageCanvas(image, base, image.name, metadata, idx + 1, `${stripExtension(image.name)}.json`);
     })
   );
 
@@ -32,7 +32,6 @@ const createStaticManifest = async (folder: Folder, images: LoadedFileImage[], b
     id: `${base}/manifest.json`,
     type: 'Manifest',
     label: { en: [ folder.name ] },
-    // TODO folder + parent folder metadata 
     items
   }
 }
@@ -60,8 +59,16 @@ export const exportImageFolderToIIIF = async (folder: Folder, baseUrl: string, m
   });
 
   // Package annotation lists
-  const annotationPages = await Promise.all(images.map(i => 
-    createAnnotationPage(i, base, miradorSafe, store)));
+  const annotationPages = await Promise.all(images.map((img, idx) => {
+    const name = stripExtension(img.name);
+    const annotationBase = `${base}/${name}.json`;
+    return createAnnotationPage(
+      img, 
+      `${base}/${name}.json`,
+      `${base}/canvas/${idx + 1}`,
+      miradorSafe, 
+      store)
+  }));
 
   annotationPages.forEach((annotations, idx) =>
     zip.file(`${folder.id}/${stripExtension(images[idx].name)}.json`, JSON.stringify(annotations, null, 2)));

--- a/src/store/export/iiif/exportImageToIIIF.ts
+++ b/src/store/export/iiif/exportImageToIIIF.ts
@@ -53,7 +53,6 @@ export const createStaticImageCanvas = async (
   filename = 'annotations.json'
 ) => {
   const { width, height } = await getImageDimensions(image.data);
-
   return {
     id: `${base}/canvas/${canvasIndex}`,
     type: 'Canvas',
@@ -91,8 +90,6 @@ export const createStaticImageCanvas = async (
 const createStaticManifest = async (image: LoadedFileImage, baseUrl: string, store: Store) => {
   const base = `${baseUrl}/${stripExtension(image.name)}`;
 
-  const { width, height } = await getImageDimensions(image.data);
-
   // Folder metadata -> manifest metadata
   const folderMetadata = await getFlattenedParentFolderMetadata(store, image.id);
 
@@ -112,7 +109,7 @@ const createStaticManifest = async (image: LoadedFileImage, baseUrl: string, sto
       imageMetadata.length > 0 ? { metadata: imageMetadata } : {}
     ),
     items: [
-      createStaticImageCanvas(
+      await createStaticImageCanvas(
         image,
         base,
         undefined,

--- a/src/store/export/iiif/exportImageToIIIF.ts
+++ b/src/store/export/iiif/exportImageToIIIF.ts
@@ -29,35 +29,43 @@ const getImageDimensions = (blob: Blob): Promise<{ width: number, height: number
     img.src = url;
   });
 
-export const createAnnotationPage = (image: FileImage, baseUrl: string, miradorSafe: boolean, store: Store) => {
-  const base = `${baseUrl}/${stripExtension(image.name)}`;
-
+export const createAnnotationPage = (
+  image: FileImage, 
+  id: string, 
+  targetId: string,
+  miradorSafe: boolean, 
+  store: Store
+) => {
   return store.getAnnotations(image.id, { type: 'image' }).then(annotations => ({
     '@context': 'http://iiif.io/api/presentation/3/context.json',
-    id: `${base}/annotations.json`,
+    id,
     type: 'AnnotationPage',
-    items: crosswalkAnnotations(annotations, miradorSafe, store, `${base}/canvas/1`)
+    items: crosswalkAnnotations(annotations, miradorSafe, store, targetId)
   }));
 }
 
 export const createStaticImageCanvas = async (
   image: LoadedFileImage, 
-  metadata: IIIFMetadataField[],
-  base: string
+  base: string,
+  label?: string,
+  metadata: IIIFMetadataField[] = [],
+  canvasIndex = 1,
+  filename = 'annotations.json'
 ) => {
   const { width, height } = await getImageDimensions(image.data);
 
   return {
-    id: `${base}/canvas/1`,
+    id: `${base}/canvas/${canvasIndex}`,
     type: 'Canvas',
     ...(metadata.length > 0 ? { metadata } : {}),
     height,
     width,
+    ...(label ? { label: { en: [label] } } : {}),
     items: [{
-      id: `${base}/page/p1/1`,
+      id: `${base}/page/p${canvasIndex}/1`,
       type: 'AnnotationPage',
       items: [{
-        id: `${base}/annotation/p0001-image`,
+        id: `${base}/annotation/p${canvasIndex}-image`,
         type: 'Annotation',
         motivation: 'painting',
         body: {
@@ -66,11 +74,11 @@ export const createStaticImageCanvas = async (
           height,
           width
         },
-        target: `${base}/canvas/1`
+        target: `${base}/canvas/${canvasIndex}`
       }]
     }],
     annotations: [{
-      id: `${base}/annotations.json`,
+      id: `${base}/${filename}`,
       type: 'AnnotationPage'
     }]
   }
@@ -105,9 +113,10 @@ const createStaticManifest = async (image: LoadedFileImage, baseUrl: string, sto
     ),
     items: [
       createStaticImageCanvas(
-        image, 
-        imageMetadata.length > 0 && folderMetadata.length > 0 ? imageMetadata : [],
-        base
+        image,
+        base,
+        undefined,
+        imageMetadata.length > 0 && folderMetadata.length > 0 ? imageMetadata : []
       )
     ]
   }
@@ -129,7 +138,14 @@ export const exportImageToIIIF = async (image: LoadedFileImage, baseUrl: string,
   const manifest = await createStaticManifest(image, baseUrl, store);
   zip.file(`${name}/manifest.json`, JSON.stringify(manifest, null, 2));
 
-  const annotations = await createAnnotationPage(image, baseUrl, miradorSafe, store);
+  const base = `${baseUrl}/${name}`;
+  const annotations = await createAnnotationPage(
+    image, 
+    `${base}/annotations.json`, 
+    `${base}/canvas/1`, 
+    miradorSafe,
+    store);
+
   zip.file(`${name}/annotations.json`, JSON.stringify(annotations, null, 2));
 
   const blob = await zip.generateAsync({ type:'blob' });

--- a/src/store/export/iiif/exportImageToIIIF.ts
+++ b/src/store/export/iiif/exportImageToIIIF.ts
@@ -1,8 +1,8 @@
 import JSZip from 'jszip';
-import { LoadedFileImage } from '@/model';
+import { FileImage, LoadedFileImage } from '@/model';
 import { getImageMetadata, Store } from '@/store';
 import { crosswalkAnnotations } from './crosswalkAnnotations';
-import { crosswalkMetadata, getFlattenedParentFolderMetadata } from './crosswalkMetadata';
+import { crosswalkMetadata, getFlattenedParentFolderMetadata, IIIFMetadataField } from './crosswalkMetadata';
 
 // Helper
 export const stripExtension = (filename: string): string => {
@@ -29,7 +29,7 @@ const getImageDimensions = (blob: Blob): Promise<{ width: number, height: number
     img.src = url;
   });
 
-const createAnnotationPage = (image: LoadedFileImage, baseUrl: string, miradorSafe: boolean, store: Store) => {
+export const createAnnotationPage = (image: FileImage, baseUrl: string, miradorSafe: boolean, store: Store) => {
   const base = `${baseUrl}/${stripExtension(image.name)}`;
 
   return store.getAnnotations(image.id, { type: 'image' }).then(annotations => ({
@@ -38,6 +38,42 @@ const createAnnotationPage = (image: LoadedFileImage, baseUrl: string, miradorSa
     type: 'AnnotationPage',
     items: crosswalkAnnotations(annotations, miradorSafe, store, `${base}/canvas/1`)
   }));
+}
+
+export const createStaticImageCanvas = async (
+  image: LoadedFileImage, 
+  metadata: IIIFMetadataField[],
+  base: string
+) => {
+  const { width, height } = await getImageDimensions(image.data);
+
+  return {
+    id: `${base}/canvas/1`,
+    type: 'Canvas',
+    ...(metadata.length > 0 ? { metadata } : {}),
+    height,
+    width,
+    items: [{
+      id: `${base}/page/p1/1`,
+      type: 'AnnotationPage',
+      items: [{
+        id: `${base}/annotation/p0001-image`,
+        type: 'Annotation',
+        motivation: 'painting',
+        body: {
+          id: `${base}/${image.name}`,
+          type: 'Image',
+          height,
+          width
+        },
+        target: `${base}/canvas/1`
+      }]
+    }],
+    annotations: [{
+      id: `${base}/annotations.json`,
+      type: 'AnnotationPage'
+    }]
+  }
 }
 
 /**
@@ -67,33 +103,13 @@ const createStaticManifest = async (image: LoadedFileImage, baseUrl: string, sto
       // If ONLY image metadata -> add as manifest metadata
       imageMetadata.length > 0 ? { metadata: imageMetadata } : {}
     ),
-    items: [{
-      id: `${base}/canvas/1`,
-      type: 'Canvas',
-      ...(imageMetadata.length > 0 && folderMetadata.length > 0 ? { metadata: imageMetadata } : {}),
-      height,
-      width,
-      items: [{
-        id: `${base}/page/p1/1`,
-        type: 'AnnotationPage',
-        items: [{
-          id: `${base}/annotation/p0001-image`,
-          type: 'Annotation',
-          motivation: 'painting',
-          body: {
-            id: `${base}/${image.name}`,
-            type: 'Image',
-            height,
-            width
-          },
-          target: `${base}/canvas/1`
-        }]
-      }],
-      annotations: [{
-        id: `${base}/annotations.json`,
-        type: 'AnnotationPage'
-      }]
-    }]
+    items: [
+      createStaticImageCanvas(
+        image, 
+        imageMetadata.length > 0 && folderMetadata.length > 0 ? imageMetadata : [],
+        base
+      )
+    ]
   }
 }
 

--- a/src/store/export/iiif/exportImageToIIIF.ts
+++ b/src/store/export/iiif/exportImageToIIIF.ts
@@ -3,6 +3,7 @@ import { FileImage, LoadedFileImage } from '@/model';
 import { getImageMetadata, Store } from '@/store';
 import { crosswalkAnnotations } from './crosswalkAnnotations';
 import { crosswalkMetadata, getFlattenedParentFolderMetadata, IIIFMetadataField } from './crosswalkMetadata';
+import { getSourceParents } from '@/utils/metadata';
 
 // Helper
 export const stripExtension = (filename: string): string => {
@@ -53,6 +54,7 @@ export const createStaticImageCanvas = async (
   filename = 'annotations.json'
 ) => {
   const { width, height } = await getImageDimensions(image.data);
+
   return {
     id: `${base}/canvas/${canvasIndex}`,
     type: 'Canvas',
@@ -91,7 +93,8 @@ const createStaticManifest = async (image: LoadedFileImage, baseUrl: string, sto
   const base = `${baseUrl}/${stripExtension(image.name)}`;
 
   // Folder metadata -> manifest metadata
-  const folderMetadata = await getFlattenedParentFolderMetadata(store, image.id);
+  const folders = getSourceParents(image.id, store);
+  const folderMetadata = await getFlattenedParentFolderMetadata(folders, store);
 
   // Image metadata -> canvas metadata
   const { metadata: imageMetaBody } = await getImageMetadata(store, image.id);

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -25,26 +25,31 @@ export const zipMetadata = (columns: SchemaField[], metadata?: W3CAnnotationBody
   return entries;
 }
 
+const getParentFoldersRecursive = (next: Folder, store: Store, hierarchy: Folder[] = []): (Folder | RootFolder)[] => {
+  if (next.parent) {
+    const folder = store.getFolder(next.parent);
+
+    const isRootFolder = !('id' in folder);
+    if (isRootFolder) {
+      return [folder, next, ...hierarchy];
+    } else {
+      return getParentFoldersRecursive(folder, store, [next, ...hierarchy]);
+    }
+  } else {
+    return [next, ...hierarchy];
+  }
+}
+
+export const getFolderHierarchy = (
+  store: Store,
+  folder: Folder
+): (RootFolder | Folder)[] => getParentFoldersRecursive(folder, store);
+
 /** Lists the parent sub-folder hierarchy for the given image or IIIF resource **/
-export const getParentFolders = (
+export const getSourceParents = (
   store: Store,
   sourceId: string
 ): (RootFolder | Folder | IIIFManifestResource)[] => {
-  const getParentFoldersRecursive = (next: Folder, hierarchy: Folder[] = []): (Folder | RootFolder)[] => {
-    if (next.parent) {
-      const folder = store.getFolder(next.parent);
-
-      const isRootFolder = !('id' in folder);
-      if (isRootFolder) {
-        return [folder, next, ...hierarchy];
-      } else {
-        return getParentFoldersRecursive(folder, [next, ...hierarchy]);
-      }
-    } else {
-      return [next, ...hierarchy];
-    }
-  }
-
   if (sourceId.startsWith('iiif')) {
     const [manifestId, _] = parseIIIFId(sourceId);
     const manifest = store.getIIIFResource(manifestId) as IIIFManifestResource;
@@ -54,7 +59,7 @@ export const getParentFolders = (
     if (isRootFolder) {
       return [folder, manifest];
     } else {
-      return [...getParentFoldersRecursive(folder), manifest];
+      return [...getParentFoldersRecursive(folder, store), manifest];
     }
   } else {
     const image = store.getImage(sourceId);
@@ -65,7 +70,7 @@ export const getParentFolders = (
       if (isRootFolder) {
         return [folder];
       } else {
-        return getParentFoldersRecursive(folder);
+        return getParentFoldersRecursive(folder, store);
       }
     } else {
       return [];

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -40,15 +40,15 @@ const getParentFoldersRecursive = (next: Folder, store: Store, hierarchy: Folder
   }
 }
 
-export const getFolderHierarchy = (
+export const getParentFolderHierarchy = (
+  folder: Folder,
   store: Store,
-  folder: Folder
 ): (RootFolder | Folder)[] => getParentFoldersRecursive(folder, store);
 
 /** Lists the parent sub-folder hierarchy for the given image or IIIF resource **/
 export const getSourceParents = (
+  sourceId: string,
   store: Store,
-  sourceId: string
 ): (RootFolder | Folder | IIIFManifestResource)[] => {
   if (sourceId.startsWith('iiif')) {
     const [manifestId, _] = parseIIIFId(sourceId);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,7 +32,6 @@ export default defineConfig({
     })
   ],
   server: {
-    cors: true,
     proxy: {
       '/api/web/clc-sinonom/': {
         target: 'https://kimhannom.clc.hcmus.edu.vn',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
     })
   ],
   server: {
+    cors: true,
     proxy: {
       '/api/web/clc-sinonom/': {
         target: 'https://kimhannom.clc.hcmus.edu.vn',


### PR DESCRIPTION
## In this PR

This PR adds functionality for exporting a folder of images to IIIF. The export returns a ZIP file with the following contents:
- A single (presentation API v3) manifest
  - Folder name → manifest label
  - Flattened metadata of the folder hierarchy → manifest metadata
  - Each image in the folder → canvas item, following the [simple image cookbook recipe](https://iiif.io/api/cookbook/recipe/0001-mvm-image/)
- The images files
- One annotation list per image 

For the time being, the option is only available if the folder:
- does not contain sub-folders
- contains only image files - no imported IIIF manifests