### PR TITLE
TanStack table migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "@radix-ui/react-tooltip": "^1.2.16",
         "@radix-ui/react-visually-hidden": "^1.2.11",
         "@react-spring/web": "^10.1.2",
-        "@tanstack/react-table": "^8.21.3",
+        "@tanstack/react-table": "^9.0.0",
         "ajv": "^8.20.0",
         "browser-image-compression": "^2.0.2",
         "browser-visual-search": "^0.6.3",
@@ -3274,33 +3274,64 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
-    "node_modules/@tanstack/react-table": {
-      "version": "8.21.3",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
-      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+    "node_modules/@tanstack/react-store": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.11.0.tgz",
+      "integrity": "sha512-tX4YXh3PDkmpvGQWkWqKpzs/MSqbtuwY9dWdWhtV9Q50PmO+jOkUKIWIX4G85dwt7lxdHLXsiaEKPdKmC8F41w==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/table-core": "8.21.3"
-      },
-      "engines": {
-        "node": ">=12"
+        "@tanstack/store": "0.11.0",
+        "use-sync-external-store": "^1.6.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-9.0.0.tgz",
+      "integrity": "sha512-Q/Z49MQcdMwge67U+LTjSEQJCnQE9/tNWK5IpiYex9JFDzfjNkLIi7yzGA4dfW4UpuMBrtqbSnSzn7oPr60T+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/react-store": "^0.11.0",
+        "@tanstack/table-core": "9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@tanstack/store": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.11.0.tgz",
+      "integrity": "sha512-WlzzCt3xi0G6pCAJu1U+2jiECwabETDpQDi3hfkFZvJii9AuZqEKbOiVarX1/bWhTNjU486yQtJCCasi/0q+Cw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/table-core": {
-      "version": "8.21.3",
-      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
-      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-9.0.0.tgz",
+      "integrity": "sha512-IyKCc4D7d/+I9euQntlVDQ7lnilmFRKpIROBeI5/866adFy+65xWvCFPz76NZ5j2lXe/RFDvFVV7bfETmwHEMA==",
       "license": "MIT",
+      "dependencies": {
+        "@tanstack/store": "^0.11.0"
+      },
       "engines": {
-        "node": ">=12"
+        "node": ">=20"
       },
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@radix-ui/react-tooltip": "^1.2.16",
     "@radix-ui/react-visually-hidden": "^1.2.11",
     "@react-spring/web": "^10.1.2",
-    "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-table": "^9.0.0",
     "ajv": "^8.20.0",
     "browser-image-compression": "^2.0.2",
     "browser-visual-search": "^0.6.3",

--- a/src/pages/datamodel/EntityTypes/EntityTypesTable/EntityTypesTable.tsx
+++ b/src/pages/datamodel/EntityTypes/EntityTypesTable/EntityTypesTable.tsx
@@ -1,6 +1,15 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ColumnDef, ExpandedState, flexRender, getCoreRowModel, getExpandedRowModel, Row, useReactTable } from '@tanstack/react-table';
+import {
+  ColumnDef,
+  ExpandedState,
+  Row,
+  createExpandedRowModel,
+  flexRender,
+  rowExpandingFeature,
+  tableFeatures,
+  useTable
+} from '@tanstack/react-table';
 import { PropertyListTooltip } from '@/components/PropertyListTooltip';
 import { EntityType, PropertyDefinition } from '@/model';
 import { useDataModel } from '@/store';
@@ -42,6 +51,11 @@ interface EntityTypeNode {
 
 const HEADER_CLASS = 'pl-2 pr-2 whitespace-nowrap text-xs text-muted-foreground font-medium text-left';
 
+const features = tableFeatures({
+  rowExpandingFeature,
+  expandedRowModel: createExpandedRowModel()
+});
+
 export const EntityTypesTable = (props: EntityTypesTableProps) => {
 
   const { t } = useTranslation('datamodel');
@@ -70,7 +84,7 @@ export const EntityTypesTable = (props: EntityTypesTableProps) => {
       }).map(toNode);
   }, [model]);
 
-  const togglerTemplate = useCallback((row: Row<EntityTypeNode>) =>
+  const togglerTemplate = useCallback((row: Row<typeof features, EntityTypeNode>) =>
     row.getCanExpand() ? (
       <Button
         variant="ghost"
@@ -148,7 +162,7 @@ export const EntityTypesTable = (props: EntityTypesTableProps) => {
     </span>
   ), [props.onEditEntityType, props.onDeleteEntityType]);
 
-  const columns: ColumnDef<EntityTypeNode>[] = useMemo(() => [
+  const columns: ColumnDef<typeof features, EntityTypeNode>[] = useMemo(() => [
     {
       id: 'entityClass',
       header: t('entityTypesTable.headerEntityClass'),
@@ -181,15 +195,14 @@ export const EntityTypesTable = (props: EntityTypesTableProps) => {
     }
   ], [t, togglerTemplate, idTemplate, displayNameTemplate, propertiesTemplate, actionsTemplate]);
 
-  const table = useReactTable({
+  const table = useTable({
+    features,
     data: nodes,
     columns,
     state: { expanded },
     onExpandedChange: setExpanded,
     getSubRows: row => row.children,
-    getRowId: row => row.id,
-    getCoreRowModel: getCoreRowModel(),
-    getExpandedRowModel: getExpandedRowModel()
+    getRowId: row => row.id
   });
 
   const columnClassName = (columnId: string) => cn(
@@ -228,7 +241,7 @@ export const EntityTypesTable = (props: EntityTypesTableProps) => {
           ) : (
             table.getRowModel().rows.map(row => (
               <TableRow key={row.id}>
-                {row.getVisibleCells().map(cell => (
+                {row.getAllCells().map(cell => (
                   <TableCell
                     key={cell.id}
                     className={cn('py-2 px-2 text-xs', columnClassName(cell.column.id))}>

--- a/src/pages/datamodel/EntityTypes/EntityTypesTable/EntityTypesTable.tsx
+++ b/src/pages/datamodel/EntityTypes/EntityTypesTable/EntityTypesTable.tsx
@@ -1,15 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  ColumnDef,
-  ExpandedState,
-  Row,
-  createExpandedRowModel,
-  flexRender,
-  rowExpandingFeature,
-  tableFeatures,
-  useTable
-} from '@tanstack/react-table';
 import { PropertyListTooltip } from '@/components/PropertyListTooltip';
 import { EntityType, PropertyDefinition } from '@/model';
 import { useDataModel } from '@/store';
@@ -30,6 +20,16 @@ import {
   Palette,
   Ruler
 } from 'lucide-react';
+import {
+  ColumnDef,
+  ExpandedState,
+  Row,
+  createExpandedRowModel,
+  flexRender,
+  rowExpandingFeature,
+  tableFeatures,
+  useTable
+} from '@tanstack/react-table';
 
 interface EntityTypesTableProps {
 

--- a/src/pages/images/IIIFManifestOverview/IIIFManifestTable/IIIFManifestTable.tsx
+++ b/src/pages/images/IIIFManifestOverview/IIIFManifestTable/IIIFManifestTable.tsx
@@ -2,7 +2,7 @@ import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useState } from
 import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
 import murmur from 'murmurhash';
-import { ColumnDef, flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
+import { ColumnDef, flexRender, tableFeatures, useTable } from '@tanstack/react-table';
 import { W3CAnnotation } from '@annotorious/react';
 import { CozyManifest, CozyRange } from 'cozy-iiif';
 import { FolderIcon } from '@/components/FolderIcon';
@@ -29,6 +29,8 @@ import {
   TABLE_HEADER_CLASS,
   TABLE_SKELETON
 } from '../../ImagesUtils';
+
+const features = tableFeatures({});
 
 const folderToRow = (range: CozyRange, annotations: Record<string, W3CAnnotation[]>): ItemTableRow => {
   const annotationsInRange = getAnnotationsInRange(range, annotations);
@@ -150,7 +152,7 @@ export const IIIFManifestTable = memo((props: IIIFManifestOverviewLayoutProps) =
     return murmur.v3(row.data.canvas.id).toString()
   }
 
-  const columns: ColumnDef<ItemTableRow>[] = useMemo(() => [
+  const columns: ColumnDef<typeof features, ItemTableRow>[] = useMemo(() => [
     {
       id: 'type',
       header: t('table.type'),
@@ -201,10 +203,10 @@ export const IIIFManifestTable = memo((props: IIIFManifestOverviewLayoutProps) =
     }
   ], [t, sorting, typeTemplate, actionsTemplate]);
 
-  const table = useReactTable({
+  const table = useTable({
+    features,
     data: sortedRows,
-    columns,
-    getCoreRowModel: getCoreRowModel()
+    columns
   });
 
   const columnClassName = (columnId: string) => cn(
@@ -243,7 +245,7 @@ export const IIIFManifestTable = memo((props: IIIFManifestOverviewLayoutProps) =
                 key={row.id}
                 className={rowClassName(row.original)}
                 onClick={() => onRowClick(row.original)}>
-                {row.getVisibleCells().map(cell => (
+                {row.getAllCells().map(cell => (
                   <TableCell
                     key={cell.id}
                     className={cn('overflow-hidden text-ellipsis whitespace-nowrap px-2 py-2', columnClassName(cell.column.id))}>

--- a/src/pages/images/ItemOverview/ItemTable/ItemTable.tsx
+++ b/src/pages/images/ItemOverview/ItemTable/ItemTable.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ColumnDef, flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
+import { ColumnDef, flexRender, tableFeatures, useTable } from '@tanstack/react-table';
 import { FolderIcon } from '@/components/FolderIcon';
 import { IIIFIcon } from '@/components/IIIFIcon';
 import { Folder, IIIFManifestResource, Image, LoadedFileImage } from '@/model';
@@ -24,6 +24,8 @@ import {
   TABLE_EMPTY_MESSAGE,
   TABLE_HEADER_CLASS
 } from '../../ImagesUtils';
+
+const features = tableFeatures({});
 
 const folderToRow = (
   folder: Folder,
@@ -147,7 +149,7 @@ export const ItemTable = (props: ItemOverviewLayoutProps) => {
     }
   }, [props.onOpenFolder, props.onOpenImage]);
 
-  const columns: ColumnDef<ItemTableRow>[] = useMemo(() => [
+  const columns: ColumnDef<typeof features, ItemTableRow>[] = useMemo(() => [
     {
       id: 'type',
       header: t('table.type'),
@@ -198,10 +200,10 @@ export const ItemTable = (props: ItemOverviewLayoutProps) => {
     }
   ], [t, sorting, onSort, typeTemplate, actionsTemplate]);
 
-  const table = useReactTable({
+  const table = useTable({
+    features,
     data: sortedRows,
-    columns,
-    getCoreRowModel: getCoreRowModel()
+    columns
   });
 
   const columnClassName = (columnId: string) => cn(
@@ -239,7 +241,7 @@ export const ItemTable = (props: ItemOverviewLayoutProps) => {
               <TableRow
                 key={row.id}
                 onClick={() => onRowClick(row.original)}>
-                {row.getVisibleCells().map(cell => (
+                {row.getAllCells().map(cell => (
                   <TableCell
                     key={cell.id}
                     className={cn('overflow-hidden text-xs text-ellipsis whitespace-nowrap px-2 py-2', columnClassName(cell.column.id))}>


### PR DESCRIPTION
## In this PR

**Sigh** - just last week we [migrated away from PrimeReact for licensing reasons](https://github.com/rsimon/immarkus/pull/347), to TanStack table as a more stable alternative. And now one week later TanStack releases [a new version with breaking changes](https://tanstack.com/table/latest/docs/framework/react/guide/migrating). So here we go...